### PR TITLE
Fix multi-rating gallery filter to use Danbooru OR syntax

### DIFF
--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -2172,7 +2172,8 @@ app.registerExtension({
                         }
 
                         const selectedRatings = getSelectedRatings();
-                        const ratingForServer = selectedRatings.length === 1 ? selectedRatings[0] : "";
+                        const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
+                        const ratingForServer = sendAll ? "" : selectedRatings.join(",");
                         const params = new URLSearchParams({
                             "search[tags]": apiFormattedTags.trim(),
                             "search[rating]": ratingForServer,
@@ -2185,14 +2186,8 @@ app.registerExtension({
 
                         if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
 
-                        // 应用评分过滤（多选）+ 文件类型和黑名单过滤
-                        const filteredPosts = newPosts.filter(post => {
-                            const normalizedRating = normalizePostRating(post.rating);
-                            const passRating = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length
-                                ? true
-                                : selectedRatings.includes(normalizedRating);
-                            return passRating && !isPostFiltered(post);
-                        });
+                        // 评分过滤已交给服务端，本地只做文件类型/黑名单过滤
+                        const filteredPosts = newPosts.filter(post => !isPostFiltered(post));
 
                         const filteredCount = newPosts.length - filteredPosts.length;
 

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -1282,8 +1282,9 @@ class DanbooruGalleryNode:
         cache_enabled = settings.get("cache_enabled", True)
         max_cache_age = settings.get("max_cache_age", 3600)
 
-        # 创建缓存键
-        cache_key = f"{tags}:{limit}:{page}:{rating}"
+        # 创建缓存键（rating 归一化排序，避免 "e,q" 与 "q,e" 命中两条缓存）
+        rating_key = ','.join(sorted(r.strip().lower() for r in (rating or '').split(',') if r.strip()))
+        cache_key = f"{tags}:{limit}:{page}:{rating_key}"
 
         # 如果启用了缓存，则检查缓存
         if cache_enabled:
@@ -1313,7 +1314,14 @@ class DanbooruGalleryNode:
             final_tags = f"{final_tags} {date_tag}".strip()
 
         if rating and rating.lower() != 'all':
-            final_tags = f"{final_tags} rating:{rating}".strip()
+            allowed = {'general', 'sensitive', 'questionable', 'explicit', 'g', 's', 'q', 'e'}
+            rating_values = [r.strip().lower() for r in rating.split(',') if r.strip()]
+            rating_values = [r for r in rating_values if r in allowed]
+            if len(rating_values) == 1:
+                final_tags = f"{final_tags} rating:{rating_values[0]}".strip()
+            elif len(rating_values) > 1:
+                or_tags = ' '.join(f"~rating:{r}" for r in rating_values)
+                final_tags = f"{final_tags} {or_tags}".strip()
         
         tags = final_tags
         


### PR DESCRIPTION
## Issue
现有的分级过滤器在多选的时候，是 api 拉取所有的图片后在本地过滤。当单页符合条件的图片数量过少时，滑动到底部无法翻页。

### Change
测试发现 rating 等 meta tag 不占用 d 站的普通用户两个 tag 搜索限制。多选改用 or 的方式放入 api 中，不做本地过滤。