### PR TITLE
fix：修复因为 d 站 cf 规则变更导致画廊无法读取图片的问题

### DIFF
--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -184,7 +184,7 @@ app.registerExtension({
 
                 let globalTooltip, globalTooltipTimeout;
                 let currentTooltipId = 0; // 用于追踪当前活动的tooltip请求
-                let posts = [], currentPage = 1, isLoading = false;
+                let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -2106,6 +2106,9 @@ app.registerExtension({
                     if (isLoading) {
                         return;
                     }
+                    if (endOfResults && !reset) {
+                        return;
+                    }
                     isLoading = true;
                     refreshButton.classList.add("loading");
                     refreshButton.disabled = true;
@@ -2118,6 +2121,7 @@ app.registerExtension({
                     if (reset) {
                         currentPage = filterState.startPage || 1;
                         posts = [];
+                        endOfResults = false;
                         imageGrid.innerHTML = "";
                         imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
                     }
@@ -2172,7 +2176,7 @@ app.registerExtension({
                         const params = new URLSearchParams({
                             "search[tags]": apiFormattedTags.trim(),
                             "search[rating]": ratingForServer,
-                            limit: "100",
+                            limit: "40",
                             page: currentPage,
                         });
 
@@ -2192,6 +2196,17 @@ app.registerExtension({
 
                         const filteredCount = newPosts.length - filteredPosts.length;
 
+                        // API returned nothing → no more pages. Flag it so scroll events stop
+                        // triggering fetches; otherwise the bottom-proximity check would keep
+                        // firing and walk off the end of the result set indefinitely.
+                        if (newPosts.length === 0) {
+                            endOfResults = true;
+                            if (reset) {
+                                imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
+                            }
+                            return;
+                        }
+
                         if (filteredPosts.length === 0 && reset) {
                             imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
                             return;
@@ -2200,6 +2215,16 @@ app.registerExtension({
                         currentPage++;
                         posts.push(...filteredPosts);
                         filteredPosts.forEach(renderPost);
+
+                        // Filter-cascade guard: if the blacklist/rating filter dropped every
+                        // post on this page, the grid didn't grow — the user's scroll is still
+                        // within the 400px bottom threshold, so the scroll listener would
+                        // re-fire immediately. Hold isLoading for ~1.5s (still inside the try
+                        // block, before the finally clears it) to space out these "auto-skip"
+                        // fetches.
+                        if (filteredPosts.length === 0 && !reset) {
+                            await new Promise(r => setTimeout(r, 1500));
+                        }
 
                     } catch (e) {
                         imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -2227,6 +2227,36 @@ app.registerExtension({
                     });
                 }
 
+                // Pre-reserve grid space from post dimensions so rate-limited async loads
+                // don't cause the waterfall to jump every time an image arrives.
+                let cachedColumnWidth = 0;
+                const getColumnWidth = () => {
+                    if (cachedColumnWidth > 0) return cachedColumnWidth;
+                    const cols = window.getComputedStyle(imageGrid).gridTemplateColumns.split(' ');
+                    const px = parseFloat(cols[0]);
+                    if (px > 0) cachedColumnWidth = px;
+                    return cachedColumnWidth;
+                };
+                const computeSpanFromDims = (imgW, imgH) => {
+                    const colW = getColumnWidth();
+                    if (!colW || !imgW || !imgH) return 0;
+                    const cs = window.getComputedStyle(imageGrid);
+                    const rowGap = parseInt(cs.gridRowGap) || parseInt(cs.rowGap) || 5;
+                    const rowHeight = parseInt(cs.gridAutoRows) || 1;
+                    const renderedH = colW * (imgH / imgW);
+                    return Math.ceil((renderedH + rowGap) / (rowHeight + rowGap));
+                };
+                // Coalesce rapid onload calls (rate-limited loads fire 200ms apart; batching
+                // to one reflow per frame avoids N² layout work as the page fills in).
+                let resizeGridTimer = null;
+                const scheduleResizeGrid = () => {
+                    if (resizeGridTimer) return;
+                    resizeGridTimer = requestAnimationFrame(() => {
+                        resizeGridTimer = null;
+                        resizeGrid();
+                    });
+                };
+
                 const showEditPanel = (post) => {
                     // 在打开编辑面板时，检查当前图像是否被选中
                     // 强制将当前编辑的图像设置为选中状态，并更新 selectionWidget
@@ -3005,6 +3035,13 @@ app.registerExtension({
                     const wrapper = $el("div.danbooru-image-wrapper");
                     wrapper.dataset.postId = post.id; // 显式设置 data-post-id
 
+                    // Reserve grid space up-front from the post's real dimensions so the
+                    // waterfall is stable before thumbnails finish loading.
+                    if (post.image_width && post.image_height) {
+                        const spans = computeSpanFromDims(post.image_width, post.image_height);
+                        if (spans > 0) wrapper.style.gridRowEnd = `span ${spans}`;
+                    }
+
                     // 首次创建post元素时，将原始post数据添加到 originalPostCache
                     if (!originalPostCache[post.id]) {
                         originalPostCache[post.id] = JSON.parse(JSON.stringify(post));
@@ -3014,9 +3051,9 @@ app.registerExtension({
                     updateEditedStatus(wrapper, post.id);
 
                     const img = $el("img", {
-                        src: `${post.preview_file_url}?v=${post.md5}`,
+                        src: `/danbooru_gallery/image_proxy?url=${encodeURIComponent(post.preview_file_url + '?v=' + post.md5)}`,
                         loading: "lazy",
-                        onload: resizeGrid,
+                        onload: scheduleResizeGrid,
                         onerror: () => { wrapper.style.display = 'none'; },
                         onclick: async (e) => {
                             e.stopPropagation(); // Prevent event from bubbling up and potentially causing issues
@@ -3333,7 +3370,10 @@ app.registerExtension({
                     }
                 };
 
-                const observer = new ResizeObserver(resizeGrid);
+                const observer = new ResizeObserver(() => {
+                    cachedColumnWidth = 0;
+                    resizeGrid();
+                });
                 observer.observe(imageGrid);
 
                 let scrollTimeout;

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -3127,8 +3127,9 @@ app.registerExtension({
                                 const fileExt = post.file_ext || 'jpg';
                                 const fileName = `danbooru_${post.id}.${fileExt}`;
 
-                                // 创建下载链接
-                                const response = await fetch(imageUrl);
+                                // 通过后端代理下载，避免被 Cloudflare 按 cross-site referer 拦截
+                                const proxyUrl = `/danbooru_gallery/image_proxy?url=${encodeURIComponent(imageUrl)}`;
+                                const response = await fetch(proxyUrl);
                                 const blob = await response.blob();
                                 const url = window.URL.createObjectURL(blob);
 
@@ -3372,7 +3373,7 @@ app.registerExtension({
                             e.stopPropagation();
                             const imageUrl = post.large_file_url || post.file_url;
                             if (imageUrl) {
-                                window.open(imageUrl, '_blank');
+                                window.open(imageUrl, '_blank', 'noreferrer');
                             }
                         }
                     });

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -36,6 +36,14 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # Danbooru API的基础URL
 BASE_URL = "https://danbooru.donmai.us"
 
+# Cloudflare 从 2026-04-23 起会把默认的 python-requests UA 判定为 bot 并返回 403 challenge。
+# 实测 Chrome/Firefox UA 也会被挡（TLS 指纹和浏览器不匹配），但 curl UA 能通过 ——
+# CF 对 UA + TLS 指纹做了一致性判断，curl UA 对应 CLI 工具的指纹，与 requests 更接近。
+# 等 Danbooru/Cloudflare 侧修复后可以移除。
+DANBOORU_HEADERS = {
+    "User-Agent": "curl/8.4.0"
+}
+
 # 获取插件目录路径
 # 获取当前文件所在目录
 PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -471,7 +479,7 @@ def check_network_connection():
     try:
         # 使用一个简单的公开API端点来检测连接
         test_url = f"{BASE_URL}/posts.json?limit=1"
-        response = requests.get(test_url, timeout=10)
+        response = requests.get(test_url, headers=DANBOORU_HEADERS, timeout=10)
         return response.status_code == 200, False
     except requests.exceptions.Timeout:
         logger.error("网络连接超时")
@@ -489,7 +497,7 @@ def verify_danbooru_auth(username, api_key):
         return False, False
     try:
         test_url = f"{BASE_URL}/profile.json"
-        response = requests.get(test_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
+        response = requests.get(test_url, headers=DANBOORU_HEADERS, auth=HTTPBasicAuth(username, api_key), timeout=15)
         is_valid = response.status_code == 200
         return is_valid, False
     except Exception as e:
@@ -500,7 +508,7 @@ def get_user_favorites(username, api_key):
     """获取用户的收藏列表"""
     try:
         favorites_url = f"{BASE_URL}/favorites.json"
-        response = requests.get(favorites_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
+        response = requests.get(favorites_url, headers=DANBOORU_HEADERS, auth=HTTPBasicAuth(username, api_key), timeout=15)
         if response.status_code == 200:
             return response.json()
         return []
@@ -535,6 +543,7 @@ async def add_favorite(request):
             favorite_url = f"{BASE_URL}/favorites.json"
             response = requests.post(
                 favorite_url,
+                headers=DANBOORU_HEADERS,
                 auth=HTTPBasicAuth(username, api_key),
                 data={"post_id": post_id},
                 timeout=15
@@ -615,7 +624,7 @@ async def remove_favorite(request):
         try:
             # 直接使用帖子ID删除收藏
             delete_url = f"{BASE_URL}/favorites/{post_id}.json"
-            delete_response = requests.delete(delete_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
+            delete_response = requests.delete(delete_url, headers=DANBOORU_HEADERS, auth=HTTPBasicAuth(username, api_key), timeout=15)
 
 
             if delete_response.status_code in [200, 204]:
@@ -808,7 +817,7 @@ async def get_autocomplete(request):
                 auth = HTTPBasicAuth(username, api_key) if username and api_key else None
 
                 logger.debug(f"[Autocomplete] 调用远程API: '{query}' (超时: {timeout}s)")
-                response = requests.get(tags_url, params=params, auth=auth, timeout=timeout)
+                response = requests.get(tags_url, params=params, headers=DANBOORU_HEADERS, auth=auth, timeout=timeout)
                 response.raise_for_status()
 
                 result = response.json()
@@ -1068,7 +1077,7 @@ async def get_autocomplete_with_translation(request):
                 auth = HTTPBasicAuth(username, api_key) if username and api_key else None
 
                 logger.debug(f"[AutocompleteTranslation] 调用远程API: '{query}' (超时: {timeout}s)")
-                response = requests.get(tags_url, params=params, auth=auth, timeout=timeout)
+                response = requests.get(tags_url, params=params, headers=DANBOORU_HEADERS, auth=auth, timeout=timeout)
                 response.raise_for_status()
 
                 result = response.json()
@@ -1224,7 +1233,7 @@ class DanbooruGalleryNode:
         }
         
         try:
-            response = requests.get(posts_url, params=params, auth=auth, timeout=15)
+            response = requests.get(posts_url, params=params, headers=DANBOORU_HEADERS, auth=auth, timeout=15)
             response.raise_for_status()
             
             result_text = response.text

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -4,6 +4,8 @@ import folder_paths
 from server import PromptServer
 from aiohttp import web
 import time
+import threading
+import asyncio
 import torch
 import io
 import urllib.request
@@ -36,13 +38,54 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # Danbooru API的基础URL
 BASE_URL = "https://danbooru.donmai.us"
 
-# Cloudflare 从 2026-04-23 起会把默认的 python-requests UA 判定为 bot 并返回 403 challenge。
-# 实测 Chrome/Firefox UA 也会被挡（TLS 指纹和浏览器不匹配），但 curl UA 能通过 ——
-# CF 对 UA + TLS 指纹做了一致性判断，curl UA 对应 CLI 工具的指纹，与 requests 更接近。
-# 等 Danbooru/Cloudflare 侧修复后可以移除。
+# 需要一个非 python-requests 的描述性 UA 才能过 Cloudflare（从 2026-04-23 起开启拦截）。
+# 实测 CF 对 UA 黑名单里包含 "ComfyUI" —— 推测 Danbooru 为抵制训练数据爬取主动加的规则。
+# 本节点只是图片浏览器（单图挑选，无批量导出），不参与训练数据收集，按 e621 式约定
+# 使用描述性项目 UA；避开 "ComfyUI" 字样以免被 CF 误伤。
 DANBOORU_HEADERS = {
-    "User-Agent": "curl/8.4.0"
+    "User-Agent": "Danbooru-Gallery/1.0"
 }
+
+# 官方文档限速为 10 req/s，保守取一半 = 5 req/s（200ms 间隔），避免触发 CF 或被站方拉黑。
+# 参考 deepghs/waifuc#22：Danbooru 管理员明确要求 "proper waits or backoffs"，否则会封项目。
+class _RateLimiter:
+    def __init__(self, min_interval_sec):
+        self.min_interval = min_interval_sec
+        self._last_ts = 0.0
+        self._lock = threading.Lock()
+
+    def wait(self):
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last_ts
+            if elapsed < self.min_interval:
+                time.sleep(self.min_interval - elapsed)
+            self._last_ts = time.monotonic()
+
+_donmai_throttle = _RateLimiter(min_interval_sec=0.2)
+
+def _danbooru_request(method, url, **kwargs):
+    """统一的 donmai.us 请求入口：限流 + 默认 UA + 429/503 带 Retry-After 退避重试一次。"""
+    headers = dict(kwargs.pop("headers", None) or {})
+    for k, v in DANBOORU_HEADERS.items():
+        headers.setdefault(k, v)
+
+    resp = None
+    for attempt in range(2):
+        _donmai_throttle.wait()
+        resp = requests.request(method, url, headers=headers, **kwargs)
+        if resp.status_code not in (429, 503) or attempt == 1:
+            return resp
+        retry_after = resp.headers.get("Retry-After")
+        delay = 2.0
+        try:
+            if retry_after is not None:
+                delay = min(max(float(retry_after), 0.5), 10.0)
+        except ValueError:
+            pass
+        logger.warning(f"[Danbooru] {resp.status_code} 限流，{delay:.1f}s 后重试: {url}")
+        time.sleep(delay)
+    return resp
 
 # 获取插件目录路径
 # 获取当前文件所在目录
@@ -479,7 +522,7 @@ def check_network_connection():
     try:
         # 使用一个简单的公开API端点来检测连接
         test_url = f"{BASE_URL}/posts.json?limit=1"
-        response = requests.get(test_url, headers=DANBOORU_HEADERS, timeout=10)
+        response = _danbooru_request("GET", test_url, timeout=10)
         return response.status_code == 200, False
     except requests.exceptions.Timeout:
         logger.error("网络连接超时")
@@ -497,7 +540,7 @@ def verify_danbooru_auth(username, api_key):
         return False, False
     try:
         test_url = f"{BASE_URL}/profile.json"
-        response = requests.get(test_url, headers=DANBOORU_HEADERS, auth=HTTPBasicAuth(username, api_key), timeout=15)
+        response = _danbooru_request("GET", test_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
         is_valid = response.status_code == 200
         return is_valid, False
     except Exception as e:
@@ -508,7 +551,7 @@ def get_user_favorites(username, api_key):
     """获取用户的收藏列表"""
     try:
         favorites_url = f"{BASE_URL}/favorites.json"
-        response = requests.get(favorites_url, headers=DANBOORU_HEADERS, auth=HTTPBasicAuth(username, api_key), timeout=15)
+        response = _danbooru_request("GET", favorites_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
         if response.status_code == 200:
             return response.json()
         return []
@@ -541,12 +584,12 @@ async def add_favorite(request):
 
         try:
             favorite_url = f"{BASE_URL}/favorites.json"
-            response = requests.post(
+            response = _danbooru_request(
+                "POST",
                 favorite_url,
-                headers=DANBOORU_HEADERS,
                 auth=HTTPBasicAuth(username, api_key),
                 data={"post_id": post_id},
-                timeout=15
+                timeout=15,
             )
 
 
@@ -624,7 +667,7 @@ async def remove_favorite(request):
         try:
             # 直接使用帖子ID删除收藏
             delete_url = f"{BASE_URL}/favorites/{post_id}.json"
-            delete_response = requests.delete(delete_url, headers=DANBOORU_HEADERS, auth=HTTPBasicAuth(username, api_key), timeout=15)
+            delete_response = _danbooru_request("DELETE", delete_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
 
 
             if delete_response.status_code in [200, 204]:
@@ -741,6 +784,57 @@ async def verify_auth(request):
         logger.error(f"验证认证接口错误: {e}")
         return web.json_response({"success": False, "error": "网络错误", "network_error": True}, status=500)
 
+# 图片代理并发上限：浏览器一次打开一页会 lazy-load 多张缩略图，没有上限会导致
+# 后端同时发出十几个 CDN 请求，配合全局限流会形成长队列；限到 3 并发即可让缩略图
+# 平滑流入，又避免瞬时流量把 CF 的 rate rule 触发。
+_image_proxy_semaphore = None
+
+def _get_image_proxy_semaphore():
+    global _image_proxy_semaphore
+    if _image_proxy_semaphore is None:
+        _image_proxy_semaphore = asyncio.Semaphore(3)
+    return _image_proxy_semaphore
+
+@PromptServer.instance.routes.get("/danbooru_gallery/image_proxy")
+async def image_proxy(request):
+    # 浏览器直连 cdn.donmai.us 会被 Cloudflare 按 cross-site <img> 请求挑战并返回 403，
+    # 而后端用描述性 UA (DANBOORU_HEADERS) 能过 CF。转发一次即可让前端拿到缩略图。
+    url = request.query.get("url", "")
+    if not url:
+        return web.Response(status=400, text="missing url")
+
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception:
+        return web.Response(status=400, text="invalid url")
+
+    if parsed.scheme not in ("http", "https"):
+        return web.Response(status=400, text="invalid scheme")
+
+    # SSRF 防护：只允许 donmai.us 域名
+    host = (parsed.hostname or "").lower()
+    if host != "donmai.us" and not host.endswith(".donmai.us"):
+        return web.Response(status=403, text="host not allowed")
+
+    async with _get_image_proxy_semaphore():
+        try:
+            resp = await asyncio.to_thread(_danbooru_request, "GET", url, timeout=15)
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"[ImageProxy] 上游请求失败 {url}: {e}")
+            return web.Response(status=502, text="upstream error")
+
+    if resp.status_code != 200:
+        logger.debug(f"[ImageProxy] 上游返回 {resp.status_code}: {url}")
+        return web.Response(status=resp.status_code)
+
+    return web.Response(
+        body=resp.content,
+        headers={
+            "Content-Type": resp.headers.get("Content-Type", "application/octet-stream"),
+            "Cache-Control": "public, max-age=86400",
+        },
+    )
+
 # --- 保留文件中剩余的其他部分 ---
 @PromptServer.instance.routes.get("/danbooru_gallery/posts")
 async def get_posts_for_front(request):
@@ -817,7 +911,7 @@ async def get_autocomplete(request):
                 auth = HTTPBasicAuth(username, api_key) if username and api_key else None
 
                 logger.debug(f"[Autocomplete] 调用远程API: '{query}' (超时: {timeout}s)")
-                response = requests.get(tags_url, params=params, headers=DANBOORU_HEADERS, auth=auth, timeout=timeout)
+                response = _danbooru_request("GET", tags_url, params=params, auth=auth, timeout=timeout)
                 response.raise_for_status()
 
                 result = response.json()
@@ -1077,7 +1171,7 @@ async def get_autocomplete_with_translation(request):
                 auth = HTTPBasicAuth(username, api_key) if username and api_key else None
 
                 logger.debug(f"[AutocompleteTranslation] 调用远程API: '{query}' (超时: {timeout}s)")
-                response = requests.get(tags_url, params=params, headers=DANBOORU_HEADERS, auth=auth, timeout=timeout)
+                response = _danbooru_request("GET", tags_url, params=params, auth=auth, timeout=timeout)
                 response.raise_for_status()
 
                 result = response.json()
@@ -1233,7 +1327,7 @@ class DanbooruGalleryNode:
         }
         
         try:
-            response = requests.get(posts_url, params=params, headers=DANBOORU_HEADERS, auth=auth, timeout=15)
+            response = _danbooru_request("GET", posts_url, params=params, auth=auth, timeout=15)
             response.raise_for_status()
             
             result_text = response.text


### PR DESCRIPTION
按照 danbooru 的要求做了以下修改

给 header 加了 user agent
相关post https://github.com/mikf/gallery-dl/issues/3665
设置 rps 速率限制，共享的池子每 5r/s，小于官方要求的 10r/s
相关 post https://github.com/deepghs/waifuc/issues/22
因为速率满了之后会布局会乱，加上了防抖
缩略图做了后端的代理，也走 api，使用 api limit 的池子
缩略图加了缓存