### PR TITLE
修复 SaveImagePlus 无法为 UNETLoader 加载的模型写出 Model hash

### DIFF
--- a/py/save_image_plus/save_image_plus.py
+++ b/py/save_image_plus/save_image_plus.py
@@ -435,16 +435,20 @@ class SaveImagePlus:
             if os.path.isabs(checkpoint_name) and os.path.exists(checkpoint_name):
                 checkpoint_file = checkpoint_name
             else:
-                # 搜索 checkpoint 文件
-                checkpoint_paths = folder_paths.get_filename_list("checkpoints")
+                # 搜索 checkpoint 文件（依次查 checkpoints / diffusion_models / unet）
                 checkpoint_file = None
-
-                # 去除扩展名进行匹配
                 base_name = os.path.splitext(os.path.basename(checkpoint_name))[0]
 
-                for path in checkpoint_paths:
-                    if os.path.splitext(os.path.basename(path))[0] == base_name:
-                        checkpoint_file = folder_paths.get_full_path("checkpoints", path)
+                for folder_type in ("checkpoints", "diffusion_models", "unet"):
+                    try:
+                        paths = folder_paths.get_filename_list(folder_type)
+                    except Exception:
+                        continue
+                    for path in paths:
+                        if os.path.splitext(os.path.basename(path))[0] == base_name:
+                            checkpoint_file = folder_paths.get_full_path(folder_type, path)
+                            break
+                    if checkpoint_file:
                         break
 
             if not checkpoint_file or not os.path.exists(checkpoint_file):


### PR DESCRIPTION
## 问题

`SaveImagePlus` 写 `Model hash:` 字段时，`_calculate_checkpoint_hash` 只在 `folder_paths.get_filename_list(\"checkpoints\")` 里搜索模型文件，但 ComfyUI 内置的 `UNETLoader`（含社区的 `UnetLoaderGGUF` 等）从 `models/diffusion_models/` 或 `models/unet/` 加载模型，这些目录下的文件不在 `checkpoints` namespace 里。

结果：
- `metadata_collector` 的 `UNETLoaderExtractor` 已正确捕获了 `unet_name`，所以 `Model:` 字段写得出来；
- 但 `_calculate_checkpoint_hash` 找不到对应文件 → 返回空字符串 → `Model hash:` 字段被跳过；
- Civitai 上传时只能拿到 `Model: <文件名>`，匹配不到 hash，自动识别底模失败。

典型受影响场景：Anima、Flux、Cosmos-Predict2 等 UNet-only 架构模型。

## 复现

1. 在 `models/diffusion_models/` 或 `models/unet/` 下放一个 UNet 模型（例如 Anima）
2. 用 `UNETLoader` 加载并跑图，用 `SaveImagePlus` 保存
3. 查看输出 PNG 的 `parameters` 字段：只有 `Model: xxx`，没有 `Model hash: xxx`
4. 上传到 Civitai，主模型显示为「未识别」或被错认成同名模糊匹配的别的模型

## 修复

`_calculate_checkpoint_hash` 依次搜索 `checkpoints` → `diffusion_models` → `unet` 三个 namespace，第一个命中 base_name 即返回。`try/except` 包住 `get_filename_list`，避免某个 namespace 未注册时报错。

## 兼容性

- `checkpoints` 仍是第一个搜索的 namespace，原有 SDXL / Illustrious / SD1.5 等基于 `CheckpointLoaderSimple` 的行为完全不变（命中后立即 break）
- 仅当 `checkpoints` 没命中时才去搜 `diffusion_models` / `unet`，对老用户零影响
- 命中后走原有的缓存（`hash_cache_manager`）和 SHA256 计算逻辑，不引入新的依赖

## 测试

- 在 `models/unet/` 下放 anima-preview3-base.safetensors，用 UNETLoader 加载跑图
- 修复前：`parameters` 里只有 `Model: anima-preview3-base`
- 修复后：`parameters` 里多出 `Model hash: 14fffe8ad5,`，Civitai 上传后能正确识别底模