### PR TITLE
fix(danbooru_gallery): reflow grid when node width changes

### DIFF
--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -91,6 +91,8 @@ app.registerExtension({
                 }
 
                 const container = $el("div.danbooru-gallery");
+                container.style.boxSizing = "border-box";
+                container.style.width = "100%";
 
                 // 添加错误显示区域
                 const errorDisplay = $el("div.danbooru-error-display", {
@@ -3862,10 +3864,20 @@ app.registerExtension({
 
                 this.onResize = (size) => {
                     const [width, height] = size;
+                    const contentWidth = Math.max(150, width - 24);
+                    container.style.width = `${contentWidth}px`;
+                    container.style.maxWidth = `${contentWidth}px`;
+                    imageGrid.style.width = "100%";
+                    imageGrid.style.maxWidth = "100%";
+                    imageGrid.style.boxSizing = "border-box";
+
                     const controlsHeight = container.querySelector('.danbooru-controls')?.offsetHeight || 0;
                     if (controlsHeight > 0) {
-                        imageGrid.style.height = `${height - controlsHeight - 10}px`;
+                        imageGrid.style.height = `${Math.max(120, height - controlsHeight - 10)}px`;
                     }
+
+                    cachedColumnWidth = 0;
+                    scheduleResizeGrid();
                 }
             };
 

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -92,7 +92,6 @@ app.registerExtension({
 
                 const container = $el("div.danbooru-gallery");
                 container.style.boxSizing = "border-box";
-                container.style.width = "100%";
 
                 // 添加错误显示区域
                 const errorDisplay = $el("div.danbooru-error-display", {
@@ -3866,9 +3865,7 @@ app.registerExtension({
                     const [width, height] = size;
                     const contentWidth = Math.max(150, width - 24);
                     container.style.width = `${contentWidth}px`;
-                    container.style.maxWidth = `${contentWidth}px`;
                     imageGrid.style.width = "100%";
-                    imageGrid.style.maxWidth = "100%";
                     imageGrid.style.boxSizing = "border-box";
 
                     const controlsHeight = container.querySelector('.danbooru-controls')?.offsetHeight || 0;


### PR DESCRIPTION
## 修复内容

修复 Danbooru Gallery 节点横向拉宽后，内部画廊仍然保持窄宽度、图片列表不会自动变成多列的问题, 而拉高高度却可以正常响应

测试版本是ComfyUI v0.22.3 (7c47f4d, 2026.05.27)

## 原因

此问题也在 #39 #27 这两个issue也有提到(

Danbooru Gallery 节点内部使用 `addDOMWidget` 渲染 HTML 画廊界面。节点本身被拉宽时，ComfyUI 外层节点尺寸会变化并且会同步px数据，但原有的 `onResize` 逻辑只更新了图片网格的高度, 却没有主动更新图片网格的宽度.

因此即使节点外框已经变宽，内部 `.danbooru-gallery` / `.danbooru-image-grid` 实际width保持不变，下面的代码

```
grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
```

无法获得新的可用宽度，画廊仍然只显示为固定列; 而且在第一次刷新浏览器后可以刷新出新的width.

同时，存在列宽缓存。如果节点宽度变化后不清理缓存并重新计算，图片卡片的行跨度也可能继续基于旧列宽计算，造成拉动节点布局不更新

## 修改

在节点 `onResize` 时同步处理内部布局尺寸：

- 根据 ComfyUI 节点的传值当前宽度计算内部内容宽度。
- 将宽度显式同步到 `.danbooru-gallery` 。
- 添加动态的宽度计算方法，使其跟随容器扩展。
- 清除 `cachedColumnWidth`，避免瀑布流继续使用旧列宽。
- 调用节点内部的 `scheduleResizeGrid()` 方法，在尺寸变化后才触发图片网格重排.
- 为图片网格高度计算增加最小值，避免节点过小时出现过小或无效高度 (max(120, height...)的那一行)

## 我期望的效果

拉宽 Danbooru Gallery 节点后，内部画廊区域会跟随节点宽度扩展，图片网格可以按可用宽度自动变成多列显示。

拉高或缩小节点时，画廊高度和瀑布流布局仍会正常更新。

顺便附上修复前和修复后的两个情况

https://github.com/user-attachments/assets/758a7a91-24b9-4a92-ad23-f3c09165e95a

https://github.com/user-attachments/assets/cef22ac5-bb02-42ed-ae4a-9491ca6c941c
