### PR TITLE
fix: anima/Qwen-Image VAE 下多图放大只出第一张

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -71,6 +71,10 @@ from .py.group_is_enabled import NODE_CLASS_MAPPINGS as gie_mappings
 from .py.group_is_enabled import NODE_DISPLAY_NAME_MAPPINGS as gie_display_mappings
 from .py.group_is_enabled.group_is_enabled import update_all_group_states as gie_update_states
 
+# 导入 VAE 图像批次修复
+from .py.vae_fix import NODE_CLASS_MAPPINGS as vae_fix_mappings
+from .py.vae_fix import NODE_DISPLAY_NAME_MAPPINGS as vae_fix_display_mappings
+
 # 优化执行系统映射
 opt_mappings = {
     **group_mute_mappings,
@@ -104,7 +108,8 @@ NODE_CLASS_MAPPINGS = {
     **workflow_description_mappings,
     **open_in_krita_mappings,
     **quick_group_navigation_mappings,
-    **gie_mappings
+    **gie_mappings,
+    **vae_fix_mappings
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -129,12 +134,13 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     **workflow_description_display_mappings,
     **open_in_krita_display_mappings,
     **quick_group_navigation_display_mappings,
-    **gie_display_mappings
+    **gie_display_mappings,
+    **vae_fix_display_mappings
 }
 
 # 统计节点加载情况
 _node_load_stats["total_nodes"] = len(NODE_CLASS_MAPPINGS)
-_node_load_stats["loaded_modules"] = 20  # 成功导入的模块数(根据上面的import语句统计)
+_node_load_stats["loaded_modules"] = 21  # 成功导入的模块数(根据上面的import语句统计)
 
 # 控制台输出
 print("=" * 70, file=sys.stderr)

--- a/py/vae_fix/__init__.py
+++ b/py/vae_fix/__init__.py
@@ -1,0 +1,12 @@
+"""
+VAE 图像批次修复模块 (VAE Image Batch Fix Module)
+"""
+
+from ..utils.logger import get_logger
+logger = get_logger(__name__)
+
+from .vae_fix import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+
+__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']
+
+logger.info("VAE 图像批次修复节点已加载")

--- a/py/vae_fix/vae_fix.py
+++ b/py/vae_fix/vae_fix.py
@@ -1,0 +1,69 @@
+"""
+VAE 图像批次修复节点 (VAE Image Batch Fix)
+
+Wan 系 VAE（含 Qwen-Image VAE，anima 模型用的就是它）在 ComfyUI 里被当成视频 VAE：
+VAE.encode() 把 N 张独立图 reshape 成「1 个 N 帧视频」（comfy/sd.py:1034），
+导致一批 N 张图编码后塌成 1 张。把 vae.not_video 置 True，编码改走 unsqueeze(2)
+分支，N 保留在批次维、每张 T=1，N 张各自独立编码。
+
+只影响编码（decode 不读 not_video），生成阶段不受影响。
+"""
+
+import sys
+
+
+def _dbg(msg):
+    print(f"[VAEImageBatchFix] {msg}", file=sys.stderr, flush=True)
+
+
+class VAEImageBatchFix:
+    RETURN_TYPES = ("VAE",)
+    RETURN_NAMES = ("vae",)
+    FUNCTION = "fix"
+    CATEGORY = "danbooru"
+
+    DESCRIPTION = (
+        "修复 Wan/Qwen-Image 系 VAE 在放大时把图像批次当视频帧、N 张塌成 1 张的问题。"
+        "接在 VAELoader 之后，整条放大流程共用即可。只影响编码，不影响生成。"
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "vae": ("VAE",),
+            },
+            "optional": {
+                "enable": ("BOOLEAN", {"default": True, "label_on": "启用", "label_off": "禁用"}),
+            },
+        }
+
+    def fix(self, vae, enable=True):
+        had_attr = hasattr(vae, "not_video")
+        latent_dim = getattr(vae, "latent_dim", None)
+
+        if not enable:
+            _dbg(f"已禁用，原样透传 (latent_dim={latent_dim}, not_video={getattr(vae, 'not_video', 'N/A')})")
+            return (vae,)
+
+        if not had_attr:
+            _dbg(f"该 VAE 无 not_video 属性 (latent_dim={latent_dim})，可能不是 Wan 系 VAE，原样透传")
+            return (vae,)
+
+        if latent_dim != 3:
+            _dbg(f"latent_dim={latent_dim} 非 3，编码不会走视频分支，无需修复，原样透传")
+            return (vae,)
+
+        old = vae.not_video
+        vae.not_video = True
+        _dbg(f"已置 not_video: {old} -> True (latent_dim=3)，批次图将按 N 张独立编码")
+        return (vae,)
+
+
+NODE_CLASS_MAPPINGS = {
+    "VAEImageBatchFix": VAEImageBatchFix,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "VAEImageBatchFix": "VAE 图像批次修复 (VAE Image Batch Fix)",
+}


### PR DESCRIPTION
给 [ShiQi_Workflow](https://github.com/Aaalice233/ShiQi_Workflow) 做第三方维护时发现的问题。

## 背景

工作流里选多张底图放大，换成 anima 模型就只放大第一张，SDXL 一切正常。anima 用的是 Qwen-Image VAE，问题出在这。

## 实现

ComfyUI 把 Qwen-Image VAE 归到 Wan 系 VAE（`latent_dim=3`、`not_video` 默认 `False`）。于是 `VAE.encode()`（`comfy/sd.py:1034`）把一批 `[N,H,W,C]` 图 reshape 成 `[1,C,N,H,W]`——N 张独立图被当成一个 N 帧的视频，解码时帧相加（`comfy/ldm/wan/vae.py` 的 `out += out_`），最后塌成一张。SDXL 的 VAE 是 `latent_dim=2`，绕开这条路，所以正常。

新增一个小节点 `VAEImageBatchFix`：接在 VAELoader 之后，把这个 VAE 实例的 `not_video` 置 `True`。编码改走 `unsqueeze(2)` 分支，`[N,H,W,C]` → `[N,C,1,H,W]`，批次维 N 保留、每张 T=1，N 张各自独立编码。

- 只碰编码。`not_video` 在 `decode()` 里完全不读，生成阶段走 decode、不受影响。
- `latent_dim != 3`（比如 SDXL）原样透传，带 `enable` 开关。
- 一个 VAE 经 Context 分发给整条放大链共用，接一次全流程覆盖。

## 结果

选 N 张底图、anima 模型、跑一次，N 张各自放大出 N 张。SDXL 行为不变。

已验证不影响生成和解码：**相同种子下，接与不接这个节点，产出的图片完全一致**。它只改多图编码时的批次处理，对单张/生成的行为零变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
