### PR TITLE
fix(ParameterBreak): 输出上限 20 → 32，支持多 ControlNet 参数面板

### DIFF
--- a/py/parameter_break/parameter_break.py
+++ b/py/parameter_break/parameter_break.py
@@ -25,6 +25,17 @@ class AnyType(str):
 # 创建通配符类型实例
 any_typ = AnyType("*")
 
+# ==================== 输出数量上限 ====================
+
+# ParameterBreak 的最大输出槽数量。
+# 之前固定为 20，但带双 ControlNet 的参数面板（每个 ControlNet 需要
+# 模型/控制类型/多个预处理器/强度/权重/结束百分比等约 10+ 个参数）很容易
+# 超过 20：超出的参数会被静默丢弃为 None，下游节点拿到 None 后报错
+# （例如 ControlNet 的 percent_to_sigma 抛 "'<=' not supported between
+# instances of 'NoneType' and 'float'"，或读取越界输出槽抛 tuple index
+# out of range）。提高到 32 以容纳多 ControlNet 面板。
+MAX_OUTPUTS = 32
+
 # ==================== 全局存储 ====================
 
 # 存储每个节点的参数结构配置 {node_id: {"meta": [...], "last_update": timestamp}}
@@ -69,10 +80,10 @@ class ParameterBreak:
         }
 
     # 固定最大输出数量以支持动态参数
-    # 定义最多20个输出槽，未使用的返回None
+    # 定义最多 MAX_OUTPUTS 个输出槽，未使用的返回None
     # 使用AnyType实例作为通配符类型，可连接到任何输入
-    RETURN_TYPES = tuple([any_typ] * 20)
-    RETURN_NAMES = tuple([f"output_{i+1}" for i in range(20)])
+    RETURN_TYPES = tuple([any_typ] * MAX_OUTPUTS)
+    RETURN_NAMES = tuple([f"output_{i+1}" for i in range(MAX_OUTPUTS)])
     FUNCTION = "break_parameters"
     CATEGORY = "danbooru"
     OUTPUT_NODE = False
@@ -99,8 +110,8 @@ class ParameterBreak:
         Returns:
             参数值的元组（固定20个输出，未使用的为None）
         """
-        # 初始化20个None输出
-        outputs = [None] * 20
+        # 初始化 MAX_OUTPUTS 个None输出
+        outputs = [None] * MAX_OUTPUTS
 
         if not parameters or not isinstance(parameters, dict):
             logger.info(f" 节点 {unique_id} 接收到无效的参数包")
@@ -119,8 +130,8 @@ class ParameterBreak:
 
         # 按照元数据顺序填充输出（最多20个）
         for i, param_meta in enumerate(meta):
-            if i >= 20:
-                logger.info(f" 警告: 参数数量超过20个，后续参数将被忽略")
+            if i >= MAX_OUTPUTS:
+                logger.info(f" 警告: 参数数量超过{MAX_OUTPUTS}个，后续参数将被忽略")
                 break
 
             name = param_meta.get("name")


### PR DESCRIPTION
## 问题

`ParameterBreak` 的输出槽数量硬编码为 20（`RETURN_TYPES = tuple([any_typ] * 20)`，且 `break_parameters` 在 `i >= 20` 时 `break`）。

在维护底图控制网工作流、引入新的 chenkin ControlNet 模型后，参数面板变成**双 ControlNet**：每个 ControlNet 需要 模型 / 控制类型 / 多个预处理器 / 强度 / 柔和缩放权重 / 结束百分比 等约 10+ 个参数，两个叠起来（实测 23 个有效参数）就超过 20。

超过 20 的参数（这里正好是 控制网2 强度 / 柔和缩放权重 / 结束百分比，第 21/22/23 个）被静默丢弃为 `None`，导致：

- ControlNet `percent_to_sigma` 抛 `'<=' not supported between instances of 'NoneType' and 'float'`（end_percent / strength = None）
- 节点上仍保留这些输出槽，但运行时返回的 tuple 只有 20 个元素，读取越界槽抛 `tuple index out of range`
- 接 Display 节点验证时这几个输出无任何值

现象是"前面的控制网正常、后面的控制网参数全 None"，很难定位。

## 改动

- 把散落在 4 处的魔数 `20` 提取为单个常量 `MAX_OUTPUTS = 32`
- 上限从 20 提到 32，容纳多 ControlNet 面板并预留余量

## 影响 / 风险

- 仅放宽上限；≤20 参数的现有工作流行为完全不变
- 多出来的输出槽返回 `None`（与原逻辑一致），前端只按实际参数数量显示引脚，无性能 / 显示负担

## 复现

带两个 ControlNet 的参数控制面板（≥21 个有效参数）→ 第 21 个起的参数输出 `None` → 下游 ControlNet 报上述错误。