### PR TITLE
修复：onSerialize 不应返回值

### DIFF
--- a/js/group_ignore_manager/group_ignore_manager.js
+++ b/js/group_ignore_manager/group_ignore_manager.js
@@ -2319,7 +2319,7 @@ app.registerExtension({
         // 序列化节点数据
         const onSerialize = nodeType.prototype.onSerialize;
         nodeType.prototype.onSerialize = function (info) {
-            const data = onSerialize?.apply?.(this, arguments);
+            onSerialize?.apply?.(this, arguments);
 
             // 保存组配置到工作流 JSON
             info.groups = this.properties.groups || [];
@@ -2335,8 +2335,6 @@ app.registerExtension({
             logger.info('[GMM-Serialize] 保存组顺序:', info.groupOrder.length, '个组');
             logger.info('[GMM-Serialize] 保存管理模式:', info.managerMode);
             logger.info('[GMM-Serialize] 保存自定义组:', info.customManagedGroups.length, '个');
-
-            return data;
         };
 
         // 反序列化节点数据

--- a/js/group_mute_manager/group_mute_manager.js
+++ b/js/group_mute_manager/group_mute_manager.js
@@ -2319,7 +2319,7 @@ app.registerExtension({
         // 序列化节点数据
         const onSerialize = nodeType.prototype.onSerialize;
         nodeType.prototype.onSerialize = function (info) {
-            const data = onSerialize?.apply?.(this, arguments);
+            onSerialize?.apply?.(this, arguments);
 
             // 保存组配置到工作流 JSON
             info.groups = this.properties.groups || [];
@@ -2335,8 +2335,6 @@ app.registerExtension({
             logger.info('[GMM-Serialize] 保存组顺序:', info.groupOrder.length, '个组');
             logger.info('[GMM-Serialize] 保存管理模式:', info.managerMode);
             logger.info('[GMM-Serialize] 保存自定义组:', info.customManagedGroups.length, '个');
-
-            return data;
         };
 
         // 反序列化节点数据

--- a/js/simple_image_compare/simple_image_compare.js
+++ b/js/simple_image_compare/simple_image_compare.js
@@ -446,7 +446,7 @@ app.registerExtension({
             // 序列化处理
             const onSerialize = nodeType.prototype.onSerialize;
             nodeType.prototype.onSerialize = function (serialised) {
-                const r = onSerialize ? onSerialize.apply(this, arguments) : undefined;
+                onSerialize?.apply(this, arguments);
 
                 for (let [index, widget] of (this.widgets || []).entries()) {
                     if (widget instanceof SimpleImageCompare) {
@@ -456,8 +456,6 @@ app.registerExtension({
                         serialised.widgets_values[index] = widget.serializeValue();
                     }
                 }
-
-                return r;
             };
         }
     },

--- a/js/workflow_description/workflow_description.js
+++ b/js/workflow_description/workflow_description.js
@@ -953,14 +953,12 @@ app.registerExtension({
         // 序列化节点数据
         const onSerialize = nodeType.prototype.onSerialize;
         nodeType.prototype.onSerialize = function (info) {
-            const data = onSerialize?.apply?.(this, arguments);
+            onSerialize?.apply?.(this, arguments);
 
             // 保存节点属性到工作流 JSON
             info.properties = this.properties || {};
 
             logger.info('[WorkflowDescription-Serialize] 保存节点属性:', info.properties);
-
-            return data;
         };
 
         // 反序列化节点数据


### PR DESCRIPTION
## 问题

`LGraphNode.serialize` 调用节点的 `onSerialize` 钩子时，若钩子函数有返回值，会触发警告：

```
node onSerialize shouldn't return anything, data should be stored in the object pass in the first parameter
```

## 原因

以下四个文件的 `onSerialize` 实现把上层钩子的返回值捕获后原样 `return` 出去：

- `js/group_ignore_manager/group_ignore_manager.js`
- `js/group_mute_manager/group_mute_manager.js`
- `js/workflow_description/workflow_description.js`
- `js/simple_image_compare/simple_image_compare.js`

LiteGraph 规范要求 `onSerialize` 只能向传入的 `info` 对象写数据，不能有返回值。

## 修改

去掉 `return` 语句，同时去掉不必要的 `const data/r = ...` 变量捕获。数据已经正确写入 `info` 对象，无需依赖返回值。