### PR TITLE
预加载和防重复还有bug

### DIFF
--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -196,6 +196,7 @@ app.registerExtension({
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
                 let lastPostId = null;            // D 站游标分页：上一批最后一张的 id
                 const seenPostIds = new Set();    // 渲染前 id 去重兜底
+                let fillAnchor = 0;               // G 站续拉锚点：本轮自该 posts 数起凑够 fillTarget
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -2453,12 +2454,24 @@ app.registerExtension({
                     }).join(' ');
                 };
 
-                const fetchAndRender = async (reset = false) => {
+                const fetchAndRender = async (reset = false, isContinuation = false) => {
                     if (isLoading) {
                         return;
                     }
                     if (endOfResults && !reset) {
                         return;
+                    }
+                    // G 站公开列表页每页固定约 42 张，单次请求凑不满较大的 preload_count。
+                    // 续拉机制：拿完一页后若本轮累计不足 fillTarget 且未到底，自动续拉下一页。
+                    // （D 站一次请求即可拿满 limit；G 站游标模式靠 lastPostId 翻批；均不续拉。）
+                    const src = uiSettings.source_site || "danbooru";
+                    const dedupMode = uiSettings.gelbooru_dedup_mode || "off";
+                    const needAutoFill = (src === "gelbooru" && dedupMode === "off");
+                    const fillTarget = needAutoFill ? (parseInt(uiSettings.preload_count, 10) || 40) : 0;
+                    // 续拉锚点：新一轮（reset 或用户滚动触发的非续拉调用）以当前 posts 数为基准，
+                    // 续拉到 posts 比基准多出 fillTarget 张为止。续拉调用(isContinuation)沿用旧基准。
+                    if (!isContinuation) {
+                        fillAnchor = reset ? 0 : posts.length;
                     }
                     isLoading = true;
                     refreshButton.classList.add("loading");
@@ -2606,6 +2619,15 @@ app.registerExtension({
                         if (indicator) {
                             indicator.remove();
                         }
+                    }
+
+                    // G 站续拉：本轮（自 fillAnchor 起）累计不足 fillTarget 且未到底，自动拉下一页。
+                    // 条件含 posts.length > fillAnchor（确有进展），避免出错时无限重试。
+                    if (needAutoFill && !endOfResults &&
+                        posts.length > fillAnchor &&
+                        (posts.length - fillAnchor) < fillTarget) {
+                        // 异步触发续拉，让出调用栈（避免深递归）；isLoading 已在 finally 释放
+                        setTimeout(() => fetchAndRender(false, true), 0);
                     }
                 };
 

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -154,6 +154,13 @@ app.registerExtension({
 
                 // 检查网络连接状态
                 const checkNetworkStatus = async () => {
+                    // 节流：上次检查成功且在 30 秒内，直接复用，避免每次滚动加载都做一次完整网络往返
+                    // （G 站的检查是抓公开 HTML 页、8 秒超时，频繁触发会卡顿并误报"网络连接失败"）。
+                    const NETWORK_CHECK_TTL = 30000;
+                    if (networkStatus.connected && networkStatus.lastChecked &&
+                        (Date.now() - networkStatus.lastChecked) < NETWORK_CHECK_TTL) {
+                        return true;
+                    }
                     try {
                         const source = uiSettings.source_site || "danbooru";
                         const response = await fetch(`/danbooru_gallery/check_network?source=${encodeURIComponent(source)}`);
@@ -187,9 +194,8 @@ app.registerExtension({
                 let globalTooltip, globalTooltipTimeout;
                 let currentTooltipId = 0; // 用于追踪当前活动的tooltip请求
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
-                let lastPostId = null; // 游标分页：最后一张图的 id，下次请求传 before_id 防重复
-                let initialLoadComplete = false; // 首次加载（含预加载缓冲）是否完成
-                const seenPostIds = new Set(); // 跨批次去重兜底，防止任何重复图渲染
+                let lastPostId = null;            // D 站游标分页：上一批最后一张的 id
+                const seenPostIds = new Set();    // 渲染前 id 去重兜底
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -1430,6 +1436,44 @@ app.registerExtension({
                     selectionModeSection.appendChild(selectionModeDesc);
                     selectionModeSection.appendChild(multiSelectDiv);
 
+                    // 预加载设置（每次加载的图片数量，越大一次拉取越多但首屏越慢）
+                    const preloadSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
+                    const preloadTitle = $el("h3", { textContent: "预加载设置", style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
+                    const preloadDesc = $el("p", { textContent: "每次加载的图片数量。数值越大一次拉取越多，但首屏等待时间也越长（建议 40-100）", style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
+                    const preloadCountLabel = $el("label", { htmlFor: "preloadCountInput", textContent: "每次加载数量", style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
+                    const preloadCountInput = $el("input", {
+                        type: "number",
+                        id: "preloadCountInput",
+                        title: "设置每次加载数量（20-200）",
+                        value: (initialState.preloadCount ?? uiSettings.preload_count) || 40,
+                        min: "20",
+                        max: "200",
+                        style: { width: "60px", padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
+                    });
+                    const preloadCountDiv = $el("div", { style: { display: "flex", alignItems: "center" } }, [preloadCountLabel, preloadCountInput]);
+                    preloadSection.appendChild(preloadTitle);
+                    preloadSection.appendChild(preloadDesc);
+                    preloadSection.appendChild(preloadCountDiv);
+
+                    // G 站防重复设置（按 id 游标分页，解决翻页时新上传挤入导致的重复图）
+                    // 三段式：off / on（未配密钥时仅1个tag留名额给游标）/ on_auth（已配密钥，多tag可用）
+                    const gelbooruDedupLabel = $el("label", { htmlFor: "gelbooruDedupSelect", textContent: "G 站防重复", style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
+                    const gelbooruDedupSelect = $el("select", {
+                        id: "gelbooruDedupSelect",
+                        title: "G 站游标防重复档位（按id推进分页，避免新上传图导致翻页重复）",
+                        style: { padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
+                    }, [
+                        $el("option", { value: "off", textContent: "关闭（可使用2个tag）" }),
+                        $el("option", { value: "on", textContent: "开启（限1个tag）" }),
+                        $el("option", { value: "on_auth", textContent: "开启·已配密钥（多tag可用）" }),
+                    ]);
+                    const dedupInitial = (initialState.gelbooruDedupMode ?? uiSettings.gelbooru_dedup_mode) || "off";
+                    if (["off", "on", "on_auth"].includes(dedupInitial)) gelbooruDedupSelect.value = dedupInitial;
+                    const gelbooruDedupDiv = $el("div", { style: { display: "flex", alignItems: "center", marginTop: "12px" } }, [gelbooruDedupLabel, gelbooruDedupSelect]);
+                    const gelbooruDedupDesc = $el("p", { textContent: "关闭时 G 站保持原样；开启时按 id 游标推进翻页。未配密钥的开启档会限 1 个 tag 留给游标；已配密钥多 tag 可用", style: { margin: "8px 0 0 0", color: "#888", fontSize: "0.85em" } });
+                    preloadSection.appendChild(gelbooruDedupDiv);
+                    preloadSection.appendChild(gelbooruDedupDesc);
+
                     // 创建侧边栏按钮和内容区域的映射
                     const sections = {
                         'general': { title: t('generalSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>', elements: [languageSection] },
@@ -1437,6 +1481,7 @@ app.registerExtension({
                         'content': { title: t('contentSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18l-1.5 14H4.5L3 6z"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>', elements: [blacklistSection] },
                         'prompt': { title: t('promptSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>', elements: [filterSection] },
                         'ui': { title: t('uiSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>', elements: [autocompleteSection, tooltipSection, selectionModeSection] },
+                        'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
                     };
 
                     const setActiveSection = (key) => {
@@ -1647,6 +1692,10 @@ app.registerExtension({
                             const newAutocompleteMaxResults = parseInt(autocompleteMaxResultsInput.value, 10);
                             const newSelectedCategories = Array.from(categoryDropdown.querySelectorAll("input:checked")).map(i => i.name);
                             const newMultiSelectEnabled = multiSelectCheckbox.checked;
+                            let newPreloadCount = parseInt(preloadCountInput.value, 10);
+                            if (isNaN(newPreloadCount)) newPreloadCount = 40;
+                            newPreloadCount = Math.min(Math.max(newPreloadCount, 20), 200); // 夹到 20-200
+                            const newGelbooruDedupMode = ["off", "on", "on_auth"].includes(gelbooruDedupSelect.value) ? gelbooruDedupSelect.value : "off";
 
                             // 保存所有设置
                             const [blacklistSuccess, filterSuccess, uiSettingsSuccess] = await Promise.all([
@@ -1658,6 +1707,8 @@ app.registerExtension({
                                     autocomplete_max_results: newAutocompleteMaxResults,
                                     selected_categories: newSelectedCategories,
                                     multi_select_enabled: newMultiSelectEnabled,
+                                    preload_count: newPreloadCount,
+                                    gelbooru_dedup_mode: newGelbooruDedupMode,
                                     source_site: uiSettings.source_site || "danbooru",
                                     gelbooru_display_all_site_content: uiSettings.gelbooru_display_all_site_content || false
                                 })
@@ -1673,6 +1724,8 @@ app.registerExtension({
                                 uiSettings.autocomplete_max_results = newAutocompleteMaxResults;
                                 uiSettings.selected_categories = newSelectedCategories;
                                 uiSettings.multi_select_enabled = newMultiSelectEnabled;
+                                uiSettings.preload_count = newPreloadCount;
+                                uiSettings.gelbooru_dedup_mode = newGelbooruDedupMode;
                                 uiSettings.source_site = sourceSelect.value || uiSettings.source_site || "danbooru";
                                 await updateSelectionData();
 
@@ -1681,7 +1734,6 @@ app.registerExtension({
 
                                 // 重新过滤当前已加载的帖子
                                 const filteredPosts = posts.filter(post => !isPostFiltered(post));
-                                posts = filteredPosts; // 同步数组，保证预加载缓冲计算准确
                                 imageGrid.innerHTML = "";
                                 filteredPosts.forEach(renderPost);
 
@@ -2058,6 +2110,8 @@ app.registerExtension({
                     multi_select_enabled: false,
                     source_site: "danbooru",
                     gelbooru_display_all_site_content: false,
+                    preload_count: 40,
+                    gelbooru_dedup_mode: "off",
                     formatting: {
                         escapeBrackets: true,
                         replaceUnderscores: true,
@@ -2077,6 +2131,8 @@ app.registerExtension({
                                 multi_select_enabled: data.settings.multi_select_enabled || false,
                                 source_site: data.settings.source_site || "danbooru",
                                 gelbooru_display_all_site_content: data.settings.gelbooru_display_all_site_content || false,
+                                preload_count: data.settings.preload_count || 40,
+                                gelbooru_dedup_mode: data.settings.gelbooru_dedup_mode || "off",
                                 formatting: data.settings.formatting || { escapeBrackets: true, replaceUnderscores: true }
                             };
                         }
@@ -2397,7 +2453,7 @@ app.registerExtension({
                     }).join(' ');
                 };
 
-                const fetchAndRender = async (reset = false, isPreload = false, preloadAmount = 0) => {
+                const fetchAndRender = async (reset = false) => {
                     if (isLoading) {
                         return;
                     }
@@ -2405,23 +2461,18 @@ app.registerExtension({
                         return;
                     }
                     isLoading = true;
+                    refreshButton.classList.add("loading");
+                    refreshButton.disabled = true;
 
-                    // 只有非预加载时才显示加载动画（预加载是后台静默补缓冲）
-                    if (!isPreload) {
-                        refreshButton.classList.add("loading");
-                        refreshButton.disabled = true;
-
-                        const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
-                        if (!loadingIndicator) {
-                            imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
-                        }
+                    const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
+                    if (!loadingIndicator) {
+                        imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
                     }
 
                     if (reset) {
                         currentPage = filterState.startPage || 1;
-                        lastPostId = null; // 重置游标
-                        initialLoadComplete = false; // 重置首次加载标记
-                        seenPostIds.clear(); // 重置去重集合
+                        lastPostId = null;        // 重置游标
+                        seenPostIds.clear();      // 重置去重集合
                         posts = [];
                         endOfResults = false;
                         imageGrid.innerHTML = "";
@@ -2432,18 +2483,18 @@ app.registerExtension({
                     const isNetworkConnected = await checkNetworkStatus();
 
                     if (!isNetworkConnected) {
-                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");
-                        if (!isPreload) {
+                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到服务器");  // 仅在控制台记录
+                        // 仅在首次加载(reset)时用整屏错误提示；滚动加载(reset=false)失败时
+                        // 不清空已加载内容，静默返回，下次滚动再试，避免"频繁报错+整屏重载"。
+                        if (reset) {
                             imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
                         }
                         isLoading = false;
-                        if (!isPreload) {
-                            refreshButton.classList.remove("loading");
-                            refreshButton.disabled = false;
-                            const indicator = imageGrid.querySelector('.danbooru-loading');
-                            if (indicator) {
-                                indicator.remove();
-                            }
+                        refreshButton.classList.remove("loading");
+                        refreshButton.disabled = false;
+                        const indicator = imageGrid.querySelector('.danbooru-loading');
+                        if (indicator) {
+                            indicator.remove();
                         }
                         return;
                     } else {
@@ -2458,9 +2509,10 @@ app.registerExtension({
                         const tagCount = tags.length;
 
                         // 如果超过2个tag，给用户提示
-                        if (tagCount > 2 && !isPreload) {
+                        if (tagCount > 2) {
                             showTagHint('搜索只考虑前两个tag，第三个及后续tag将被忽略', false);
-                        } else if (!isPreload) {
+                        } else {
+                            // 清除之前的提示
                             clearTagHint();
                         }
 
@@ -2477,138 +2529,82 @@ app.registerExtension({
                         const selectedRatings = getSelectedRatings();
                         const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
                         const ratingForServer = sendAll ? "" : selectedRatings.join(",");
+                        const params = new URLSearchParams({
+                            "source": uiSettings.source_site || "danbooru",
+                            "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
+                            "search[tags]": apiFormattedTags.trim(),
+                            "search[rating]": ratingForServer,
+                            limit: String(uiSettings.preload_count || 40),
+                            page: currentPage,
+                        });
 
-                        // 计算目标加载数量：
-                        // - 首次加载：先铺一屏(40) + 预加载缓冲，让用户一打开就有富余
-                        // - 预加载补充：只补指定的少量(滑一个补一张式的小批)
-                        // - 普通触底加载：一屏量
-                        let targetCount;
-                        if (!initialLoadComplete && !isPreload) {
-                            targetCount = 40 + (uiSettings.preload_count || 50);
-                        } else if (isPreload && preloadAmount > 0) {
-                            targetCount = preloadAmount;
-                        } else {
-                            targetCount = 40;
-                        }
-
-                        // 单次请求上限（未登录 Danbooru 每次最多 20）
-                        const MAX_PER_REQUEST = 20;
-                        let totalLoaded = 0;
-                        let consecutiveEmpty = 0; // 连续空结果计数，避免死循环
-
-                        // 循环请求直到达到目标数量或没有更多数据
-                        while (totalLoaded < targetCount && consecutiveEmpty < 3) {
-                            const remaining = targetCount - totalLoaded;
-                            const requestSize = Math.min(remaining, MAX_PER_REQUEST);
-
-                            const params = new URLSearchParams({
-                                "source": uiSettings.source_site || "danbooru",
-                                "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
-                                "search[tags]": apiFormattedTags.trim(),
-                                "search[rating]": ratingForServer,
-                                limit: requestSize.toString(),
-                                page: currentPage,
-                            });
-
-                            // 用 before_id 游标分页防重复（reset 后的第一次请求不带，从最新开始）
-                            if (lastPostId && !(reset && totalLoaded === 0)) {
+                        // 游标防重复：reset 后第一次不带（从最新开始）。
+                        // D 站默认排序始终用；G 站仅当 dedup 开关非 off 时用（后端会再校验密钥/排序）。
+                        if (lastPostId && !reset) {
+                            const src = uiSettings.source_site || "danbooru";
+                            const dedup = uiSettings.gelbooru_dedup_mode || "off";
+                            if (src === "danbooru" || (src === "gelbooru" && dedup !== "off")) {
                                 params.set("before_id", lastPostId);
                             }
-
-                            const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                            let newPosts = await response.json();
-
-                            if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
-
-                            // 没有更多数据了
-                            if (newPosts.length === 0) {
-                                endOfResults = true;
-                                if (reset && totalLoaded === 0 && !isPreload) {
-                                    imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
-                                }
-                                break;
-                            }
-
-                            // 评分过滤交给服务端，本地做文件类型/黑名单过滤 + id 去重兜底
-                            const filteredPosts = newPosts.filter(post => {
-                                if (isPostFiltered(post)) return false;
-                                if (seenPostIds.has(post.id)) return false; // 跨批次重复图，丢弃
-                                seenPostIds.add(post.id);
-                                return true;
-                            });
-
-                            // 更新游标（用原始返回的最后一张，保证游标连续推进，
-                            // 即使这批全被过滤，下一批也能接着往后取）
-                            lastPostId = newPosts[newPosts.length - 1].id;
-                            currentPage++;
-
-                            if (filteredPosts.length > 0) {
-                                posts.push(...filteredPosts);
-                                filteredPosts.forEach(renderPost);
-                                totalLoaded += filteredPosts.length;
-                                consecutiveEmpty = 0;
-                            } else {
-                                // 这一批全被过滤了，继续请求下一批
-                                consecutiveEmpty++;
-                            }
-
-                            // API 返回数量少于请求数量，说明已到结果尾部
-                            if (newPosts.length < requestSize) {
-                                endOfResults = true;
-                                break;
-                            }
                         }
 
-                        // 首次加载没有任何图片
-                        if (totalLoaded === 0 && reset && !isPreload) {
+                        const response = await fetch(`/danbooru_gallery/posts?${params}`);
+                        let newPosts = await response.json();
+
+                        if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
+
+                        // 评分过滤已交给服务端，本地只做文件类型/黑名单过滤
+                        const filteredPosts = newPosts.filter(post => !isPostFiltered(post));
+
+                        const filteredCount = newPosts.length - filteredPosts.length;
+
+                        // API returned nothing → no more pages. Flag it so scroll events stop
+                        // triggering fetches; otherwise the bottom-proximity check would keep
+                        // firing and walk off the end of the result set indefinitely.
+                        if (newPosts.length === 0) {
+                            endOfResults = true;
+                            if (reset) {
+                                imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
+                            }
+                            return;
+                        }
+
+                        if (filteredPosts.length === 0 && reset) {
                             imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
                             return;
                         }
 
-                        // 标记首次加载完成
-                        if (!initialLoadComplete && !isPreload && totalLoaded > 0) {
-                            initialLoadComplete = true;
+                        currentPage++;
+                        // 渲染前 id 去重兜底（防游标边界残留重复）
+                        const fresh = filteredPosts.filter(p => {
+                            if (seenPostIds.has(p.id)) return false;
+                            seenPostIds.add(p.id);
+                            return true;
+                        });
+                        // 游标用原始返回最后一张推进（即使本批被过滤光也连续）
+                        lastPostId = newPosts[newPosts.length - 1].id;
+                        posts.push(...fresh);
+                        fresh.forEach(renderPost);
+
+                        // Filter-cascade guard: if the blacklist/rating filter dropped every
+                        // post on this page, the grid didn't grow — the user's scroll is still
+                        // within the 400px bottom threshold, so the scroll listener would
+                        // re-fire immediately. Hold isLoading for ~1.5s (still inside the try
+                        // block, before the finally clears it) to space out these "auto-skip"
+                        // fetches.
+                        if (filteredPosts.length === 0 && !reset) {
+                            await new Promise(r => setTimeout(r, 1500));
                         }
 
                     } catch (e) {
-                        if (!isPreload) {
-                            imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
-                        }
+                        imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
                     } finally {
                         isLoading = false;
-                        if (!isPreload) {
-                            refreshButton.classList.remove("loading");
-                            refreshButton.disabled = false;
-                            const indicator = imageGrid.querySelector('.danbooru-loading');
-                            if (indicator) {
-                                indicator.remove();
-                            }
-                        }
-
-                        // 加载完成后检查是否还需要继续加载
-                        if (!endOfResults) {
-                            setTimeout(() => {
-                                if (isLoading) return;
-
-                                // 1. 接近底部 → 正常加载一屏
-                                if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
-                                    fetchAndRender(false);
-                                    return;
-                                }
-
-                                // 2. 缓冲不足 → 预加载补充（滑一个补一张的"补"在这里发生）
-                                if (initialLoadComplete) {
-                                    const targetBufferSize = uiSettings.preload_count || 50;
-                                    const scrollableHeight = imageGrid.scrollHeight - imageGrid.clientHeight;
-                                    const scrollRatio = scrollableHeight > 0 ? imageGrid.scrollTop / scrollableHeight : 0;
-                                    const viewedCount = Math.floor(scrollRatio * posts.length);
-                                    const remainingBuffer = posts.length - viewedCount;
-
-                                    if (remainingBuffer < targetBufferSize) {
-                                        fetchAndRender(false, true, 20);
-                                    }
-                                }
-                            }, 100);
+                        refreshButton.classList.remove("loading");
+                        refreshButton.disabled = false;
+                        const indicator = imageGrid.querySelector('.danbooru-loading');
+                        if (indicator) {
+                            indicator.remove();
                         }
                     }
                 };
@@ -3252,10 +3248,22 @@ app.registerExtension({
 
                     // Reserve grid space up-front from the post's real dimensions so the
                     // waterfall is stable before thumbnails finish loading.
+                    // G 站公开抓取返回 image_width/height=0，算不出 span；此时给一个保底高度，
+                    // 否则 wrapper 只占 grid-auto-rows(1px)，整个网格塌成一条线 →
+                    // 永远到不了"距底部 400px" → 滚动加载再也不触发。
+                    let reservedSpans = 0;
                     if (post.image_width && post.image_height) {
-                        const spans = computeSpanFromDims(post.image_width, post.image_height);
-                        if (spans > 0) wrapper.style.gridRowEnd = `span ${spans}`;
+                        reservedSpans = computeSpanFromDims(post.image_width, post.image_height);
                     }
+                    if (reservedSpans <= 0) {
+                        // 保底：按列宽估一个近似正方形高度（图片 onload 后 resizeGrid 会修正为真实高度）
+                        const colW = getColumnWidth();
+                        const cs = window.getComputedStyle(imageGrid);
+                        const rowGap = parseInt(cs.gridRowGap) || parseInt(cs.rowGap) || 5;
+                        const rowHeight = parseInt(cs.gridAutoRows) || 1;
+                        reservedSpans = colW > 0 ? Math.ceil((colW + rowGap) / (rowHeight + rowGap)) : 200;
+                    }
+                    if (reservedSpans > 0) wrapper.style.gridRowEnd = `span ${reservedSpans}`;
 
                     // 首次创建post元素时，将原始post数据添加到 originalPostCache
                     if (!originalPostCache[post.id]) {
@@ -3271,7 +3279,7 @@ app.registerExtension({
 
                     const img = $el("img", {
                         src: `/danbooru_gallery/image_proxy?url=${encodeURIComponent(previewUrl)}`,
-                        loading: "lazy",
+                        loading: "eager",
                         onload: scheduleResizeGrid,
                         onerror: () => { wrapper.style.display = 'none'; },
                         onclick: async (e) => {
@@ -3605,23 +3613,8 @@ app.registerExtension({
 
                 let scrollTimeout;
                 imageGrid.addEventListener("scroll", () => {
-                    if (!isLoading && !endOfResults) {
-                        // 触底 → 正常加载一屏
-                        if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
-                            fetchAndRender(false);
-                        } else if (initialLoadComplete) {
-                            // 缓冲不足 → 后台预加载补充（滑一个补一张：前方始终保留 preload_count 张未看过的图）
-                            const targetBufferSize = uiSettings.preload_count || 50;
-                            const scrollableHeight = imageGrid.scrollHeight - imageGrid.clientHeight;
-                            if (scrollableHeight > 0) {
-                                const scrollRatio = imageGrid.scrollTop / scrollableHeight;
-                                const viewedCount = Math.floor(scrollRatio * posts.length);
-                                const remainingBuffer = posts.length - viewedCount;
-                                if (remainingBuffer < targetBufferSize) {
-                                    fetchAndRender(false, true, 20);
-                                }
-                            }
-                        }
+                    if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
+                        fetchAndRender(false);
                     }
 
                     // Debounced scroll logic for page indicator

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -196,7 +196,6 @@ app.registerExtension({
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
                 let lastPostId = null;            // D 站游标分页：上一批最后一张的 id
                 const seenPostIds = new Set();    // 渲染前 id 去重兜底
-                let fillAnchor = 0;               // G 站续拉锚点：本轮自该 posts 数起凑够 fillTarget
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -1483,6 +1482,7 @@ app.registerExtension({
                         'prompt': { title: t('promptSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>', elements: [filterSection] },
                         'ui': { title: t('uiSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>', elements: [autocompleteSection, tooltipSection, selectionModeSection] },
                         'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
+                        'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
                     };
 
                     const setActiveSection = (key) => {
@@ -2295,13 +2295,21 @@ app.registerExtension({
                             params.set("force_public_detail", "1");
                         }
                         const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        const data = await response.json();
-                        if (data && data.length > 0) {
+                        // 防御性解析：避免非 JSON 响应抛裸 JSON.parse 异常刷屏
+                        const rawText = await response.text();
+                        let data;
+                        try {
+                            data = JSON.parse(rawText);
+                        } catch (parseErr) {
+                            logger.warn(`[fetchOriginalPost] id=${postId} 响应非 JSON(status=${response.status})，跳过`);
+                            return null;
+                        }
+                        if (Array.isArray(data) && data.length > 0) {
                             return data[0];
                         }
                         return null;
                     } catch (error) {
-                        logger.error("Failed to fetch original post data:", error);
+                        logger.warn(`[fetchOriginalPost] id=${postId} 详情抓取失败:`, error?.message || error);
                         return null;
                     }
                 };
@@ -2454,25 +2462,17 @@ app.registerExtension({
                     }).join(' ');
                 };
 
-                const fetchAndRender = async (reset = false, isContinuation = false) => {
+                const fetchAndRender = async (reset = false) => {
                     if (isLoading) {
                         return;
                     }
                     if (endOfResults && !reset) {
                         return;
                     }
-                    // G 站公开列表页每页固定约 42 张，单次请求凑不满较大的 preload_count。
-                    // 续拉机制：拿完一页后若本轮累计不足 fillTarget 且未到底，自动续拉下一页。
-                    // （D 站一次请求即可拿满 limit；G 站游标模式靠 lastPostId 翻批；均不续拉。）
                     const src = uiSettings.source_site || "danbooru";
-                    const dedupMode = uiSettings.gelbooru_dedup_mode || "off";
-                    const needAutoFill = (src === "gelbooru" && dedupMode === "off");
-                    const fillTarget = needAutoFill ? (parseInt(uiSettings.preload_count, 10) || 40) : 0;
-                    // 续拉锚点：新一轮（reset 或用户滚动触发的非续拉调用）以当前 posts 数为基准，
-                    // 续拉到 posts 比基准多出 fillTarget 张为止。续拉调用(isContinuation)沿用旧基准。
-                    if (!isContinuation) {
-                        fillAnchor = reset ? 0 : posts.length;
-                    }
+                    // G 站游标模式（防重复开启）：分页靠 id:<X 推进，pid 必须恒为 0，
+                    // 否则 page 偏移与游标双重推进会跳图。此时翻批不递增 currentPage。
+                    const gelbooruCursorMode = (src === "gelbooru" && (uiSettings.gelbooru_dedup_mode || "off") !== "off");
                     isLoading = true;
                     refreshButton.classList.add("loading");
                     refreshButton.disabled = true;
@@ -2562,9 +2562,25 @@ app.registerExtension({
                         }
 
                         const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        let newPosts = await response.json();
+                        // 防御性解析：后端偶发返回非 JSON（错误页/半截响应）时，
+                        // 不让裸 JSON.parse 异常冒泡导致整屏清空。
+                        let newPosts;
+                        let parseFailed = false;
+                        try {
+                            const rawText = await response.text();
+                            newPosts = JSON.parse(rawText);
+                        } catch (parseErr) {
+                            logger.warn(`[fetchAndRender] 响应解析失败(status=${response.status})，本次跳过:`, parseErr?.message || parseErr);
+                            parseFailed = true;
+                            newPosts = [];
+                        }
 
-                        if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
+                        if (!Array.isArray(newPosts)) newPosts = [];
+
+                        // 解析失败：不标记到底（可能只是偶发），保留已有内容，静默返回等下次触发
+                        if (parseFailed) {
+                            return;
+                        }
 
                         // 评分过滤已交给服务端，本地只做文件类型/黑名单过滤
                         const filteredPosts = newPosts.filter(post => !isPostFiltered(post));
@@ -2587,7 +2603,10 @@ app.registerExtension({
                             return;
                         }
 
-                        currentPage++;
+                        // 游标模式靠 id:<X 推进，pid 须恒为 0，不递增 page；其余模式正常翻页
+                        if (!gelbooruCursorMode) {
+                            currentPage++;
+                        }
                         // 渲染前 id 去重兜底（防游标边界残留重复）
                         const fresh = filteredPosts.filter(p => {
                             if (seenPostIds.has(p.id)) return false;
@@ -2598,6 +2617,14 @@ app.registerExtension({
                         lastPostId = newPosts[newPosts.length - 1].id;
                         posts.push(...fresh);
                         fresh.forEach(renderPost);
+
+                        // 防无限补货：本页返回了数据，但去重后 0 张新增（全是已见过的）。
+                        // 说明分页失效或到底（如 Gelbooru 空标签浏览时 pid 偏移无效，每页返回同样内容）。
+                        // 标记到底，停止后续补货，避免无限翻页空转。
+                        if (fresh.length === 0 && newPosts.length > 0 && !reset) {
+                            endOfResults = true;
+                            logger.warn(`[fetchAndRender] 本页 ${newPosts.length} 张全是重复，判定到底/分页失效，停止加载`);
+                        }
 
                         // Filter-cascade guard: if the blacklist/rating filter dropped every
                         // post on this page, the grid didn't grow — the user's scroll is still
@@ -2610,7 +2637,13 @@ app.registerExtension({
                         }
 
                     } catch (e) {
-                        imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
+                        // 仅首次加载(reset)时用整屏错误提示；滚动/续拉失败时保留已加载内容，
+                        // 不清屏（单次请求失败不该抹掉已经看到的图）。
+                        if (reset) {
+                            imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
+                        } else {
+                            logger.warn('[fetchAndRender] 加载失败，保留已有内容:', e?.message || e);
+                        }
                     } finally {
                         isLoading = false;
                         refreshButton.classList.remove("loading");
@@ -2621,13 +2654,27 @@ app.registerExtension({
                         }
                     }
 
-                    // G 站续拉：本轮（自 fillAnchor 起）累计不足 fillTarget 且未到底，自动拉下一页。
-                    // 条件含 posts.length > fillAnchor（确有进展），避免出错时无限重试。
-                    if (needAutoFill && !endOfResults &&
-                        posts.length > fillAnchor &&
-                        (posts.length - fillAnchor) < fillTarget) {
-                        // 异步触发续拉，让出调用栈（避免深递归）；isLoading 已在 finally 释放
-                        setTimeout(() => fetchAndRender(false, true), 0);
+                    // 加载完一页后，检查缓冲是否仍不足（前方未看的图 < preload_count），
+                    // 不足则继续补——渐进式补货，每次补一页，直到缓冲满或到底。
+                    maybeLoadMore();
+                };
+
+                // 统一的缓冲补货：估算"前方未看过的图片数"，不足 preload_count 就再加载一页。
+                // 两站、两档共用。reset 后首屏、滚动、每次加载完成都会调它。
+                const maybeLoadMore = () => {
+                    if (isLoading || endOfResults) return;
+                    const bufferTarget = parseInt(uiSettings.preload_count, 10) || 40;
+                    // 估算已浏览到的张数：按滚动位置比例 * 总数。grid 高度为 0（首屏未铺开）时按已看 0 处理。
+                    const scrollH = imageGrid.scrollHeight;
+                    let viewedCount = 0;
+                    if (scrollH > 0) {
+                        const viewedRatio = Math.min(1, (imageGrid.scrollTop + imageGrid.clientHeight) / scrollH);
+                        viewedCount = Math.floor(posts.length * viewedRatio);
+                    }
+                    const aheadBuffer = posts.length - viewedCount;  // 前方未看过的张数
+                    if (aheadBuffer < bufferTarget) {
+                        // 异步触发，让出调用栈避免深递归；isLoading 已释放
+                        setTimeout(() => fetchAndRender(false), 0);
                     }
                 };
 
@@ -3635,6 +3682,9 @@ app.registerExtension({
 
                 let scrollTimeout;
                 imageGrid.addEventListener("scroll", () => {
+                    // 滚动消耗了前方缓冲 → 检查是否需要补货（维持前方 preload_count 张未看）。
+                    // 同时保留"接近底部"作为兜底触发（缓冲估算在 0 尺寸图下可能偏差）。
+                    maybeLoadMore();
                     if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
                         fetchAndRender(false);
                     }

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -187,6 +187,9 @@ app.registerExtension({
                 let globalTooltip, globalTooltipTimeout;
                 let currentTooltipId = 0; // 用于追踪当前活动的tooltip请求
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
+                let lastPostId = null; // 游标分页：最后一张图的 id，下次请求传 before_id 防重复
+                let initialLoadComplete = false; // 首次加载（含预加载缓冲）是否完成
+                const seenPostIds = new Set(); // 跨批次去重兜底，防止任何重复图渲染
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -1678,6 +1681,7 @@ app.registerExtension({
 
                                 // 重新过滤当前已加载的帖子
                                 const filteredPosts = posts.filter(post => !isPostFiltered(post));
+                                posts = filteredPosts; // 同步数组，保证预加载缓冲计算准确
                                 imageGrid.innerHTML = "";
                                 filteredPosts.forEach(renderPost);
 
@@ -2393,7 +2397,7 @@ app.registerExtension({
                     }).join(' ');
                 };
 
-                const fetchAndRender = async (reset = false) => {
+                const fetchAndRender = async (reset = false, isPreload = false, preloadAmount = 0) => {
                     if (isLoading) {
                         return;
                     }
@@ -2401,16 +2405,23 @@ app.registerExtension({
                         return;
                     }
                     isLoading = true;
-                    refreshButton.classList.add("loading");
-                    refreshButton.disabled = true;
 
-                    const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
-                    if (!loadingIndicator) {
-                        imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
+                    // 只有非预加载时才显示加载动画（预加载是后台静默补缓冲）
+                    if (!isPreload) {
+                        refreshButton.classList.add("loading");
+                        refreshButton.disabled = true;
+
+                        const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
+                        if (!loadingIndicator) {
+                            imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
+                        }
                     }
 
                     if (reset) {
                         currentPage = filterState.startPage || 1;
+                        lastPostId = null; // 重置游标
+                        initialLoadComplete = false; // 重置首次加载标记
+                        seenPostIds.clear(); // 重置去重集合
                         posts = [];
                         endOfResults = false;
                         imageGrid.innerHTML = "";
@@ -2421,16 +2432,18 @@ app.registerExtension({
                     const isNetworkConnected = await checkNetworkStatus();
 
                     if (!isNetworkConnected) {
-                        // 网络连接失败，隐藏持久错误提示 - 本小姐才不想看到这些烦人的提示呢！
-                        // showError('网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接', true);
-                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");  // 仅在控制台记录
-                        imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
+                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");
+                        if (!isPreload) {
+                            imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
+                        }
                         isLoading = false;
-                        refreshButton.classList.remove("loading");
-                        refreshButton.disabled = false;
-                        const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) {
-                            indicator.remove();
+                        if (!isPreload) {
+                            refreshButton.classList.remove("loading");
+                            refreshButton.disabled = false;
+                            const indicator = imageGrid.querySelector('.danbooru-loading');
+                            if (indicator) {
+                                indicator.remove();
+                            }
                         }
                         return;
                     } else {
@@ -2445,10 +2458,9 @@ app.registerExtension({
                         const tagCount = tags.length;
 
                         // 如果超过2个tag，给用户提示
-                        if (tagCount > 2) {
+                        if (tagCount > 2 && !isPreload) {
                             showTagHint('搜索只考虑前两个tag，第三个及后续tag将被忽略', false);
-                        } else {
-                            // 清除之前的提示
+                        } else if (!isPreload) {
                             clearTagHint();
                         }
 
@@ -2465,64 +2477,138 @@ app.registerExtension({
                         const selectedRatings = getSelectedRatings();
                         const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
                         const ratingForServer = sendAll ? "" : selectedRatings.join(",");
-                        const params = new URLSearchParams({
-                            "source": uiSettings.source_site || "danbooru",
-                            "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
-                            "search[tags]": apiFormattedTags.trim(),
-                            "search[rating]": ratingForServer,
-                            limit: "40",
-                            page: currentPage,
-                        });
 
-                        const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        let newPosts = await response.json();
-
-                        if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
-
-                        // 评分过滤已交给服务端，本地只做文件类型/黑名单过滤
-                        const filteredPosts = newPosts.filter(post => !isPostFiltered(post));
-
-                        const filteredCount = newPosts.length - filteredPosts.length;
-
-                        // API returned nothing → no more pages. Flag it so scroll events stop
-                        // triggering fetches; otherwise the bottom-proximity check would keep
-                        // firing and walk off the end of the result set indefinitely.
-                        if (newPosts.length === 0) {
-                            endOfResults = true;
-                            if (reset) {
-                                imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
-                            }
-                            return;
+                        // 计算目标加载数量：
+                        // - 首次加载：先铺一屏(40) + 预加载缓冲，让用户一打开就有富余
+                        // - 预加载补充：只补指定的少量(滑一个补一张式的小批)
+                        // - 普通触底加载：一屏量
+                        let targetCount;
+                        if (!initialLoadComplete && !isPreload) {
+                            targetCount = 40 + (uiSettings.preload_count || 50);
+                        } else if (isPreload && preloadAmount > 0) {
+                            targetCount = preloadAmount;
+                        } else {
+                            targetCount = 40;
                         }
 
-                        if (filteredPosts.length === 0 && reset) {
+                        // 单次请求上限（未登录 Danbooru 每次最多 20）
+                        const MAX_PER_REQUEST = 20;
+                        let totalLoaded = 0;
+                        let consecutiveEmpty = 0; // 连续空结果计数，避免死循环
+
+                        // 循环请求直到达到目标数量或没有更多数据
+                        while (totalLoaded < targetCount && consecutiveEmpty < 3) {
+                            const remaining = targetCount - totalLoaded;
+                            const requestSize = Math.min(remaining, MAX_PER_REQUEST);
+
+                            const params = new URLSearchParams({
+                                "source": uiSettings.source_site || "danbooru",
+                                "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
+                                "search[tags]": apiFormattedTags.trim(),
+                                "search[rating]": ratingForServer,
+                                limit: requestSize.toString(),
+                                page: currentPage,
+                            });
+
+                            // 用 before_id 游标分页防重复（reset 后的第一次请求不带，从最新开始）
+                            if (lastPostId && !(reset && totalLoaded === 0)) {
+                                params.set("before_id", lastPostId);
+                            }
+
+                            const response = await fetch(`/danbooru_gallery/posts?${params}`);
+                            let newPosts = await response.json();
+
+                            if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
+
+                            // 没有更多数据了
+                            if (newPosts.length === 0) {
+                                endOfResults = true;
+                                if (reset && totalLoaded === 0 && !isPreload) {
+                                    imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
+                                }
+                                break;
+                            }
+
+                            // 评分过滤交给服务端，本地做文件类型/黑名单过滤 + id 去重兜底
+                            const filteredPosts = newPosts.filter(post => {
+                                if (isPostFiltered(post)) return false;
+                                if (seenPostIds.has(post.id)) return false; // 跨批次重复图，丢弃
+                                seenPostIds.add(post.id);
+                                return true;
+                            });
+
+                            // 更新游标（用原始返回的最后一张，保证游标连续推进，
+                            // 即使这批全被过滤，下一批也能接着往后取）
+                            lastPostId = newPosts[newPosts.length - 1].id;
+                            currentPage++;
+
+                            if (filteredPosts.length > 0) {
+                                posts.push(...filteredPosts);
+                                filteredPosts.forEach(renderPost);
+                                totalLoaded += filteredPosts.length;
+                                consecutiveEmpty = 0;
+                            } else {
+                                // 这一批全被过滤了，继续请求下一批
+                                consecutiveEmpty++;
+                            }
+
+                            // API 返回数量少于请求数量，说明已到结果尾部
+                            if (newPosts.length < requestSize) {
+                                endOfResults = true;
+                                break;
+                            }
+                        }
+
+                        // 首次加载没有任何图片
+                        if (totalLoaded === 0 && reset && !isPreload) {
                             imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
                             return;
                         }
 
-                        currentPage++;
-                        posts.push(...filteredPosts);
-                        filteredPosts.forEach(renderPost);
-
-                        // Filter-cascade guard: if the blacklist/rating filter dropped every
-                        // post on this page, the grid didn't grow — the user's scroll is still
-                        // within the 400px bottom threshold, so the scroll listener would
-                        // re-fire immediately. Hold isLoading for ~1.5s (still inside the try
-                        // block, before the finally clears it) to space out these "auto-skip"
-                        // fetches.
-                        if (filteredPosts.length === 0 && !reset) {
-                            await new Promise(r => setTimeout(r, 1500));
+                        // 标记首次加载完成
+                        if (!initialLoadComplete && !isPreload && totalLoaded > 0) {
+                            initialLoadComplete = true;
                         }
 
                     } catch (e) {
-                        imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
+                        if (!isPreload) {
+                            imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
+                        }
                     } finally {
                         isLoading = false;
-                        refreshButton.classList.remove("loading");
-                        refreshButton.disabled = false;
-                        const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) {
-                            indicator.remove();
+                        if (!isPreload) {
+                            refreshButton.classList.remove("loading");
+                            refreshButton.disabled = false;
+                            const indicator = imageGrid.querySelector('.danbooru-loading');
+                            if (indicator) {
+                                indicator.remove();
+                            }
+                        }
+
+                        // 加载完成后检查是否还需要继续加载
+                        if (!endOfResults) {
+                            setTimeout(() => {
+                                if (isLoading) return;
+
+                                // 1. 接近底部 → 正常加载一屏
+                                if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
+                                    fetchAndRender(false);
+                                    return;
+                                }
+
+                                // 2. 缓冲不足 → 预加载补充（滑一个补一张的"补"在这里发生）
+                                if (initialLoadComplete) {
+                                    const targetBufferSize = uiSettings.preload_count || 50;
+                                    const scrollableHeight = imageGrid.scrollHeight - imageGrid.clientHeight;
+                                    const scrollRatio = scrollableHeight > 0 ? imageGrid.scrollTop / scrollableHeight : 0;
+                                    const viewedCount = Math.floor(scrollRatio * posts.length);
+                                    const remainingBuffer = posts.length - viewedCount;
+
+                                    if (remainingBuffer < targetBufferSize) {
+                                        fetchAndRender(false, true, 20);
+                                    }
+                                }
+                            }, 100);
                         }
                     }
                 };
@@ -3519,8 +3605,23 @@ app.registerExtension({
 
                 let scrollTimeout;
                 imageGrid.addEventListener("scroll", () => {
-                    if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
-                        fetchAndRender(false);
+                    if (!isLoading && !endOfResults) {
+                        // 触底 → 正常加载一屏
+                        if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
+                            fetchAndRender(false);
+                        } else if (initialLoadComplete) {
+                            // 缓冲不足 → 后台预加载补充（滑一个补一张：前方始终保留 preload_count 张未看过的图）
+                            const targetBufferSize = uiSettings.preload_count || 50;
+                            const scrollableHeight = imageGrid.scrollHeight - imageGrid.clientHeight;
+                            if (scrollableHeight > 0) {
+                                const scrollRatio = imageGrid.scrollTop / scrollableHeight;
+                                const viewedCount = Math.floor(scrollRatio * posts.length);
+                                const remainingBuffer = posts.length - viewedCount;
+                                if (remainingBuffer < targetBufferSize) {
+                                    fetchAndRender(false, true, 20);
+                                }
+                            }
+                        }
                     }
 
                     // Debounced scroll logic for page indicator

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -5,7 +5,7 @@ import { AutocompleteUI } from "../global/autocomplete_ui.js";
 import { toastManagerProxy } from "../global/toast_manager.js";
 import { globalMultiLanguageManager } from "../global/multi_language.js";
 
-import { createLogger } from '../global/logger_client.js';
+import { createLogger, loggerClient } from '../global/logger_client.js';
 
 // 创建logger实例
 const logger = createLogger('danbooru_gallery');
@@ -64,7 +64,7 @@ app.registerExtension({
                 // 存储每张图片的原始标签数据，用于重置和编辑状态判断
                 const originalPostCache = {};
 
-                // 创建隐藏的 selection_data widget
+                // 创建隐藏的 selection_data widget（仍保留用于兼容/回退）
                 const selectionWidget = this.addWidget("text", "selection_data", JSON.stringify({}), () => { }, {
                     serialize: true // 确保序列化
                 });
@@ -152,11 +152,9 @@ app.registerExtension({
                     tagHintDisplay.style.display = "none";
                 };
 
-                // 检查网络连接状态
+                // 检查网络连接状态（30s TTL：上次成功且 30s 内则跳过完整网络往返）
+                const NETWORK_CHECK_TTL = 30000;
                 const checkNetworkStatus = async () => {
-                    // 节流：上次检查成功且在 30 秒内，直接复用，避免每次滚动加载都做一次完整网络往返
-                    // （G 站的检查是抓公开 HTML 页、8 秒超时，频繁触发会卡顿并误报"网络连接失败"）。
-                    const NETWORK_CHECK_TTL = 30000;
                     if (networkStatus.connected && networkStatus.lastChecked &&
                         (Date.now() - networkStatus.lastChecked) < NETWORK_CHECK_TTL) {
                         return true;
@@ -194,8 +192,10 @@ app.registerExtension({
                 let globalTooltip, globalTooltipTimeout;
                 let currentTooltipId = 0; // 用于追踪当前活动的tooltip请求
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
-                let lastPostId = null;            // D 站游标分页：上一批最后一张的 id
-                const seenPostIds = new Set();    // 渲染前 id 去重兜底
+                let lastPostId = null;
+                let scrollAnchorPostId = null;
+                const seenPostIds = new Set();
+                let selectionQueueId = 0; // FIFO 队列唯一 ID 计数器
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -727,7 +727,7 @@ app.registerExtension({
                         uiSettings.selected_categories = newSelectedCategories;
                         saveToLocalStorage('selectedCategories', newSelectedCategories);
                         await saveUiSettings(uiSettings);
-                        await updateSelectionData();
+                        updateSelectionData();
                     });
                     return $el("div.danbooru-category-item", [
                         checkbox,
@@ -760,7 +760,7 @@ app.registerExtension({
                         uiSettings.formatting = newFormattingOptions;
                         saveToLocalStorage('formatting', newFormattingOptions);
                         await saveUiSettings(uiSettings);
-                        await updateSelectionData();
+                        updateSelectionData();
                     });
                     return $el("div.danbooru-category-item", [
                         checkbox,
@@ -1436,43 +1436,45 @@ app.registerExtension({
                     selectionModeSection.appendChild(selectionModeDesc);
                     selectionModeSection.appendChild(multiSelectDiv);
 
-                    // 预加载设置（每次加载的图片数量，越大一次拉取越多但首屏越慢）
+                    // 预加载设置
                     const preloadSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
-                    const preloadTitle = $el("h3", { textContent: "预加载设置", style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
-                    const preloadDesc = $el("p", { textContent: "每次加载的图片数量。数值越大一次拉取越多，但首屏等待时间也越长（建议 40-100）", style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
-                    const preloadCountLabel = $el("label", { htmlFor: "preloadCountInput", textContent: "每次加载数量", style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
+                    const preloadTitle = $el("h3", { textContent: "预加载 / 去重", style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
+                    preloadSection.appendChild(preloadTitle);
+
+                    // 每次增加张数
+                    const preloadCountLabel = $el("label", { htmlFor: "preloadCountInput", textContent: "每次增加缓冲张数：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
                     const preloadCountInput = $el("input", {
-                        type: "number",
-                        id: "preloadCountInput",
-                        title: "设置每次加载数量（20-200）",
-                        value: (initialState.preloadCount ?? uiSettings.preload_count) || 40,
-                        min: "20",
-                        max: "200",
+                        type: "number", id: "preloadCountInput", min: "20", max: "200",
+                        value: (initialState.preloadCount !== undefined ? initialState.preloadCount : uiSettings.preload_count) || 40,
                         style: { width: "60px", padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
                     });
-                    const preloadCountDiv = $el("div", { style: { display: "flex", alignItems: "center" } }, [preloadCountLabel, preloadCountInput]);
-                    preloadSection.appendChild(preloadTitle);
-                    preloadSection.appendChild(preloadDesc);
-                    preloadSection.appendChild(preloadCountDiv);
+                    const preloadCountDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [preloadCountLabel, preloadCountInput]);
 
-                    // G 站防重复设置（按 id 游标分页，解决翻页时新上传挤入导致的重复图）
-                    // 三段式：off / on（未配密钥时仅1个tag留名额给游标）/ on_auth（已配密钥，多tag可用）
-                    const gelbooruDedupLabel = $el("label", { htmlFor: "gelbooruDedupSelect", textContent: "G 站防重复", style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
+                    // G站防重复模式
+                    const gelbooruDedupLabel = $el("label", { htmlFor: "gelbooruDedupSelect", textContent: "G站防重复：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
                     const gelbooruDedupSelect = $el("select", {
                         id: "gelbooruDedupSelect",
-                        title: "G 站游标防重复档位（按id推进分页，避免新上传图导致翻页重复）",
                         style: { padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
                     }, [
                         $el("option", { value: "off", textContent: "关闭（可使用2个tag）" }),
                         $el("option", { value: "on", textContent: "开启（限1个tag）" }),
                         $el("option", { value: "on_auth", textContent: "开启·已配密钥（多tag可用）" }),
                     ]);
-                    const dedupInitial = (initialState.gelbooruDedupMode ?? uiSettings.gelbooru_dedup_mode) || "off";
-                    if (["off", "on", "on_auth"].includes(dedupInitial)) gelbooruDedupSelect.value = dedupInitial;
-                    const gelbooruDedupDiv = $el("div", { style: { display: "flex", alignItems: "center", marginTop: "12px" } }, [gelbooruDedupLabel, gelbooruDedupSelect]);
-                    const gelbooruDedupDesc = $el("p", { textContent: "关闭时 G 站保持原样；开启时按 id 游标推进翻页。未配密钥的开启档会限 1 个 tag 留给游标；已配密钥多 tag 可用", style: { margin: "8px 0 0 0", color: "#888", fontSize: "0.85em" } });
+                    gelbooruDedupSelect.value = initialState.gelbooruDedupMode !== undefined ? initialState.gelbooruDedupMode : (uiSettings.gelbooru_dedup_mode || "off");
+                    const gelbooruDedupDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [gelbooruDedupLabel, gelbooruDedupSelect]);
+
+                    // 全局日志
+                    const globalLogLabel = $el("label", { htmlFor: "globalLogCheck", textContent: "启用全局日志：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
+                    const globalLogCheck = $el("input", {
+                        type: "checkbox", id: "globalLogCheck",
+                        checked: initialState.globalLogging !== undefined ? initialState.globalLogging : (uiSettings.global_logging || false),
+                        style: { width: "16px", height: "16px" }
+                    });
+                    const globalLogDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "8px" } }, [globalLogCheck, globalLogLabel]);
+
+                    preloadSection.appendChild(preloadCountDiv);
                     preloadSection.appendChild(gelbooruDedupDiv);
-                    preloadSection.appendChild(gelbooruDedupDesc);
+                    preloadSection.appendChild(globalLogDiv);
 
                     // 创建侧边栏按钮和内容区域的映射
                     const sections = {
@@ -1481,7 +1483,6 @@ app.registerExtension({
                         'content': { title: t('contentSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18l-1.5 14H4.5L3 6z"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>', elements: [blacklistSection] },
                         'prompt': { title: t('promptSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>', elements: [filterSection] },
                         'ui': { title: t('uiSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>', elements: [autocompleteSection, tooltipSection, selectionModeSection] },
-                        'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
                         'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
                     };
 
@@ -1693,10 +1694,6 @@ app.registerExtension({
                             const newAutocompleteMaxResults = parseInt(autocompleteMaxResultsInput.value, 10);
                             const newSelectedCategories = Array.from(categoryDropdown.querySelectorAll("input:checked")).map(i => i.name);
                             const newMultiSelectEnabled = multiSelectCheckbox.checked;
-                            let newPreloadCount = parseInt(preloadCountInput.value, 10);
-                            if (isNaN(newPreloadCount)) newPreloadCount = 40;
-                            newPreloadCount = Math.min(Math.max(newPreloadCount, 20), 200); // 夹到 20-200
-                            const newGelbooruDedupMode = ["off", "on", "on_auth"].includes(gelbooruDedupSelect.value) ? gelbooruDedupSelect.value : "off";
 
                             // 保存所有设置
                             const [blacklistSuccess, filterSuccess, uiSettingsSuccess] = await Promise.all([
@@ -1708,8 +1705,6 @@ app.registerExtension({
                                     autocomplete_max_results: newAutocompleteMaxResults,
                                     selected_categories: newSelectedCategories,
                                     multi_select_enabled: newMultiSelectEnabled,
-                                    preload_count: newPreloadCount,
-                                    gelbooru_dedup_mode: newGelbooruDedupMode,
                                     source_site: uiSettings.source_site || "danbooru",
                                     gelbooru_display_all_site_content: uiSettings.gelbooru_display_all_site_content || false
                                 })
@@ -1725,10 +1720,24 @@ app.registerExtension({
                                 uiSettings.autocomplete_max_results = newAutocompleteMaxResults;
                                 uiSettings.selected_categories = newSelectedCategories;
                                 uiSettings.multi_select_enabled = newMultiSelectEnabled;
-                                uiSettings.preload_count = newPreloadCount;
-                                uiSettings.gelbooru_dedup_mode = newGelbooruDedupMode;
                                 uiSettings.source_site = sourceSelect.value || uiSettings.source_site || "danbooru";
-                                await updateSelectionData();
+
+                                // 保存 preload/dedup/global_logging
+                                let newPreloadCount = parseInt(preloadCountInput.value, 10);
+                                if (isNaN(newPreloadCount)) newPreloadCount = 40;
+                                newPreloadCount = Math.min(Math.max(newPreloadCount, 20), 200);
+                                uiSettings.preload_count = newPreloadCount;
+                                saveToLocalStorage('preload_count', newPreloadCount);
+
+                                const newGelbooruDedupMode = ["off", "on", "on_auth"].includes(gelbooruDedupSelect.value) ? gelbooruDedupSelect.value : "off";
+                                uiSettings.gelbooru_dedup_mode = newGelbooruDedupMode;
+                                saveToLocalStorage('gelbooru_dedup_mode', newGelbooruDedupMode);
+
+                                const newGlobalLogging = globalLogCheck.checked;
+                                uiSettings.global_logging = newGlobalLogging;
+                                saveToLocalStorage('global_logging', newGlobalLogging);
+                                loggerClient.setConsoleOutput(newGlobalLogging);
+                                updateSelectionData();
 
                                 dialog.remove();
                                 showToast(t('saveSuccess'), 'success');
@@ -2111,8 +2120,6 @@ app.registerExtension({
                     multi_select_enabled: false,
                     source_site: "danbooru",
                     gelbooru_display_all_site_content: false,
-                    preload_count: 40,
-                    gelbooru_dedup_mode: "off",
                     formatting: {
                         escapeBrackets: true,
                         replaceUnderscores: true,
@@ -2132,8 +2139,6 @@ app.registerExtension({
                                 multi_select_enabled: data.settings.multi_select_enabled || false,
                                 source_site: data.settings.source_site || "danbooru",
                                 gelbooru_display_all_site_content: data.settings.gelbooru_display_all_site_content || false,
-                                preload_count: data.settings.preload_count || 40,
-                                gelbooru_dedup_mode: data.settings.gelbooru_dedup_mode || "off",
                                 formatting: data.settings.formatting || { escapeBrackets: true, replaceUnderscores: true }
                             };
                         }
@@ -2295,21 +2300,13 @@ app.registerExtension({
                             params.set("force_public_detail", "1");
                         }
                         const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        // 防御性解析：避免非 JSON 响应抛裸 JSON.parse 异常刷屏
-                        const rawText = await response.text();
-                        let data;
-                        try {
-                            data = JSON.parse(rawText);
-                        } catch (parseErr) {
-                            logger.warn(`[fetchOriginalPost] id=${postId} 响应非 JSON(status=${response.status})，跳过`);
-                            return null;
-                        }
-                        if (Array.isArray(data) && data.length > 0) {
+                        const data = await response.json();
+                        if (data && data.length > 0) {
                             return data[0];
                         }
                         return null;
                     } catch (error) {
-                        logger.warn(`[fetchOriginalPost] id=${postId} 详情抓取失败:`, error?.message || error);
+                        logger.error("Failed to fetch original post data:", error);
                         return null;
                     }
                 };
@@ -2365,9 +2362,10 @@ app.registerExtension({
                     return allowPreviewFallback ? (postData.preview_file_url || "") : "";
                 };
 
-                const getPostWithOriginalMedia = async (postData) => {
+                const getPostWithOriginalMedia = (postData) => {
                     const basePost = temporaryTagEdits[postData.id] || postData;
-                    return await hydrateGelbooruPost(basePost);
+                    // 同步：帖子在加载时已完成 hydrate，选图时无需再 await 网络请求
+                    return basePost;
                 };
 
                 const proxiedMediaUrl = (url) => `/danbooru_gallery/image_proxy?url=${encodeURIComponent(url)}`;
@@ -2462,17 +2460,11 @@ app.registerExtension({
                     }).join(' ');
                 };
 
+                let currentTags = ""; // 追踪当前搜索条件，用于决定是否重置游标（搜索条件变化时清空 lastPostId）
+
                 const fetchAndRender = async (reset = false) => {
-                    if (isLoading) {
-                        return;
-                    }
-                    if (endOfResults && !reset) {
-                        return;
-                    }
-                    const src = uiSettings.source_site || "danbooru";
-                    // G 站游标模式（防重复开启）：分页靠 id:<X 推进，pid 必须恒为 0，
-                    // 否则 page 偏移与游标双重推进会跳图。此时翻批不递增 currentPage。
-                    const gelbooruCursorMode = (src === "gelbooru" && (uiSettings.gelbooru_dedup_mode || "off") !== "off");
+                    if (isLoading) return;
+                    if (endOfResults && !reset) return;
                     isLoading = true;
                     refreshButton.classList.add("loading");
                     refreshButton.disabled = true;
@@ -2484,52 +2476,50 @@ app.registerExtension({
 
                     if (reset) {
                         currentPage = filterState.startPage || 1;
-                        lastPostId = null;        // 重置游标
-                        seenPostIds.clear();      // 重置去重集合
+                        const newTags = searchInput.value.trim();
+                        if (newTags !== currentTags) {
+                            lastPostId = null;
+                            scrollAnchorPostId = null;
+                            seenPostIds.clear();
+                        } else if (scrollAnchorPostId) {
+                            // 搜索条件没变 + 有锚点 → 用锚点做游标，往下接
+                            lastPostId = scrollAnchorPostId;
+                        }
+                        currentTags = newTags;
+
                         posts = [];
                         endOfResults = false;
                         imageGrid.innerHTML = "";
                         imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
                     }
 
-                    // 检查网络连接状态
+                    // 网络检查
                     const isNetworkConnected = await checkNetworkStatus();
-
                     if (!isNetworkConnected) {
-                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到服务器");  // 仅在控制台记录
-                        // 仅在首次加载(reset)时用整屏错误提示；滚动加载(reset=false)失败时
-                        // 不清空已加载内容，静默返回，下次滚动再试，避免"频繁报错+整屏重载"。
-                        if (reset) {
-                            imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
-                        }
+                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");
+                        imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
                         isLoading = false;
                         refreshButton.classList.remove("loading");
                         refreshButton.disabled = false;
                         const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) {
-                            indicator.remove();
-                        }
+                        if (indicator) indicator.remove();
                         return;
                     } else {
-                        // 网络连接恢复，清除之前的错误提示
                         clearError();
                     }
 
+                    let parseFailed = false;
                     try {
-                        // 检测tag数量
                         const searchValue = searchInput.value.trim();
                         const tags = searchValue.split(',').filter(tag => tag.trim() !== '');
                         const tagCount = tags.length;
 
-                        // 如果超过2个tag，给用户提示
                         if (tagCount > 2) {
                             showTagHint('搜索只考虑前两个tag，第三个及后续tag将被忽略', false);
                         } else {
-                            // 清除之前的提示
                             clearTagHint();
                         }
 
-                        // 将搜索框中的标签转换为API格式
                         let apiFormattedTags = convertTagsToApiFormat(searchValue);
 
                         // 添加日期筛选
@@ -2539,58 +2529,75 @@ app.registerExtension({
                             apiFormattedTags += ` date:${start}..${end}`;
                         }
 
+                        const src = uiSettings.source_site || "danbooru";
+                        const dedup = uiSettings.gelbooru_dedup_mode || "off";
                         const selectedRatings = getSelectedRatings();
                         const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
                         const ratingForServer = sendAll ? "" : selectedRatings.join(",");
                         const params = new URLSearchParams({
-                            "source": uiSettings.source_site || "danbooru",
+                            "source": src,
                             "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
+                            "gelbooru_dedup_mode": dedup,
                             "search[tags]": apiFormattedTags.trim(),
                             "search[rating]": ratingForServer,
-                            limit: String(uiSettings.preload_count || 40),
+                            limit: "40",
                             page: currentPage,
                         });
 
-                        // 游标防重复：reset 后第一次不带（从最新开始）。
-                        // D 站默认排序始终用；G 站仅当 dedup 开关非 off 时用（后端会再校验密钥/排序）。
-                        if (lastPostId && !reset) {
-                            const src = uiSettings.source_site || "danbooru";
-                            const dedup = uiSettings.gelbooru_dedup_mode || "off";
-                            if (src === "danbooru" || (src === "gelbooru" && dedup !== "off")) {
-                                params.set("before_id", lastPostId);
-                            }
+                        // 游标分页：D站始终用游标；G站仅当 dedup 非 off 时
+                        const useCursor = src === "danbooru" || (src === "gelbooru" && dedup !== "off");
+                        if (useCursor && lastPostId) {
+                            params.set("before_id", lastPostId);
                         }
 
+                        // G站游标模式下 pid 恒为 0，不允许当前页推进
+                        const gelbooruCursorMode = (src === "gelbooru" && dedup !== "off");
+
                         const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        // 防御性解析：后端偶发返回非 JSON（错误页/半截响应）时，
-                        // 不让裸 JSON.parse 异常冒泡导致整屏清空。
+                        const rawText = await response.text();
+
+                        // 防御性 JSON 解析：后端偶发返回非 JSON（错误页/半截响应），此时不销毁已有内容
                         let newPosts;
-                        let parseFailed = false;
                         try {
-                            const rawText = await response.text();
                             newPosts = JSON.parse(rawText);
                         } catch (parseErr) {
                             logger.warn(`[fetchAndRender] 响应解析失败(status=${response.status})，本次跳过:`, parseErr?.message || parseErr);
                             parseFailed = true;
                             newPosts = [];
                         }
-
                         if (!Array.isArray(newPosts)) newPosts = [];
 
-                        // 解析失败：不标记到底（可能只是偶发），保留已有内容，静默返回等下次触发
                         if (parseFailed) {
+                            if (reset) {
+                                imageGrid.innerHTML = `<p class="danbooru-status error">响应解析失败(status=${response.status})</p>`;
+                                return;
+                            }
+                            renderPost({ error: `响应解析失败(status=${response.status})` });
                             return;
                         }
 
-                        // 评分过滤已交给服务端，本地只做文件类型/黑名单过滤
-                        const filteredPosts = newPosts.filter(post => !isPostFiltered(post));
+                        // 先分离 error 占位格与正常 post
+                        const errorPosts = newPosts.filter(p => p && p.error);
+                        const normalRaw = newPosts.filter(p => !p || !p.error);
 
-                        const filteredCount = newPosts.length - filteredPosts.length;
+                        // 去重：seenPostIds 中已存在的跳过（防止 G站 pid 失效产生的重复被加入 posts 数组）
+                        const freshRaw = normalRaw.filter(p => !seenPostIds.has(String(p.id)));
+                        freshRaw.forEach(p => seenPostIds.add(String(p.id)));
 
-                        // API returned nothing → no more pages. Flag it so scroll events stop
-                        // triggering fetches; otherwise the bottom-proximity check would keep
-                        // firing and walk off the end of the result set indefinitely.
-                        if (newPosts.length === 0) {
+                        // 对正常格做过滤
+                        const filteredPosts = freshRaw.filter(post => !isPostFiltered(post));
+
+                        if (errorPosts.length > 0) {
+                            if (reset && filteredPosts.length === 0 && freshRaw.length === 0) {
+                                // 首次加载全是 error 格：整屏错误
+                                imageGrid.innerHTML = `<p class="danbooru-status error">${errorPosts[0].error}</p>`;
+                                return;
+                            }
+                            // 续加载/混合正常格：追加 error 格
+                            errorPosts.forEach(renderPost);
+                        }
+
+                        if (newPosts.length === 0 && errorPosts.length === 0) {
                             endOfResults = true;
                             if (reset) {
                                 imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
@@ -2598,97 +2605,134 @@ app.registerExtension({
                             return;
                         }
 
-                        if (filteredPosts.length === 0 && reset) {
+                        if (filteredPosts.length === 0 && freshRaw.length === 0 && reset && errorPosts.length === 0) {
                             imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
                             return;
                         }
 
-                        // 游标模式靠 id:<X 推进，pid 须恒为 0，不递增 page；其余模式正常翻页
+                        // 确保即使在 cursor 模式下过滤掉了所有正常图片也能推进游标
+                        if (normalRaw.length > 0) {
+                            lastPostId = normalRaw[normalRaw.length - 1].id;
+                        }
+
+                        // G站游标模式下 pid 恒定不推进；D站正常推进 page
                         if (!gelbooruCursorMode) {
                             currentPage++;
                         }
-                        // 渲染前 id 去重兜底（防游标边界残留重复）
-                        const fresh = filteredPosts.filter(p => {
-                            if (seenPostIds.has(p.id)) return false;
-                            seenPostIds.add(p.id);
-                            return true;
-                        });
-                        // 游标用原始返回最后一张推进（即使本批被过滤光也连续）
-                        lastPostId = newPosts[newPosts.length - 1].id;
-                        posts.push(...fresh);
-                        fresh.forEach(renderPost);
 
-                        // 防无限补货：本页返回了数据，但去重后 0 张新增（全是已见过的）。
-                        // 说明分页失效或到底（如 Gelbooru 空标签浏览时 pid 偏移无效，每页返回同样内容）。
-                        // 标记到底，停止后续补货，避免无限翻页空转。
-                        if (fresh.length === 0 && newPosts.length > 0 && !reset) {
+                        posts.push(...filteredPosts);
+                        filteredPosts.forEach(renderPost);
+
+                        // 去重陷阱检测：本页有返回值但全部是已见过的 → 判定到底
+                        if (freshRaw.length === 0 && normalRaw.length > 0 && !reset) {
                             endOfResults = true;
                             logger.warn(`[fetchAndRender] 本页 ${newPosts.length} 张全是重复，判定到底/分页失效，停止加载`);
+                            return;
                         }
 
-                        // Filter-cascade guard: if the blacklist/rating filter dropped every
-                        // post on this page, the grid didn't grow — the user's scroll is still
-                        // within the 400px bottom threshold, so the scroll listener would
-                        // re-fire immediately. Hold isLoading for ~1.5s (still inside the try
-                        // block, before the finally clears it) to space out these "auto-skip"
-                        // fetches.
+                        // Filter-cascade guard
                         if (filteredPosts.length === 0 && !reset) {
                             await new Promise(r => setTimeout(r, 1500));
                         }
 
                     } catch (e) {
-                        // 仅首次加载(reset)时用整屏错误提示；滚动/续拉失败时保留已加载内容，
-                        // 不清屏（单次请求失败不该抹掉已经看到的图）。
+                        // 首次加载→整屏错误；滚动续拉→保留内容+加错误格
                         if (reset) {
                             imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
                         } else {
                             logger.warn('[fetchAndRender] 加载失败，保留已有内容:', e?.message || e);
+                            renderPost({ error: `请求失败: ${e.message}` });
                         }
                     } finally {
                         isLoading = false;
                         refreshButton.classList.remove("loading");
                         refreshButton.disabled = false;
                         const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) {
-                            indicator.remove();
+                        if (indicator) indicator.remove();
+                        // 刷新后还原滚动位置
+                        if (reset && scrollAnchorPostId) {
+                            // 等 maybeLoadMore 链走完（多个 setTimeout(…,0)）后尝试还原
+                            const attemptScroll = (retries = 8) => {
+                                const target = imageGrid.querySelector(`[data-post-id="${scrollAnchorPostId}"]`);
+                                if (target) {
+                                    target.scrollIntoView({ block: "start", behavior: "instant" });
+                                    return;
+                                }
+                                if (retries > 0) {
+                                    setTimeout(() => attemptScroll(retries - 1), 150);
+                                }
+                            };
+                            setTimeout(() => attemptScroll(), 300);
+                        }
+                        // 每次加载完成后检查是否需要补充更多（maybeLoadMore）
+                        if (!endOfResults && !parseFailed) {
+                            maybeLoadMore();
                         }
                     }
-
-                    // 加载完一页后，检查缓冲是否仍不足（前方未看的图 < preload_count），
-                    // 不足则继续补——渐进式补货，每次补一页，直到缓冲满或到底。
-                    maybeLoadMore();
                 };
 
-                // 统一的缓冲补货：估算"前方未看过的图片数"，不足 preload_count 就再加载一页。
-                // 两站、两档共用。reset 后首屏、滚动、每次加载完成都会调它。
                 const maybeLoadMore = () => {
                     if (isLoading || endOfResults) return;
                     const bufferTarget = parseInt(uiSettings.preload_count, 10) || 40;
-                    // 估算已浏览到的张数：按滚动位置比例 * 总数。grid 高度为 0（首屏未铺开）时按已看 0 处理。
                     const scrollH = imageGrid.scrollHeight;
                     let viewedCount = 0;
                     if (scrollH > 0) {
                         const viewedRatio = Math.min(1, (imageGrid.scrollTop + imageGrid.clientHeight) / scrollH);
                         viewedCount = Math.floor(posts.length * viewedRatio);
                     }
-                    const aheadBuffer = posts.length - viewedCount;  // 前方未看过的张数
+                    const aheadBuffer = posts.length - viewedCount;
                     if (aheadBuffer < bufferTarget) {
-                        // 异步触发，让出调用栈避免深递归；isLoading 已释放
+                        // 异步触发避免递归撑爆调用栈
                         setTimeout(() => fetchAndRender(false), 0);
                     }
                 };
 
-                const resizeGrid = () => {
-                    const rowGap = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-row-gap'));
-                    const rowHeight = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-auto-rows'));
-
-                    Array.from(imageGrid.children).forEach((wrapper) => {
-                        const img = wrapper.querySelector('img');
-                        if (img && img.clientHeight > 0) {
-                            const spans = Math.ceil((img.clientHeight + rowGap) / (rowHeight + rowGap));
-                            wrapper.style.gridRowEnd = `span ${spans}`;
+                // Queue 按钮拦截：每次点击时将当前选中快照推入后端 FIFO 队列
+                const _hookQueueButton = () => {
+                    // 兼容不同 ComfyUI 前端版本：data-testid（新版）/ #comfy-queue-btn（旧版）
+                    const queueBtn = document.querySelector('[data-testid="queue-button"]') || document.getElementById("comfy-queue-btn");
+                    if (!queueBtn) { setTimeout(_hookQueueButton, 500); return; }
+                    queueBtn.addEventListener("click", async () => {
+                        const selectedWrappers = imageGrid.querySelectorAll('.danbooru-image-wrapper.selected');
+                        if (selectedWrappers.length === 0) return;
+                        const selections = [];
+                        for (const wrapper of selectedWrappers) {
+                            const postId = wrapper.dataset.postId;
+                            const postData = posts.find(p => p.id == postId) || temporaryTagEdits[postId];
+                            if (postData) {
+                                const prompt = buildPromptForPost(postData);
+                                const mediaPost = getPostWithOriginalMedia(postData);
+                                const imageUrl = getBestImageUrl(mediaPost, false);
+                                selections.push({ post_id: postId, prompt, image_url: imageUrl });
+                            }
                         }
-                    });
+                        if (selections.length === 0) return;
+                        selectionQueueId++;
+                        await fetch("/danbooru_gallery/selection_queue_push", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ item: { selections, _queue_id: selectionQueueId } })
+                        });
+                    }, true); // useCapture = true：在原始 onclick 之前触发
+                };
+                setTimeout(_hookQueueButton, 1000);
+
+                const resizeGrid = () => {
+                    try {
+                        const cs = window.getComputedStyle(imageGrid);
+                        const rowGap = parseInt(cs.getPropertyValue('grid-row-gap')) || parseInt(cs.rowGap) || 5;
+                        const rowHeight = parseInt(cs.getPropertyValue('grid-auto-rows')) || 1;
+
+                        Array.from(imageGrid.children).forEach((wrapper) => {
+                            const img = wrapper.querySelector('img');
+                            if (img && img.clientHeight > 0) {
+                                const spans = Math.ceil((img.clientHeight + rowGap) / (rowHeight + rowGap));
+                                wrapper.style.gridRowEnd = `span ${spans}`;
+                            }
+                        });
+                    } catch (e) {
+                        // 计算失败不影响主体流程
+                    }
                 }
 
                 // Pre-reserve grid space from post dimensions so rate-limited async loads
@@ -2696,10 +2740,16 @@ app.registerExtension({
                 let cachedColumnWidth = 0;
                 const getColumnWidth = () => {
                     if (cachedColumnWidth > 0) return cachedColumnWidth;
-                    const cols = window.getComputedStyle(imageGrid).gridTemplateColumns.split(' ');
-                    const px = parseFloat(cols[0]);
-                    if (px > 0) cachedColumnWidth = px;
-                    return cachedColumnWidth;
+                    try {
+                        const cs = window.getComputedStyle(imageGrid);
+                        const template = cs.gridTemplateColumns;
+                        if (template && template !== 'none') {
+                            const cols = template.split(' ');
+                            const px = parseFloat(cols[0]);
+                            if (px > 0) cachedColumnWidth = px;
+                        }
+                    } catch (e) {}
+                    return cachedColumnWidth || 150; // grid 未 layout 时保底 150px
                 };
                 const computeSpanFromDims = (imgW, imgH) => {
                     const colW = getColumnWidth();
@@ -2844,7 +2894,7 @@ app.registerExtension({
                                 newPostElement.classList.add('selected');
 
                             }
-                            await updateSelectionData();
+                            updateSelectionData();
                         } else { // 如果打开面板时未选中，则清除所有选中的图像和提示词
 
                             imageGrid.querySelectorAll('.danbooru-image-wrapper.selected').forEach(w => {
@@ -2907,7 +2957,7 @@ app.registerExtension({
                             const selectedCategoriesToCopy = Array.from(selectedCategoriesCheckboxes).map(cb => cb.name);
 
                             const postToCopy = temporaryTagEdits[post.id] || post;
-                            const formattedTags = await buildPromptForPost(postToCopy, selectedCategoriesToCopy);
+                            const formattedTags = buildPromptForPost(postToCopy, selectedCategoriesToCopy);
 
                             if (formattedTags) {
                                 try {
@@ -2953,7 +3003,7 @@ app.registerExtension({
 
                                 // 6. Update selectionWidget if the post is currently selected
                                 if (isPostCurrentlySelected) {
-                                    await updateSelectionData();
+                                    updateSelectionData();
                                 }
                                 showToast(t('resetTags') + '成功', 'success', resetTagsButton);
                             } else {
@@ -3235,9 +3285,9 @@ app.registerExtension({
                 };
 
                 // 辅助函数：为单个帖子构建提示词
-                const buildPromptForPost = async (postData, selectedCategoriesOverride = null) => {
-                    let promptPost = temporaryTagEdits[postData.id] || postData;
-                    promptPost = await hydrateGelbooruPost(promptPost);
+                const buildPromptForPost = (postData, selectedCategoriesOverride = null) => {
+                    // 同步：G站在加载时已完成 hydrate，选图时 tag_xxx 已就绪，无需再 await 网络请求
+                    const promptPost = temporaryTagEdits[postData.id] || postData;
 
                     const promptCategories = Array.isArray(selectedCategoriesOverride)
                         ? selectedCategoriesOverride.filter(name => TAG_CATEGORY_ORDER.includes(name))
@@ -3253,7 +3303,7 @@ app.registerExtension({
                 };
 
                 // 辅助函数：收集所有选中图片的数据并更新 widget
-                const updateSelectionData = async () => {
+                const updateSelectionData = () => {
                     const selectedWrappers = imageGrid.querySelectorAll('.danbooru-image-wrapper.selected');
                     const selections = [];
 
@@ -3261,9 +3311,9 @@ app.registerExtension({
                         const postId = wrapper.dataset.postId;
                         const postData = posts.find(p => p.id == postId) || temporaryTagEdits[postId];
                         if (postData) {
-                            const prompt = await buildPromptForPost(postData);
+                            const prompt = buildPromptForPost(postData);
                             const updatedPostData = posts.find(p => p.id == postId) || temporaryTagEdits[postId] || postData;
-                            const mediaPost = await getPostWithOriginalMedia(updatedPostData);
+                            const mediaPost = getPostWithOriginalMedia(updatedPostData);
                             const imageUrl = getBestImageUrl(mediaPost, false);
                             selections.push({
                                 post_id: postId,
@@ -3275,7 +3325,7 @@ app.registerExtension({
 
                     const selectionData = { selections: selections };
 
-                    // 更新 widget
+                    // 更新 widget（仍保留用于兼容回退）
                     if (nodeInstance && nodeInstance.widgets) {
                         const selectionWidget = nodeInstance.widgets.find(w => w.name === "selection_data");
                         if (selectionWidget) {
@@ -3310,6 +3360,16 @@ app.registerExtension({
                 };
 
                 const createPostElement = (post) => {
+                    // error 占位格：红色边框，直接显示错误文本
+                    if (post && post.error) {
+                        const wrapper = $el("div.danbooru-image-wrapper", {
+                            style: { border: '1px solid #ff4444', minHeight: '80px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#ff4444', fontSize: '0.85em', padding: '8px', textAlign: 'center' }
+                        });
+                        wrapper.dataset.postId = `err_${post.pid || post.page || '?'}`;
+                        wrapper.textContent = post.error;
+                        return wrapper;
+                    }
+
                     if (!post.id || !post.preview_file_url) return null;
 
                     const wrapper = $el("div.danbooru-image-wrapper");
@@ -3317,19 +3377,15 @@ app.registerExtension({
 
                     // Reserve grid space up-front from the post's real dimensions so the
                     // waterfall is stable before thumbnails finish loading.
-                    // G 站公开抓取返回 image_width/height=0，算不出 span；此时给一个保底高度，
-                    // 否则 wrapper 只占 grid-auto-rows(1px)，整个网格塌成一条线 →
-                    // 永远到不了"距底部 400px" → 滚动加载再也不触发。
+                    // G公开页返回的 post 经常 image_width/height=0，按列宽的估算方形保底高度
                     let reservedSpans = 0;
                     if (post.image_width && post.image_height) {
                         reservedSpans = computeSpanFromDims(post.image_width, post.image_height);
                     }
                     if (reservedSpans <= 0) {
-                        // 保底：按列宽估一个近似正方形高度（图片 onload 后 resizeGrid 会修正为真实高度）
                         const colW = getColumnWidth();
-                        const cs = window.getComputedStyle(imageGrid);
-                        const rowGap = parseInt(cs.gridRowGap) || parseInt(cs.rowGap) || 5;
-                        const rowHeight = parseInt(cs.gridAutoRows) || 1;
+                        const rowGap = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-row-gap')) || parseInt(window.getComputedStyle(imageGrid).rowGap) || 5;
+                        const rowHeight = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-auto-rows')) || 1;
                         reservedSpans = colW > 0 ? Math.ceil((colW + rowGap) / (rowHeight + rowGap)) : 200;
                     }
                     if (reservedSpans > 0) wrapper.style.gridRowEnd = `span ${reservedSpans}`;
@@ -3348,7 +3404,6 @@ app.registerExtension({
 
                     const img = $el("img", {
                         src: `/danbooru_gallery/image_proxy?url=${encodeURIComponent(previewUrl)}`,
-                        loading: "eager",
                         onload: scheduleResizeGrid,
                         onerror: () => { wrapper.style.display = 'none'; },
                         onclick: async (e) => {
@@ -3389,7 +3444,7 @@ app.registerExtension({
                             e.stopPropagation(); // 阻止事件冒泡，避免触发图片选择
 
                             try {
-                                const mediaPost = await getPostWithOriginalMedia(post);
+                                const mediaPost = getPostWithOriginalMedia(post);
                                 const imageUrl = getBestImageUrl(mediaPost, false);
                                 if (!imageUrl) {
                                     return;
@@ -3648,7 +3703,7 @@ app.registerExtension({
                         title: t('viewImage'),
                         onclick: async (e) => {
                             e.stopPropagation();
-                            const mediaPost = await getPostWithOriginalMedia(post);
+                            const mediaPost = getPostWithOriginalMedia(post);
                             const imageUrl = getBestImageUrl(mediaPost, false);
                             if (imageUrl) {
                                 window.open(proxiedMediaUrl(imageUrl), '_blank', 'noreferrer');
@@ -3681,10 +3736,8 @@ app.registerExtension({
                 observer.observe(imageGrid);
 
                 let scrollTimeout;
+                let scrollAnchorTimeout; // 锚点记录的防抖
                 imageGrid.addEventListener("scroll", () => {
-                    // 滚动消耗了前方缓冲 → 检查是否需要补货（维持前方 preload_count 张未看）。
-                    // 同时保留"接近底部"作为兜底触发（缓冲估算在 0 尺寸图下可能偏差）。
-                    maybeLoadMore();
                     if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
                         fetchAndRender(false);
                     }
@@ -3692,6 +3745,27 @@ app.registerExtension({
                     // Debounced scroll logic for page indicator
                     clearTimeout(scrollTimeout);
                     scrollTimeout = setTimeout(updateCurrentPageIndicator, 150);
+
+                    // 记录滚动锚点（每秒；取视野最上方的图往前 8 张，刷新时用其 id 做游标往下接）
+                    clearTimeout(scrollAnchorTimeout);
+                    scrollAnchorTimeout = setTimeout(() => {
+                        const scrollRect = imageGrid.getBoundingClientRect();
+                        let closestIdx = -1, closestDist = Infinity;
+                        const children = Array.from(imageGrid.children);
+                        children.forEach((w, i) => {
+                            const rect = w.getBoundingClientRect();
+                            const dist = Math.abs(rect.top - scrollRect.top);
+                            if (dist < closestDist) { closestDist = dist; closestIdx = i; }
+                        });
+                        if (closestIdx >= 0) {
+                            const anchorIdx = Math.max(0, closestIdx - 8);
+                            const anchorEl = children[anchorIdx];
+                            if (anchorEl && anchorEl.dataset.postId) {
+                                scrollAnchorPostId = anchorEl.dataset.postId;
+                                saveToLocalStorage('scrollAnchorPostId', scrollAnchorPostId);
+                            }
+                        }
+                    }, 1000);
                 });
 
                 searchInput.addEventListener("keydown", (e) => {
@@ -4110,6 +4184,35 @@ app.registerExtension({
                             filterWidget.value = JSON.stringify(filterState);
                         }
 
+                        // 恢复已存储的 preload/dedup/globalLogging（在 loadUiSettings 之后）
+                        const savedPreloadCount = loadFromLocalStorage('preload_count', null);
+                        if (savedPreloadCount !== null) {
+                            const clamped = Math.min(Math.max(parseInt(savedPreloadCount, 10) || 40, 20), 200);
+                            uiSettings.preload_count = clamped;
+                        } else {
+                            uiSettings.preload_count = 40;
+                        }
+                        const savedGelbooruDedupMode = loadFromLocalStorage('gelbooru_dedup_mode', null);
+                        if (savedGelbooruDedupMode && ["off", "on", "on_auth"].includes(savedGelbooruDedupMode)) {
+                            uiSettings.gelbooru_dedup_mode = savedGelbooruDedupMode;
+                        } else {
+                            uiSettings.gelbooru_dedup_mode = "off";
+                        }
+                        const savedGlobalLogging = loadFromLocalStorage('global_logging', null);
+                        if (typeof savedGlobalLogging === "boolean") {
+                            uiSettings.global_logging = savedGlobalLogging;
+                            loggerClient.setConsoleOutput(savedGlobalLogging);
+                        } else {
+                            uiSettings.global_logging = false;
+                            loggerClient.setConsoleOutput(false);
+                        }
+
+                        // 恢复保存的滚动锚点（刷新后用其 id 做游标往下接）
+                        const savedScrollAnchor = loadFromLocalStorage('scrollAnchorPostId', null);
+                        if (savedScrollAnchor) {
+                            scrollAnchorPostId = savedScrollAnchor;
+                        }
+
                         // 初始化排行榜按钮状态
                         updateRankingButtonState();
 
@@ -4120,7 +4223,8 @@ app.registerExtension({
                             filterButton.classList.remove('active');
                         }
 
-                        // 页面加载时直接获取第一页的帖子
+                        // 页面加载时直接获取第一页的帖子（先同步 currentTags，否则重置块会因 '' !== 搜索值而清空锚点）
+                        currentTags = searchInput.value.trim();
                         fetchAndRender(true);
 
                     } catch (error) {

--- a/js/global/logger_client.js
+++ b/js/global/logger_client.js
@@ -293,6 +293,12 @@ class LoggerClient {
      */
     setConsoleOutput(enabled) {
         this.consoleOutputEnabled = enabled;
+        // 当全局日志开启时，级别过滤器降到 DEBUG，确保所有日志都能被控制台输出
+        if (enabled) {
+            this.currentLevel = LOG_LEVELS.DEBUG;
+        } else {
+            this.currentLevel = LOG_LEVELS.INFO;
+        }
         this._saveConfig();
     }
 }

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -273,7 +273,9 @@ def load_ui_settings():
         "selected_categories": settings.get("selected_categories", ["copyright", "character", "general"]),
         "multi_select_enabled": settings.get("multi_select_enabled", False),
         "source_site": settings.get("source_site", "danbooru"),
-        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False)
+        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False),
+        "preload_count": settings.get("preload_count", 40),
+        "gelbooru_dedup_mode": settings.get("gelbooru_dedup_mode", "off")
     }
 
 def save_ui_settings(ui_settings):
@@ -286,6 +288,8 @@ def save_ui_settings(ui_settings):
     settings["multi_select_enabled"] = ui_settings.get("multi_select_enabled", False)
     settings["source_site"] = ui_settings.get("source_site", "danbooru")
     settings["gelbooru_display_all_site_content"] = ui_settings.get("gelbooru_display_all_site_content", False)
+    settings["preload_count"] = ui_settings.get("preload_count", 40)
+    settings["gelbooru_dedup_mode"] = ui_settings.get("gelbooru_dedup_mode", "off")
     return save_settings(settings)
 
 # ================================
@@ -1509,7 +1513,9 @@ async def save_ui_settings_route(request):
             "selected_categories": data.get("selected_categories", ["copyright", "character", "general"]),
             "multi_select_enabled": data.get("multi_select_enabled", False),
             "source_site": data.get("source_site", "danbooru"),
-            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False)
+            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False),
+            "preload_count": data.get("preload_count", 40),
+            "gelbooru_dedup_mode": data.get("gelbooru_dedup_mode", "off")
         }
         success = save_ui_settings(ui_settings)
         return web.json_response({"success": success})
@@ -1800,9 +1806,20 @@ class DanbooruGalleryNode:
         if gelbooru_display_all_site_content is None:
             gelbooru_display_all_site_content = settings.get("gelbooru_display_all_site_content", False)
 
-        # 归一化 before_id（游标分页：只取数字，防止注入）
+        # 游标分页（page=b<id>）归一化：只接受纯数字，防注入
         before_id = str(before_id).strip() if before_id else ""
         if before_id and not before_id.isdigit():
+            before_id = ""
+        # order/ordfav/sort 改变 id 降序前提，任何站点都禁用游标（防乱序漏图）
+        gelbooru_dedup_mode = settings.get("gelbooru_dedup_mode", "off")
+        has_sort = bool(re.search(r'(?:^|\s)(?:order|ordfav|sort):', tags or ''))
+        if before_id and has_sort:
+            before_id = ""
+        # D 站默认排序始终用游标；G 站仅当 gelbooru_dedup_mode 开启时用；其余禁用
+        if before_id and not (
+            adapter.key == "danbooru"
+            or (adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"))
+        ):
             before_id = ""
 
         # 创建缓存键（rating 归一化排序，避免 "e,q" 与 "q,e" 命中两条缓存）
@@ -1810,6 +1827,8 @@ class DanbooruGalleryNode:
         site_options_key = ""
         if adapter.key == "gelbooru":
             site_options_key = "display_all" if gelbooru_display_all_site_content else "default"
+            # dedup 档位影响 tag 截断数量，纳入缓存键避免不同档位（尤其首页 before_id 同为空时）互相污染
+            site_options_key = f"{site_options_key}:dedup_{gelbooru_dedup_mode}"
         # before_id 纳入缓存键，避免不同游标页命中同一条缓存
         cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}:{before_id}"
 
@@ -1832,9 +1851,16 @@ class DanbooruGalleryNode:
             elif tag.strip():
                 other_tags.append(tag.strip())
 
-        # 限制其他标签的数量
-        if len(other_tags) > 2:
-            other_tags = other_tags[:2]
+        # 限制其他标签的数量。默认 2；G 站开启游标时按档位调整名额
+        max_tags = 2
+        if adapter.key == "gelbooru" and before_id:  # before_id 非空 = 已确认走 G 站游标
+            creds = get_site_credentials(adapter)
+            if gelbooru_dedup_mode == "on_auth" and has_required_site_credentials(adapter, creds):
+                max_tags = 10   # 已配密钥，解除限制（较大上限）
+            else:
+                max_tags = 1    # 未配密钥，留一个名额给游标 id:<X
+        if len(other_tags) > max_tags:
+            other_tags = other_tags[:max_tags]
         
         # 重新组合标签
         final_tags = ' '.join(other_tags)
@@ -1855,9 +1881,9 @@ class DanbooruGalleryNode:
         
         tags = final_tags
 
-        # 游标分页防重复：Gelbooru 无 page 游标，但支持 meta-tag id:<X（默认按 id 降序，等效"取这张之前的"）。
-        # Danbooru 走 page=b<id>（见下方 build 后覆盖），这里不动它的 tags。
-        if before_id and adapter.key != "danbooru":
+        # G 站游标：注入 id:<X 作为搜索 metatag（配合默认 id 降序 = 取该 id 之前的图）。
+        # 三条 G 站路径（force_public_detail / 无凭据公开抓取 / DAPI）都会带上。
+        if before_id and adapter.key == "gelbooru":
             tags = f"{tags} id:<{before_id}".strip()
 
         username, api_key = load_user_auth()
@@ -1882,7 +1908,8 @@ class DanbooruGalleryNode:
             return ("[]",)
             
         params = adapter.build_posts_params(tags, limit, page, rating_query)
-        # Danbooru 游标分页：page=b<id> 表示"id 小于该值的结果"，避免有新图上传时翻页重复。
+        # Danbooru 游标分页：page=b<id> 表示"id 小于该值的结果"，消除偏移翻页重复。
+        # 显式限定 danbooru，避免与 G 站 before_id（走 id:<X 注入）串台。
         if before_id and adapter.key == "danbooru":
             params["page"] = f"b{before_id}"
         params = adapter.apply_auth_params(params, credentials)

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -21,8 +21,14 @@ from pathlib import Path
 import sys
 from ..utils.logger import get_logger
 from .site_adapters import get_site_adapter
+from collections import deque
 
 logger = get_logger(__name__)
+
+# FIFO 选择队列：每次 Queue 时前端快照一个选中条目入队，
+# 节点执行时从队首 pop 出一个，彻底解耦缓存碰撞
+_selection_queue = deque()
+_selection_queue_lock = threading.Lock()
 
 # 导入数据库管理器
 try:
@@ -38,10 +44,6 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Danbooru API的基础URL
 BASE_URL = "https://danbooru.donmai.us"
-
-# Gelbooru 公开列表页（未登录 HTML 抓取）每页固定显示的图片数，用于 pid 偏移翻页。
-# 实测约 42；pid 必须按此对齐，否则 limit≠42 时翻页会跳过/重复。
-GELBOORU_PUBLIC_PAGE_SIZE = 42
 
 # 需要一个非 python-requests 的描述性 UA 才能过 Cloudflare（从 2026-04-23 起开启拦截）。
 # 实测 CF 对 UA 黑名单里包含 "ComfyUI" —— 推测 Danbooru 为抵制训练数据爬取主动加的规则。
@@ -68,9 +70,12 @@ class _RateLimiter:
             self._last_ts = time.monotonic()
 
 _donmai_throttle = _RateLimiter(min_interval_sec=0.2)
-# Gelbooru 公开网页抓取限流：公开页对频繁请求敏感，缓冲补货会连发多次请求。
-# 取 2.5s 间隔：凑 200 张约需 5 次请求 ≈ 12.5s（落在期望的 10-20s 加载耗时区间），且避开 429。
-_gelbooru_public_throttle = _RateLimiter(min_interval_sec=2.5)
+
+# Gelbooru 公开 HTML 页列表固定每页 42 张，pid 为该页首张图片的偏移量
+GELBOORU_PUBLIC_PAGE_SIZE = 42
+
+# Gelbooru 公开页抓取限流器（0.75s = ~1.33 req/s，避开 429）
+_gelbooru_public_throttle = _RateLimiter(min_interval_sec=0.75)
 
 def _danbooru_request(method, url, **kwargs):
     """统一的 donmai.us 请求入口：限流 + 默认 UA + 429/503 带 Retry-After 退避重试一次。"""
@@ -280,9 +285,7 @@ def load_ui_settings():
         "selected_categories": settings.get("selected_categories", ["copyright", "character", "general"]),
         "multi_select_enabled": settings.get("multi_select_enabled", False),
         "source_site": settings.get("source_site", "danbooru"),
-        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False),
-        "preload_count": settings.get("preload_count", 40),
-        "gelbooru_dedup_mode": settings.get("gelbooru_dedup_mode", "off")
+        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False)
     }
 
 def save_ui_settings(ui_settings):
@@ -295,8 +298,6 @@ def save_ui_settings(ui_settings):
     settings["multi_select_enabled"] = ui_settings.get("multi_select_enabled", False)
     settings["source_site"] = ui_settings.get("source_site", "danbooru")
     settings["gelbooru_display_all_site_content"] = ui_settings.get("gelbooru_display_all_site_content", False)
-    settings["preload_count"] = ui_settings.get("preload_count", 40)
-    settings["gelbooru_dedup_mode"] = ui_settings.get("gelbooru_dedup_mode", "off")
     return save_settings(settings)
 
 # ================================
@@ -1215,52 +1216,73 @@ def _fetch_supported_media(url):
 def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, display_all_site_content=False):
     """Fetch Gelbooru posts from public HTML pages when DAPI credentials are unavailable.
 
-    单页抓取：每次只请求 Gelbooru 公开列表页的一页（约 42 张，由网站固定）。
-    pid 偏移基于固定页大小（GELBOORU_PUBLIC_PAGE_SIZE），与 limit 解耦——
-    否则 limit≠42 时 page 翻页会错位跳过/重复。凑够 preload_count 由前端连续翻页完成。
+    Uses fixed page size GELBOORU_PUBLIC_PAGE_SIZE (42) so pid is decoupled from
+    the frontend's requested limit; the frontend chains multiple page fetches via
+    maybeLoadMore to reach the user's preload_count.
+
+    On transient failure (429/503) it retries once with Retry-After back-off.
+    If retry also fails or the response is non-recoverable, returns an error
+    placeholder object so the frontend can display a per-cell error rather than
+    crashing the whole gallery.
     """
     id_match = re.search(r"(?:^|\s)id:(\d+)(?:\s|$)", tags or "")
     if id_match:
         refs = [{"id": id_match.group(1)}]
     else:
-        session = _get_gelbooru_session(display_all_site_content)
-        # 公开列表页 pid 是图片偏移量；每页固定约 42 张，按固定页大小推进，避免与 limit 错位
+        # 固定页大小，pid 与 frontend 的 limit 解耦
         pid_value = max(page - 1, 0) * GELBOORU_PUBLIC_PAGE_SIZE
         params = adapter.build_public_posts_params(tags, limit, page, rating_query)
+        # override pid with fixed page size
         params["pid"] = pid_value
 
+        session = _get_gelbooru_session(display_all_site_content)
+
         def _get_list_page(sess):
-            """限流 + 429/503 退避重试一次。返回 response 或 None（失败时不抛异常）。"""
+            """Inner closure: fetch list page with rate limiting + retry."""
             for attempt in range(2):
                 _gelbooru_public_throttle.wait()
-                resp = sess.get(adapter.posts_url, params=params, timeout=(8, 15))
+                try:
+                    resp = sess.get(adapter.posts_url, params=params, timeout=(8, 15))
+                except requests.exceptions.RequestException as e:
+                    if attempt == 0:
+                        _log_gelbooru_retry_warning(f"网络异常: {e}", pid_value=pid_value)
+                        time.sleep(3)
+                    continue
+
                 if resp.status_code not in (429, 503):
-                    resp.raise_for_status()
-                    return resp
+                    return resp  # 正常（含 200/500/403），交调用方判断
+
+                # 429/503 限流: 读 Retry-After 退避一次
+                retry_after = resp.headers.get("Retry-After")
+                delay = 2.0
+                try:
+                    if retry_after is not None:
+                        delay = min(max(float(retry_after), 0.5), 10.0)
+                except ValueError:
+                    pass
                 if attempt == 0:
-                    retry_after = resp.headers.get("Retry-After")
-                    delay = 3.0
-                    try:
-                        if retry_after is not None:
-                            delay = min(max(float(retry_after), 1.0), 10.0)
-                    except ValueError:
-                        pass
-                    logger.warning(f"[GelbooruPublic] {resp.status_code} 限流，{delay:.1f}s 后重试 pid={pid_value}")
+                    _log_gelbooru_retry_warning(f"HTTP {resp.status_code} 限流，{delay:.1f}s 后重试", pid_value=pid_value)
                     time.sleep(delay)
                 else:
-                    logger.warning(f"[GelbooruPublic] 重试后仍 {resp.status_code}，本页放弃 pid={pid_value}")
-                    return None
+                    _log_gelbooru_retry_warning(f"重试仍限流({resp.status_code})，跳过本页", pid_value=pid_value)
+                    return None  # 重试仍限流 → 跳过本页
+
             return None
 
         list_response = _get_list_page(session)
         if list_response is None:
-            return []  # 被限流且重试失败 → 返回空，让前端按"暂无更多"处理，不崩溃
+            # 返回 error 占位格（不含 list_response.text 细节）
+            driver_pid = params.get("pid", pid_value)
+            return [{"error": "Gelbooru 服务暂不可用", "pid": driver_pid, "page": page}]
+
         if display_all_site_content and _gelbooru_public_page_requires_options(list_response.text):
             logger.warning("[GelbooruPublic] Result page still requested Display all site content; rebuilding session and retrying")
             session = _get_gelbooru_session(display_all_site_content, force_refresh=True)
             list_response = _get_list_page(session)
             if list_response is None:
-                return []
+                driver_pid = params.get("pid", pid_value)
+                return [{"error": "Gelbooru 服务暂不可用", "pid": driver_pid, "page": page}]
+
         refs = adapter.extract_public_post_refs(list_response.text, limit)
         logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} refs={len(refs)}")
 
@@ -1273,20 +1295,35 @@ def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, displ
         if not post_id:
             continue
 
-        try:
-            post_response = _get_gelbooru_session(display_all_site_content).get(
-                adapter.posts_url,
-                params=adapter.build_public_post_params(post_id),
-                timeout=(8, 15),
-            )
-            post_response.raise_for_status()
-            post = adapter.normalize_public_post_page(post_id, post_response.text, ref)
-            if post.get("preview_file_url") or post.get("file_url"):
-                posts.append(post)
-        except requests.exceptions.RequestException as e:
-            logger.warning(f"[GelbooruPublic] 帖子页面解析失败 id={post_id}: {e}")
+        # 0 引用重试：HTML 结构有可能解析失败
+        for attempt in range(2):
+            try:
+                post_response = _get_gelbooru_session(display_all_site_content).get(
+                    adapter.posts_url,
+                    params=adapter.build_public_post_params(post_id),
+                    timeout=(8, 15),
+                )
+                post_response.raise_for_status()
+                post = adapter.normalize_public_post_page(post_id, post_response.text, ref)
+                if post.get("preview_file_url") or post.get("file_url"):
+                    posts.append(post)
+                    break
+            except requests.exceptions.RequestException as e:
+                if attempt == 0:
+                    logger.warning(f"[GelbooruPublic] 帖子页面解析失败/id={post_id} 尝试重试: {e}")
+                    time.sleep(1)
+                else:
+                    logger.warning(f"[GelbooruPublic] 帖子页面解析失败/id={post_id} 放弃: {e}")
 
     return posts
+
+
+def _log_gelbooru_retry_warning(message, pid_value=None):
+    """Short helper for logging gelbooru public fetch retry messages."""
+    if pid_value is not None:
+        logger.warning(f"[GelbooruPublic] {message} (pid={pid_value})")
+    else:
+        logger.warning(f"[GelbooruPublic] {message}")
 
 @PromptServer.instance.routes.get("/danbooru_gallery/image_proxy")
 async def image_proxy(request):
@@ -1359,9 +1396,12 @@ async def get_posts_for_front(request):
     limit = query.get("limit", "100")
     rating = query.get("search[rating]", "")
     source = query.get("source", "danbooru")
-    before_id = query.get("before_id", "")
     gelbooru_display_all_site_content = query.get("gelbooru_display_all_site_content", "").lower() in ("1", "true", "yes", "on")
     force_public_detail = query.get("force_public_detail", "").lower() in ("1", "true", "yes", "on")
+    before_id_raw = query.get("before_id", "")
+    gelbooru_dedup_mode = query.get("gelbooru_dedup_mode", "off").strip().lower()
+    if gelbooru_dedup_mode not in ("off", "on", "on_auth"):
+        gelbooru_dedup_mode = "off"
 
     posts_json_str, = DanbooruGalleryNode.get_posts_internal(
         tags=tags,
@@ -1369,9 +1409,10 @@ async def get_posts_for_front(request):
         page=int(page),
         rating=rating,
         source=source,
-        before_id=before_id,
         gelbooru_display_all_site_content=gelbooru_display_all_site_content,
         force_public_detail=force_public_detail,
+        before_id=before_id_raw,
+        gelbooru_dedup_mode=gelbooru_dedup_mode,
     )
     
     try:
@@ -1547,14 +1588,43 @@ async def save_ui_settings_route(request):
             "selected_categories": data.get("selected_categories", ["copyright", "character", "general"]),
             "multi_select_enabled": data.get("multi_select_enabled", False),
             "source_site": data.get("source_site", "danbooru"),
-            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False),
-            "preload_count": data.get("preload_count", 40),
-            "gelbooru_dedup_mode": data.get("gelbooru_dedup_mode", "off")
+            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False)
         }
         success = save_ui_settings(ui_settings)
         return web.json_response({"success": success})
     except Exception as e:
         logger.error(f"保存UI设置接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/selection_queue_push")
+async def selection_queue_push(request):
+    """前端在每次 Queue 前把当前选中的条目推入 FIFO 队列"""
+    try:
+        data = await request.json()
+        item = data.get("item")
+        if item:
+            with _selection_queue_lock:
+                _selection_queue.append(item)
+            logger.debug(f"[SelectionQueue] push → 队列长度 {len(_selection_queue)}")
+        return web.json_response({"success": True})
+    except Exception as e:
+        logger.error(f"[SelectionQueue] push error: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/selection_queue_pop")
+async def selection_queue_pop(request):
+    """节点执行时从队列头部 pop 一个条目（不移除则 peek）"""
+    try:
+        data = await request.json() if request.can_read_body else {}
+        remove = data.get("remove", True)
+        with _selection_queue_lock:
+            if _selection_queue:
+                item = _selection_queue.popleft() if remove else _selection_queue[0]
+                logger.debug(f"[SelectionQueue] pop → 剩余 {len(_selection_queue)}")
+                return web.json_response({"success": True, "item": item})
+        return web.json_response({"success": True, "item": None})
+    except Exception as e:
+        logger.error(f"[SelectionQueue] pop error: {e}")
         return web.json_response({"success": False, "error": str(e)})
 
 # ================================
@@ -1787,19 +1857,37 @@ class DanbooruGalleryNode:
 
     @classmethod
     def IS_CHANGED(cls, selection_data="{}", **kwargs):
-        return selection_data
+        """返回队首条目的 _queue_id（唯一），队列空时返回 ""（缓存命中不再重复执行）。
+        彻底解决快速选图 1→Queue→2→Queue→... 导致的提示词覆盖竞态。"""
+        with _selection_queue_lock:
+            if _selection_queue:
+                return _selection_queue[0].get("_queue_id", time.time())
+        return ""
 
     def get_selected_data(self, selection_data="{}", **kwargs):
-        """处理选中的图片数据，支持单选和多选模式"""
-        if not selection_data or selection_data == "{}":
-            return ([torch.zeros(1, 1, 1, 3)], [""])
-
+        """处理选中的图片数据，从 FIFO 队列中 pop（优先），否则回退到 selection_data widget。
+        队列模式确保 1→Queue→2→Queue→3→Queue→4→Queue 依次正确输出，互不覆盖。"""
         images = []
         prompts = []
 
         try:
-            data = json.loads(selection_data)
-            selections = data.get("selections", [])
+            # 先从 FIFO 队列 pop（每次 Queue 时前端推入的 snapshot）
+            with _selection_queue_lock:
+                if _selection_queue:
+                    item = _selection_queue.popleft()
+                    logger.debug(f"[SelectionQueue] get_selected_data pop → 剩余 {len(_selection_queue)}")
+                else:
+                    item = None
+
+            if item:
+                # 队列模式：单个条目
+                selections = item.get("selections", [])
+            else:
+                # 回退：widget 值（无 Queue 点击，手动拖线等场景）
+                if not selection_data or selection_data == "{}":
+                    return ([torch.zeros(1, 1, 1, 3)], [""])
+                data = json.loads(selection_data)
+                selections = data.get("selections", [])
 
             if not selections:
                 return ([torch.zeros(1, 1, 1, 3)], [""])
@@ -1832,7 +1920,7 @@ class DanbooruGalleryNode:
         return (images, prompts)
     
     @staticmethod
-    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", before_id: str = None, gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False):
+    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False, before_id=None, gelbooru_dedup_mode: str = "off"):
         settings = load_settings()
         cache_enabled = settings.get("cache_enabled", True)
         max_cache_age = settings.get("max_cache_age", 3600)
@@ -1840,30 +1928,34 @@ class DanbooruGalleryNode:
         if gelbooru_display_all_site_content is None:
             gelbooru_display_all_site_content = settings.get("gelbooru_display_all_site_content", False)
 
-        # 游标分页（page=b<id>）归一化：只接受纯数字，防注入
+        if gelbooru_dedup_mode not in ("off", "on", "on_auth"):
+            gelbooru_dedup_mode = "off"
+
+        # before_id分页：化 + 数字校验，防止 page=b; DROP TABLE 类拼接注入
         before_id = str(before_id).strip() if before_id else ""
         if before_id and not before_id.isdigit():
             before_id = ""
-        # order/ordfav/sort 改变 id 降序前提，任何站点都禁用游标（防乱序漏图）
-        gelbooru_dedup_mode = settings.get("gelbooru_dedup_mode", "off")
-        has_sort = bool(re.search(r'(?:^|\s)(?:order|ordfav|sort):', tags or ''))
-        if before_id and has_sort:
+        # order/ordfav/sort变结果顺序，游标会漏图，禁用
+        if before_id and re.search(r'(?:^|\s)(?:order|ordfav|sort):', tags or ''):
             before_id = ""
-        # D 站默认排序始终用游标；G 站仅当 gelbooru_dedup_mode 开启时用；其余禁用
+        #仅在 Danbooru（官方 page=b<id>）或 Gelbooru + dedup 开启时生效
         if before_id and not (
             adapter.key == "danbooru"
             or (adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"))
         ):
             before_id = ""
 
+        credentials = get_site_credentials(adapter)
+        has_gelbooru_creds = has_required_site_credentials(adapter, credentials)
+
         # 创建缓存键（rating 归一化排序，避免 "e,q" 与 "q,e" 命中两条缓存）
         rating_key = ','.join(sorted(r.strip().lower() for r in (rating or '').split(',') if r.strip()))
         site_options_key = ""
         if adapter.key == "gelbooru":
             site_options_key = "display_all" if gelbooru_display_all_site_content else "default"
-            # dedup 档位影响 tag 截断数量，纳入缓存键避免不同档位（尤其首页 before_id 同为空时）互相污染
-            site_options_key = f"{site_options_key}:dedup_{gelbooru_dedup_mode}"
-        # before_id 纳入缓存键，避免不同游标页命中同一条缓存
+            # dedup位影响 tag断数量，须区分，否则 on/off/on_auth 在 before_id 同为空时互相污染
+            site_options_key += f"_dedup_{gelbooru_dedup_mode}"
+        # before_id 入键避免不同游标页相互污染
         cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}:{before_id}"
 
         # 判断是否获取收藏列表，如果是清除缓存以避免相同的请求前端列表不更新
@@ -1885,14 +1977,15 @@ class DanbooruGalleryNode:
             elif tag.strip():
                 other_tags.append(tag.strip())
 
-        # 限制其他标签的数量。默认 2；G 站开启游标时按档位调整名额
-        max_tags = 2
-        if adapter.key == "gelbooru" and before_id:  # before_id 非空 = 已确认走 G 站游标
-            creds = get_site_credentials(adapter)
-            if gelbooru_dedup_mode == "on_auth" and has_required_site_credentials(adapter, creds):
-                max_tags = 10   # 已配密钥，解除限制（较大上限）
+        # 限制其他标签的数量。Gelbooru标模式下 id:<X 占用一个 tag 名额（公开页/2-tag 限制），
+        # on_auth + 已配密钥走 DAPI 时可放宽到更多 tag。
+        if adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"):
+            if gelbooru_dedup_mode == "on_auth" and has_gelbooru_creds:
+                max_tags = 10
             else:
-                max_tags = 1    # 未配密钥，留一个名额给游标 id:<X
+                max_tags = 1
+        else:
+            max_tags = 2
         if len(other_tags) > max_tags:
             other_tags = other_tags[:max_tags]
         
@@ -1914,9 +2007,7 @@ class DanbooruGalleryNode:
             rating_query = rating
         
         tags = final_tags
-
-        # G 站游标：注入 id:<X 作为搜索 metatag（配合默认 id 降序 = 取该 id 之前的图）。
-        # 三条 G 站路径（force_public_detail / 无凭据公开抓取 / DAPI）都会带上。
+        # Gelbooru：拼进 tags（公开页 / DAPI用 tags 参数，见 build_public_posts_params / build_posts_params）
         if before_id and adapter.key == "gelbooru":
             tags = f"{tags} id:<{before_id}".strip()
 
@@ -1935,18 +2026,20 @@ class DanbooruGalleryNode:
                 result_text = json.dumps(posts, ensure_ascii=False)
 
                 if cache_enabled and not (adapter.key == "gelbooru" and gelbooru_display_all_site_content and not posts):
-                    DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
+                    # 跳过 error 占位格缓存（否则一次限流会让接下来 TTL 内都看不到新图）
+                    has_error_placeholder = posts and any(isinstance(p, dict) and p.get("error") for p in posts)
+                    if not has_error_placeholder:
+                        DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
 
                 return (result_text,)
             logger.warning(f"[{adapter.key}] 缺少必要认证信息，已跳过帖子请求")
             return ("[]",)
             
         params = adapter.build_posts_params(tags, limit, page, rating_query)
-        # Danbooru 游标分页：page=b<id> 表示"id 小于该值的结果"，消除偏移翻页重复。
-        # 显式限定 danbooru，避免与 G 站 before_id（走 id:<X 注入）串台。
+        params = adapter.apply_auth_params(params, credentials)
+        # Danbooru：走官方 page=b<id>
         if before_id and adapter.key == "danbooru":
             params["page"] = f"b{before_id}"
-        params = adapter.apply_auth_params(params, credentials)
 
         try:
             response = _danbooru_request("GET", adapter.posts_url, params=params, auth=auth, timeout=15)
@@ -1959,9 +2052,11 @@ class DanbooruGalleryNode:
 
             result_text = json.dumps(posts, ensure_ascii=False)
             
-            # 如果启用了缓存，则存储结果
+            # 如果启用了缓存，则存储结果（跳过 error 占位格）
             if cache_enabled and not (adapter.key == "gelbooru" and gelbooru_display_all_site_content and not posts):
-                DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
+                has_error_placeholder = posts and any(isinstance(p, dict) and p.get("error") for p in posts)
+                if not has_error_placeholder:
+                    DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
                 # 清理旧缓存（可选，防止内存无限增长）
                 if len(DanbooruGalleryNode._post_cache) > 200: # 假设最多缓存200个请求
                     oldest_key = min(DanbooruGalleryNode._post_cache.keys(), key=lambda k: DanbooruGalleryNode._post_cache[k][1])

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -1321,6 +1321,7 @@ async def get_posts_for_front(request):
     limit = query.get("limit", "100")
     rating = query.get("search[rating]", "")
     source = query.get("source", "danbooru")
+    before_id = query.get("before_id", "")
     gelbooru_display_all_site_content = query.get("gelbooru_display_all_site_content", "").lower() in ("1", "true", "yes", "on")
     force_public_detail = query.get("force_public_detail", "").lower() in ("1", "true", "yes", "on")
 
@@ -1330,6 +1331,7 @@ async def get_posts_for_front(request):
         page=int(page),
         rating=rating,
         source=source,
+        before_id=before_id,
         gelbooru_display_all_site_content=gelbooru_display_all_site_content,
         force_public_detail=force_public_detail,
     )
@@ -1790,7 +1792,7 @@ class DanbooruGalleryNode:
         return (images, prompts)
     
     @staticmethod
-    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False):
+    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", before_id: str = None, gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False):
         settings = load_settings()
         cache_enabled = settings.get("cache_enabled", True)
         max_cache_age = settings.get("max_cache_age", 3600)
@@ -1798,12 +1800,18 @@ class DanbooruGalleryNode:
         if gelbooru_display_all_site_content is None:
             gelbooru_display_all_site_content = settings.get("gelbooru_display_all_site_content", False)
 
+        # 归一化 before_id（游标分页：只取数字，防止注入）
+        before_id = str(before_id).strip() if before_id else ""
+        if before_id and not before_id.isdigit():
+            before_id = ""
+
         # 创建缓存键（rating 归一化排序，避免 "e,q" 与 "q,e" 命中两条缓存）
         rating_key = ','.join(sorted(r.strip().lower() for r in (rating or '').split(',') if r.strip()))
         site_options_key = ""
         if adapter.key == "gelbooru":
             site_options_key = "display_all" if gelbooru_display_all_site_content else "default"
-        cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}"
+        # before_id 纳入缓存键，避免不同游标页命中同一条缓存
+        cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}:{before_id}"
 
         # 判断是否获取收藏列表，如果是清除缓存以避免相同的请求前端列表不更新
         match = re.search(r'\bordfav:([^\s]+)', tags)
@@ -1847,6 +1855,11 @@ class DanbooruGalleryNode:
         
         tags = final_tags
 
+        # 游标分页防重复：Gelbooru 无 page 游标，但支持 meta-tag id:<X（默认按 id 降序，等效"取这张之前的"）。
+        # Danbooru 走 page=b<id>（见下方 build 后覆盖），这里不动它的 tags。
+        if before_id and adapter.key != "danbooru":
+            tags = f"{tags} id:<{before_id}".strip()
+
         username, api_key = load_user_auth()
         auth = HTTPBasicAuth(username, api_key) if adapter.requires_auth and username and api_key else None
         credentials = get_site_credentials(adapter)
@@ -1869,6 +1882,9 @@ class DanbooruGalleryNode:
             return ("[]",)
             
         params = adapter.build_posts_params(tags, limit, page, rating_query)
+        # Danbooru 游标分页：page=b<id> 表示"id 小于该值的结果"，避免有新图上传时翻页重复。
+        if before_id and adapter.key == "danbooru":
+            params["page"] = f"b{before_id}"
         params = adapter.apply_auth_params(params, credentials)
 
         try:

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -68,6 +68,9 @@ class _RateLimiter:
             self._last_ts = time.monotonic()
 
 _donmai_throttle = _RateLimiter(min_interval_sec=0.2)
+# Gelbooru 公开网页抓取限流：公开页对频繁请求敏感，缓冲补货会连发多次请求。
+# 取 2.5s 间隔：凑 200 张约需 5 次请求 ≈ 12.5s（落在期望的 10-20s 加载耗时区间），且避开 429。
+_gelbooru_public_throttle = _RateLimiter(min_interval_sec=2.5)
 
 def _danbooru_request(method, url, **kwargs):
     """统一的 donmai.us 请求入口：限流 + 默认 UA + 429/503 带 Retry-After 退避重试一次。"""
@@ -1225,15 +1228,41 @@ def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, displ
         pid_value = max(page - 1, 0) * GELBOORU_PUBLIC_PAGE_SIZE
         params = adapter.build_public_posts_params(tags, limit, page, rating_query)
         params["pid"] = pid_value
-        list_response = session.get(adapter.posts_url, params=params, timeout=(8, 15))
-        list_response.raise_for_status()
+
+        def _get_list_page(sess):
+            """限流 + 429/503 退避重试一次。返回 response 或 None（失败时不抛异常）。"""
+            for attempt in range(2):
+                _gelbooru_public_throttle.wait()
+                resp = sess.get(adapter.posts_url, params=params, timeout=(8, 15))
+                if resp.status_code not in (429, 503):
+                    resp.raise_for_status()
+                    return resp
+                if attempt == 0:
+                    retry_after = resp.headers.get("Retry-After")
+                    delay = 3.0
+                    try:
+                        if retry_after is not None:
+                            delay = min(max(float(retry_after), 1.0), 10.0)
+                    except ValueError:
+                        pass
+                    logger.warning(f"[GelbooruPublic] {resp.status_code} 限流，{delay:.1f}s 后重试 pid={pid_value}")
+                    time.sleep(delay)
+                else:
+                    logger.warning(f"[GelbooruPublic] 重试后仍 {resp.status_code}，本页放弃 pid={pid_value}")
+                    return None
+            return None
+
+        list_response = _get_list_page(session)
+        if list_response is None:
+            return []  # 被限流且重试失败 → 返回空，让前端按"暂无更多"处理，不崩溃
         if display_all_site_content and _gelbooru_public_page_requires_options(list_response.text):
             logger.warning("[GelbooruPublic] Result page still requested Display all site content; rebuilding session and retrying")
             session = _get_gelbooru_session(display_all_site_content, force_refresh=True)
-            list_response = session.get(adapter.posts_url, params=params, timeout=(8, 15))
-            list_response.raise_for_status()
+            list_response = _get_list_page(session)
+            if list_response is None:
+                return []
         refs = adapter.extract_public_post_refs(list_response.text, limit)
-        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} page={page} pid={pid_value} refs={len(refs)}")
+        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} refs={len(refs)}")
 
     if not id_match:
         return refs

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -39,6 +39,10 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # Danbooru API的基础URL
 BASE_URL = "https://danbooru.donmai.us"
 
+# Gelbooru 公开列表页（未登录 HTML 抓取）每页固定显示的图片数，用于 pid 偏移翻页。
+# 实测约 42；pid 必须按此对齐，否则 limit≠42 时翻页会跳过/重复。
+GELBOORU_PUBLIC_PAGE_SIZE = 42
+
 # 需要一个非 python-requests 的描述性 UA 才能过 Cloudflare（从 2026-04-23 起开启拦截）。
 # 实测 CF 对 UA 黑名单里包含 "ComfyUI" —— 推测 Danbooru 为抵制训练数据爬取主动加的规则。
 # 本节点只是图片浏览器（单图挑选，无批量导出），不参与训练数据收集，按 e621 式约定
@@ -1206,29 +1210,30 @@ def _fetch_supported_media(url):
     return response.content
 
 def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, display_all_site_content=False):
-    """Fetch Gelbooru posts from public HTML pages when DAPI credentials are unavailable."""
+    """Fetch Gelbooru posts from public HTML pages when DAPI credentials are unavailable.
+
+    单页抓取：每次只请求 Gelbooru 公开列表页的一页（约 42 张，由网站固定）。
+    pid 偏移基于固定页大小（GELBOORU_PUBLIC_PAGE_SIZE），与 limit 解耦——
+    否则 limit≠42 时 page 翻页会错位跳过/重复。凑够 preload_count 由前端连续翻页完成。
+    """
     id_match = re.search(r"(?:^|\s)id:(\d+)(?:\s|$)", tags or "")
     if id_match:
         refs = [{"id": id_match.group(1)}]
     else:
         session = _get_gelbooru_session(display_all_site_content)
-        list_response = session.get(
-            adapter.posts_url,
-            params=adapter.build_public_posts_params(tags, limit, page, rating_query),
-            timeout=(8, 15),
-        )
+        # 公开列表页 pid 是图片偏移量；每页固定约 42 张，按固定页大小推进，避免与 limit 错位
+        pid_value = max(page - 1, 0) * GELBOORU_PUBLIC_PAGE_SIZE
+        params = adapter.build_public_posts_params(tags, limit, page, rating_query)
+        params["pid"] = pid_value
+        list_response = session.get(adapter.posts_url, params=params, timeout=(8, 15))
         list_response.raise_for_status()
         if display_all_site_content and _gelbooru_public_page_requires_options(list_response.text):
             logger.warning("[GelbooruPublic] Result page still requested Display all site content; rebuilding session and retrying")
             session = _get_gelbooru_session(display_all_site_content, force_refresh=True)
-            list_response = session.get(
-                adapter.posts_url,
-                params=adapter.build_public_posts_params(tags, limit, page, rating_query),
-                timeout=(8, 15),
-            )
+            list_response = session.get(adapter.posts_url, params=params, timeout=(8, 15))
             list_response.raise_for_status()
         refs = adapter.extract_public_post_refs(list_response.text, limit)
-        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} refs={len(refs)}")
+        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} page={page} pid={pid_value} refs={len(refs)}")
 
     if not id_match:
         return refs

--- a/py/danbooru_gallery/site_adapters.py
+++ b/py/danbooru_gallery/site_adapters.py
@@ -118,8 +118,9 @@ class GelbooruAdapter(GallerySiteAdapter):
             "page": "post",
             "s": "list",
             "tags": public_tags,
-            # Gelbooru's public list page uses an offset-like pid.
-            "pid": max(page - 1, 0) * max(limit, 1),
+            # Gelbooru's public list page uses a fixed page size of 42.
+            # pid = (page-1) * 42, decoupled from the frontend's limit param.
+            "pid": max(page - 1, 0) * 42,
         }
 
     def build_public_post_params(self, post_id: Any) -> Dict[str, Any]:


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Commit 已经成功了，但 push 到远程仓库时因为权限问题（403）失败了——当前 git 凭据的用户名 <code>ztztfdsf</code> 没有该仓库的推权限。</p>
<p>你可以手动推送：</p>
<pre><code class="language-bash">cd "D:/ComfyUI-aki-v3（anima）/ComfyUI/custom_nodes/ComfyUI-Danbooru-Gallery"
git push origin main
</code></pre>
<hr>
<p><strong>提交内容总结：</strong></p>
<p>改动了 <strong>4 个文件</strong>，+568 / -119 行。</p>

文件 | 改动
-- | --
js/danbooru_gallery/danbooru_gallery.js | +424/-119
js/global/logger_client.js | +6
py/danbooru_gallery/danbooru_gallery.py | +252
py/danbooru_gallery/site_adapters.py | +1/-1


<p><strong>新增的功能：</strong></p>
<ol>
<li><strong>游标分页</strong>（<code>before_id</code>）—— D 站 <code>page=b&lt;id&gt;</code>，G 站 <code>id:&lt;X</code> tag，彻底解决偏移翻页图片重复/漏图</li>
<li><strong>maybeLoadMore 渐进补货</strong> —— 滚动不够时自动续拉，直到满足缓冲张数</li>
<li><strong>Gelbooru 公开抓取重构</strong> —— 独立限流器 0.75s、429/503 重试、失败返回 error 占位格而非抛异常、固定页大小 42</li>
<li><strong>FIFO 选择队列</strong> —— 拦截 Queue 按钮（兼容新旧版 UI），快照入队，节点执行时先 pop。<strong>解决快速 1→Queue→2→Queue→3→Queue→4→Queue 提示词全部被最后一张覆盖的竞态 bug</strong></li>
<li><strong>刷新重定位</strong> —— 每秒记录视野上方第 8 张图 id，刷新后锚图不变、游标往下接、滚动还原</li>
<li><strong>网格塌陷兜底</strong> —— G 站图片宽高=0 时保底 150px 网格，grid 不崩</li>
<li><strong>错误占位格</strong> —— 限流失效时面板不白屏，追加红色错误格</li>
<li><strong>防御性 JSON 解析</strong> —— 后端返回非 JSON 时不销毁已加载的内容</li>
<li><strong>同步选图链路</strong> —— <code>buildPromptForPost</code>/<code>updateSelectionData</code> 移除 await，消除链式竞态</li>
<li><strong>全局日志</strong> —— 设置中开启后控制台输出 DEBUG 及以上全部日志</li>
<li><strong>预加载设置面板</strong> —— 独立导航栏，含缓冲张数、G 站防重复、全局日志</li>
<li><strong>网络检查 30s TTL</strong> —— 上次成功 30s 内跳过检查</li>
</ol>
<p><strong>删除的代码：</strong></p>
<ul>
<li><code>__selection_version__</code> 旧版本号机制（已被 FIFO 队列覆盖取代）</li>
<li><code>selection_queue_peek</code> / <code>selection_queue_clear</code> 两条未调用路由</li>
<li><code>localStorage</code> 中的 <code>lastPostId</code> 持久化（改用 <code>scrollAnchorPostId</code>）</li>
<li><code>&lt;img loading="lazy"&gt;</code>（已在代理层处理）</li>
</ul>
<p><strong>修复的 bug：</strong></p>
<ul>
<li><code>??</code> + <code>||</code> 混用 SyntaxError（导致模块加载失败→黑屏）</li>
<li><code>parseFailed</code> 块作用域泄漏（<code>let</code> 在 <code>try</code> 内，<code>finally</code> 访问报错）</li>
<li>刷新后 <code>scrollTop</code> 归零，锚点从未实际恢复</li>
<li>初始化时 <code>currentTags=""</code> 与恢复后的搜索词不匹配，锚点总被清空</li>
</ul></body></html><!--EndFragment-->
</body>
</html>