### PR TITLE
fix: compute model hash for UNet/diffusion_models loaders

### DIFF
--- a/py/save_image_plus/save_image_plus.py
+++ b/py/save_image_plus/save_image_plus.py
@@ -435,16 +435,20 @@ class SaveImagePlus:
             if os.path.isabs(checkpoint_name) and os.path.exists(checkpoint_name):
                 checkpoint_file = checkpoint_name
             else:
-                # 搜索 checkpoint 文件
-                checkpoint_paths = folder_paths.get_filename_list("checkpoints")
                 checkpoint_file = None
+                base_name = os.path.splitext(os.path.basename(checkpoint_name))[0].lower()
 
-                # 去除扩展名进行匹配
-                base_name = os.path.splitext(os.path.basename(checkpoint_name))[0]
-
-                for path in checkpoint_paths:
-                    if os.path.splitext(os.path.basename(path))[0] == base_name:
-                        checkpoint_file = folder_paths.get_full_path("checkpoints", path)
+                # 先搜 checkpoints，再 fallback 到 unet / diffusion_models
+                for folder_type in ("checkpoints", "unet", "diffusion_models"):
+                    try:
+                        paths = folder_paths.get_filename_list(folder_type)
+                    except Exception:
+                        continue
+                    for path in paths:
+                        if os.path.splitext(os.path.basename(path))[0].lower() == base_name:
+                            checkpoint_file = folder_paths.get_full_path(folder_type, path)
+                            break
+                    if checkpoint_file:
                         break
 
             if not checkpoint_file or not os.path.exists(checkpoint_file):


### PR DESCRIPTION
## Problem

When a workflow uses a standalone UNet loader (e.g. Flux), `SaveImagePlus` writes `Model: {name}` to PNG metadata but omits `Model hash`. This happens because `_calculate_checkpoint_hash` only searches the `checkpoints` folder type, while UNet models are stored under `unet` / `diffusion_models`.

## Fix

Fall back through `checkpoints → unet → diffusion_models` until the file is found. Also normalises the filename comparison to `.lower()` for Windows case-insensitive paths.

## Test

Run a Flux workflow with a UNet loader, save with SaveImagePlus, inspect the PNG `parameters` field — `Model hash: xxxxxxxx, Model: {name}` should now appear.