### PR TITLE
这次应该没bug了。

### DIFF
--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -196,6 +196,7 @@ app.registerExtension({
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
                 let lastPostId = null;            // D 站游标分页：上一批最后一张的 id
                 const seenPostIds = new Set();    // 渲染前 id 去重兜底
+                let fillAnchor = 0;               // G 站续拉锚点：本轮自该 posts 数起凑够 fillTarget
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -2453,12 +2454,24 @@ app.registerExtension({
                     }).join(' ');
                 };
 
-                const fetchAndRender = async (reset = false) => {
+                const fetchAndRender = async (reset = false, isContinuation = false) => {
                     if (isLoading) {
                         return;
                     }
                     if (endOfResults && !reset) {
                         return;
+                    }
+                    // G 站公开列表页每页固定约 42 张，单次请求凑不满较大的 preload_count。
+                    // 续拉机制：拿完一页后若本轮累计不足 fillTarget 且未到底，自动续拉下一页。
+                    // （D 站一次请求即可拿满 limit；G 站游标模式靠 lastPostId 翻批；均不续拉。）
+                    const src = uiSettings.source_site || "danbooru";
+                    const dedupMode = uiSettings.gelbooru_dedup_mode || "off";
+                    const needAutoFill = (src === "gelbooru" && dedupMode === "off");
+                    const fillTarget = needAutoFill ? (parseInt(uiSettings.preload_count, 10) || 40) : 0;
+                    // 续拉锚点：新一轮（reset 或用户滚动触发的非续拉调用）以当前 posts 数为基准，
+                    // 续拉到 posts 比基准多出 fillTarget 张为止。续拉调用(isContinuation)沿用旧基准。
+                    if (!isContinuation) {
+                        fillAnchor = reset ? 0 : posts.length;
                     }
                     isLoading = true;
                     refreshButton.classList.add("loading");
@@ -2606,6 +2619,15 @@ app.registerExtension({
                         if (indicator) {
                             indicator.remove();
                         }
+                    }
+
+                    // G 站续拉：本轮（自 fillAnchor 起）累计不足 fillTarget 且未到底，自动拉下一页。
+                    // 条件含 posts.length > fillAnchor（确有进展），避免出错时无限重试。
+                    if (needAutoFill && !endOfResults &&
+                        posts.length > fillAnchor &&
+                        (posts.length - fillAnchor) < fillTarget) {
+                        // 异步触发续拉，让出调用栈（避免深递归）；isLoading 已在 finally 释放
+                        setTimeout(() => fetchAndRender(false, true), 0);
                     }
                 };
 

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -2722,6 +2722,9 @@ app.registerExtension({
                 };
                 setTimeout(_hookQueueButton, 1000);
 
+                // 2 秒定时轮询检查前方缓冲，不够就自动补货
+                setInterval(maybeLoadMore, 2000);
+
                 const resizeGrid = () => {
                     try {
                         const cs = window.getComputedStyle(imageGrid);
@@ -3748,8 +3751,18 @@ app.registerExtension({
                 let scrollTimeout;
                 let scrollAnchorTimeout; // 锚点记录的防抖
                 imageGrid.addEventListener("scroll", () => {
-                    if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
-                        fetchAndRender(false);
+                    // 每次滚动检查前方缓冲，不够就补
+                    if (!isLoading && !endOfResults) {
+                        const bufferTarget = parseInt(uiSettings.preload_count, 10) || 40;
+                        const scrollH = imageGrid.scrollHeight;
+                        let viewedCount = 0;
+                        if (scrollH > 0) {
+                            const viewedRatio = Math.min(1, (imageGrid.scrollTop + imageGrid.clientHeight) / scrollH);
+                            viewedCount = Math.floor(posts.length * viewedRatio);
+                        }
+                        if (posts.length - viewedCount < bufferTarget) {
+                            setTimeout(() => fetchAndRender(false), 0);
+                        }
                     }
 
                     // Debounced scroll logic for page indicator

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -154,6 +154,13 @@ app.registerExtension({
 
                 // 检查网络连接状态
                 const checkNetworkStatus = async () => {
+                    // 节流：上次检查成功且在 30 秒内，直接复用，避免每次滚动加载都做一次完整网络往返
+                    // （G 站的检查是抓公开 HTML 页、8 秒超时，频繁触发会卡顿并误报"网络连接失败"）。
+                    const NETWORK_CHECK_TTL = 30000;
+                    if (networkStatus.connected && networkStatus.lastChecked &&
+                        (Date.now() - networkStatus.lastChecked) < NETWORK_CHECK_TTL) {
+                        return true;
+                    }
                     try {
                         const source = uiSettings.source_site || "danbooru";
                         const response = await fetch(`/danbooru_gallery/check_network?source=${encodeURIComponent(source)}`);
@@ -187,9 +194,8 @@ app.registerExtension({
                 let globalTooltip, globalTooltipTimeout;
                 let currentTooltipId = 0; // 用于追踪当前活动的tooltip请求
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
-                let lastPostId = null; // 游标分页：最后一张图的 id，下次请求传 before_id 防重复
-                let initialLoadComplete = false; // 首次加载（含预加载缓冲）是否完成
-                const seenPostIds = new Set(); // 跨批次去重兜底，防止任何重复图渲染
+                let lastPostId = null;            // D 站游标分页：上一批最后一张的 id
+                const seenPostIds = new Set();    // 渲染前 id 去重兜底
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -1430,6 +1436,44 @@ app.registerExtension({
                     selectionModeSection.appendChild(selectionModeDesc);
                     selectionModeSection.appendChild(multiSelectDiv);
 
+                    // 预加载设置（每次加载的图片数量，越大一次拉取越多但首屏越慢）
+                    const preloadSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
+                    const preloadTitle = $el("h3", { textContent: "预加载设置", style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
+                    const preloadDesc = $el("p", { textContent: "每次加载的图片数量。数值越大一次拉取越多，但首屏等待时间也越长（建议 40-100）", style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
+                    const preloadCountLabel = $el("label", { htmlFor: "preloadCountInput", textContent: "每次加载数量", style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
+                    const preloadCountInput = $el("input", {
+                        type: "number",
+                        id: "preloadCountInput",
+                        title: "设置每次加载数量（20-200）",
+                        value: (initialState.preloadCount ?? uiSettings.preload_count) || 40,
+                        min: "20",
+                        max: "200",
+                        style: { width: "60px", padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
+                    });
+                    const preloadCountDiv = $el("div", { style: { display: "flex", alignItems: "center" } }, [preloadCountLabel, preloadCountInput]);
+                    preloadSection.appendChild(preloadTitle);
+                    preloadSection.appendChild(preloadDesc);
+                    preloadSection.appendChild(preloadCountDiv);
+
+                    // G 站防重复设置（按 id 游标分页，解决翻页时新上传挤入导致的重复图）
+                    // 三段式：off / on（未配密钥时仅1个tag留名额给游标）/ on_auth（已配密钥，多tag可用）
+                    const gelbooruDedupLabel = $el("label", { htmlFor: "gelbooruDedupSelect", textContent: "G 站防重复", style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
+                    const gelbooruDedupSelect = $el("select", {
+                        id: "gelbooruDedupSelect",
+                        title: "G 站游标防重复档位（按id推进分页，避免新上传图导致翻页重复）",
+                        style: { padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
+                    }, [
+                        $el("option", { value: "off", textContent: "关闭（可使用2个tag）" }),
+                        $el("option", { value: "on", textContent: "开启（限1个tag）" }),
+                        $el("option", { value: "on_auth", textContent: "开启·已配密钥（多tag可用）" }),
+                    ]);
+                    const dedupInitial = (initialState.gelbooruDedupMode ?? uiSettings.gelbooru_dedup_mode) || "off";
+                    if (["off", "on", "on_auth"].includes(dedupInitial)) gelbooruDedupSelect.value = dedupInitial;
+                    const gelbooruDedupDiv = $el("div", { style: { display: "flex", alignItems: "center", marginTop: "12px" } }, [gelbooruDedupLabel, gelbooruDedupSelect]);
+                    const gelbooruDedupDesc = $el("p", { textContent: "关闭时 G 站保持原样；开启时按 id 游标推进翻页。未配密钥的开启档会限 1 个 tag 留给游标；已配密钥多 tag 可用", style: { margin: "8px 0 0 0", color: "#888", fontSize: "0.85em" } });
+                    preloadSection.appendChild(gelbooruDedupDiv);
+                    preloadSection.appendChild(gelbooruDedupDesc);
+
                     // 创建侧边栏按钮和内容区域的映射
                     const sections = {
                         'general': { title: t('generalSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>', elements: [languageSection] },
@@ -1437,6 +1481,7 @@ app.registerExtension({
                         'content': { title: t('contentSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18l-1.5 14H4.5L3 6z"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>', elements: [blacklistSection] },
                         'prompt': { title: t('promptSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>', elements: [filterSection] },
                         'ui': { title: t('uiSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>', elements: [autocompleteSection, tooltipSection, selectionModeSection] },
+                        'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
                     };
 
                     const setActiveSection = (key) => {
@@ -1647,6 +1692,10 @@ app.registerExtension({
                             const newAutocompleteMaxResults = parseInt(autocompleteMaxResultsInput.value, 10);
                             const newSelectedCategories = Array.from(categoryDropdown.querySelectorAll("input:checked")).map(i => i.name);
                             const newMultiSelectEnabled = multiSelectCheckbox.checked;
+                            let newPreloadCount = parseInt(preloadCountInput.value, 10);
+                            if (isNaN(newPreloadCount)) newPreloadCount = 40;
+                            newPreloadCount = Math.min(Math.max(newPreloadCount, 20), 200); // 夹到 20-200
+                            const newGelbooruDedupMode = ["off", "on", "on_auth"].includes(gelbooruDedupSelect.value) ? gelbooruDedupSelect.value : "off";
 
                             // 保存所有设置
                             const [blacklistSuccess, filterSuccess, uiSettingsSuccess] = await Promise.all([
@@ -1658,6 +1707,8 @@ app.registerExtension({
                                     autocomplete_max_results: newAutocompleteMaxResults,
                                     selected_categories: newSelectedCategories,
                                     multi_select_enabled: newMultiSelectEnabled,
+                                    preload_count: newPreloadCount,
+                                    gelbooru_dedup_mode: newGelbooruDedupMode,
                                     source_site: uiSettings.source_site || "danbooru",
                                     gelbooru_display_all_site_content: uiSettings.gelbooru_display_all_site_content || false
                                 })
@@ -1673,6 +1724,8 @@ app.registerExtension({
                                 uiSettings.autocomplete_max_results = newAutocompleteMaxResults;
                                 uiSettings.selected_categories = newSelectedCategories;
                                 uiSettings.multi_select_enabled = newMultiSelectEnabled;
+                                uiSettings.preload_count = newPreloadCount;
+                                uiSettings.gelbooru_dedup_mode = newGelbooruDedupMode;
                                 uiSettings.source_site = sourceSelect.value || uiSettings.source_site || "danbooru";
                                 await updateSelectionData();
 
@@ -1681,7 +1734,6 @@ app.registerExtension({
 
                                 // 重新过滤当前已加载的帖子
                                 const filteredPosts = posts.filter(post => !isPostFiltered(post));
-                                posts = filteredPosts; // 同步数组，保证预加载缓冲计算准确
                                 imageGrid.innerHTML = "";
                                 filteredPosts.forEach(renderPost);
 
@@ -2058,6 +2110,8 @@ app.registerExtension({
                     multi_select_enabled: false,
                     source_site: "danbooru",
                     gelbooru_display_all_site_content: false,
+                    preload_count: 40,
+                    gelbooru_dedup_mode: "off",
                     formatting: {
                         escapeBrackets: true,
                         replaceUnderscores: true,
@@ -2077,6 +2131,8 @@ app.registerExtension({
                                 multi_select_enabled: data.settings.multi_select_enabled || false,
                                 source_site: data.settings.source_site || "danbooru",
                                 gelbooru_display_all_site_content: data.settings.gelbooru_display_all_site_content || false,
+                                preload_count: data.settings.preload_count || 40,
+                                gelbooru_dedup_mode: data.settings.gelbooru_dedup_mode || "off",
                                 formatting: data.settings.formatting || { escapeBrackets: true, replaceUnderscores: true }
                             };
                         }
@@ -2397,7 +2453,7 @@ app.registerExtension({
                     }).join(' ');
                 };
 
-                const fetchAndRender = async (reset = false, isPreload = false, preloadAmount = 0) => {
+                const fetchAndRender = async (reset = false) => {
                     if (isLoading) {
                         return;
                     }
@@ -2405,23 +2461,18 @@ app.registerExtension({
                         return;
                     }
                     isLoading = true;
+                    refreshButton.classList.add("loading");
+                    refreshButton.disabled = true;
 
-                    // 只有非预加载时才显示加载动画（预加载是后台静默补缓冲）
-                    if (!isPreload) {
-                        refreshButton.classList.add("loading");
-                        refreshButton.disabled = true;
-
-                        const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
-                        if (!loadingIndicator) {
-                            imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
-                        }
+                    const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
+                    if (!loadingIndicator) {
+                        imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
                     }
 
                     if (reset) {
                         currentPage = filterState.startPage || 1;
-                        lastPostId = null; // 重置游标
-                        initialLoadComplete = false; // 重置首次加载标记
-                        seenPostIds.clear(); // 重置去重集合
+                        lastPostId = null;        // 重置游标
+                        seenPostIds.clear();      // 重置去重集合
                         posts = [];
                         endOfResults = false;
                         imageGrid.innerHTML = "";
@@ -2432,18 +2483,18 @@ app.registerExtension({
                     const isNetworkConnected = await checkNetworkStatus();
 
                     if (!isNetworkConnected) {
-                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");
-                        if (!isPreload) {
+                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到服务器");  // 仅在控制台记录
+                        // 仅在首次加载(reset)时用整屏错误提示；滚动加载(reset=false)失败时
+                        // 不清空已加载内容，静默返回，下次滚动再试，避免"频繁报错+整屏重载"。
+                        if (reset) {
                             imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
                         }
                         isLoading = false;
-                        if (!isPreload) {
-                            refreshButton.classList.remove("loading");
-                            refreshButton.disabled = false;
-                            const indicator = imageGrid.querySelector('.danbooru-loading');
-                            if (indicator) {
-                                indicator.remove();
-                            }
+                        refreshButton.classList.remove("loading");
+                        refreshButton.disabled = false;
+                        const indicator = imageGrid.querySelector('.danbooru-loading');
+                        if (indicator) {
+                            indicator.remove();
                         }
                         return;
                     } else {
@@ -2458,9 +2509,10 @@ app.registerExtension({
                         const tagCount = tags.length;
 
                         // 如果超过2个tag，给用户提示
-                        if (tagCount > 2 && !isPreload) {
+                        if (tagCount > 2) {
                             showTagHint('搜索只考虑前两个tag，第三个及后续tag将被忽略', false);
-                        } else if (!isPreload) {
+                        } else {
+                            // 清除之前的提示
                             clearTagHint();
                         }
 
@@ -2477,138 +2529,82 @@ app.registerExtension({
                         const selectedRatings = getSelectedRatings();
                         const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
                         const ratingForServer = sendAll ? "" : selectedRatings.join(",");
+                        const params = new URLSearchParams({
+                            "source": uiSettings.source_site || "danbooru",
+                            "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
+                            "search[tags]": apiFormattedTags.trim(),
+                            "search[rating]": ratingForServer,
+                            limit: String(uiSettings.preload_count || 40),
+                            page: currentPage,
+                        });
 
-                        // 计算目标加载数量：
-                        // - 首次加载：先铺一屏(40) + 预加载缓冲，让用户一打开就有富余
-                        // - 预加载补充：只补指定的少量(滑一个补一张式的小批)
-                        // - 普通触底加载：一屏量
-                        let targetCount;
-                        if (!initialLoadComplete && !isPreload) {
-                            targetCount = 40 + (uiSettings.preload_count || 50);
-                        } else if (isPreload && preloadAmount > 0) {
-                            targetCount = preloadAmount;
-                        } else {
-                            targetCount = 40;
-                        }
-
-                        // 单次请求上限（未登录 Danbooru 每次最多 20）
-                        const MAX_PER_REQUEST = 20;
-                        let totalLoaded = 0;
-                        let consecutiveEmpty = 0; // 连续空结果计数，避免死循环
-
-                        // 循环请求直到达到目标数量或没有更多数据
-                        while (totalLoaded < targetCount && consecutiveEmpty < 3) {
-                            const remaining = targetCount - totalLoaded;
-                            const requestSize = Math.min(remaining, MAX_PER_REQUEST);
-
-                            const params = new URLSearchParams({
-                                "source": uiSettings.source_site || "danbooru",
-                                "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
-                                "search[tags]": apiFormattedTags.trim(),
-                                "search[rating]": ratingForServer,
-                                limit: requestSize.toString(),
-                                page: currentPage,
-                            });
-
-                            // 用 before_id 游标分页防重复（reset 后的第一次请求不带，从最新开始）
-                            if (lastPostId && !(reset && totalLoaded === 0)) {
+                        // 游标防重复：reset 后第一次不带（从最新开始）。
+                        // D 站默认排序始终用；G 站仅当 dedup 开关非 off 时用（后端会再校验密钥/排序）。
+                        if (lastPostId && !reset) {
+                            const src = uiSettings.source_site || "danbooru";
+                            const dedup = uiSettings.gelbooru_dedup_mode || "off";
+                            if (src === "danbooru" || (src === "gelbooru" && dedup !== "off")) {
                                 params.set("before_id", lastPostId);
                             }
-
-                            const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                            let newPosts = await response.json();
-
-                            if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
-
-                            // 没有更多数据了
-                            if (newPosts.length === 0) {
-                                endOfResults = true;
-                                if (reset && totalLoaded === 0 && !isPreload) {
-                                    imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
-                                }
-                                break;
-                            }
-
-                            // 评分过滤交给服务端，本地做文件类型/黑名单过滤 + id 去重兜底
-                            const filteredPosts = newPosts.filter(post => {
-                                if (isPostFiltered(post)) return false;
-                                if (seenPostIds.has(post.id)) return false; // 跨批次重复图，丢弃
-                                seenPostIds.add(post.id);
-                                return true;
-                            });
-
-                            // 更新游标（用原始返回的最后一张，保证游标连续推进，
-                            // 即使这批全被过滤，下一批也能接着往后取）
-                            lastPostId = newPosts[newPosts.length - 1].id;
-                            currentPage++;
-
-                            if (filteredPosts.length > 0) {
-                                posts.push(...filteredPosts);
-                                filteredPosts.forEach(renderPost);
-                                totalLoaded += filteredPosts.length;
-                                consecutiveEmpty = 0;
-                            } else {
-                                // 这一批全被过滤了，继续请求下一批
-                                consecutiveEmpty++;
-                            }
-
-                            // API 返回数量少于请求数量，说明已到结果尾部
-                            if (newPosts.length < requestSize) {
-                                endOfResults = true;
-                                break;
-                            }
                         }
 
-                        // 首次加载没有任何图片
-                        if (totalLoaded === 0 && reset && !isPreload) {
+                        const response = await fetch(`/danbooru_gallery/posts?${params}`);
+                        let newPosts = await response.json();
+
+                        if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
+
+                        // 评分过滤已交给服务端，本地只做文件类型/黑名单过滤
+                        const filteredPosts = newPosts.filter(post => !isPostFiltered(post));
+
+                        const filteredCount = newPosts.length - filteredPosts.length;
+
+                        // API returned nothing → no more pages. Flag it so scroll events stop
+                        // triggering fetches; otherwise the bottom-proximity check would keep
+                        // firing and walk off the end of the result set indefinitely.
+                        if (newPosts.length === 0) {
+                            endOfResults = true;
+                            if (reset) {
+                                imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
+                            }
+                            return;
+                        }
+
+                        if (filteredPosts.length === 0 && reset) {
                             imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
                             return;
                         }
 
-                        // 标记首次加载完成
-                        if (!initialLoadComplete && !isPreload && totalLoaded > 0) {
-                            initialLoadComplete = true;
+                        currentPage++;
+                        // 渲染前 id 去重兜底（防游标边界残留重复）
+                        const fresh = filteredPosts.filter(p => {
+                            if (seenPostIds.has(p.id)) return false;
+                            seenPostIds.add(p.id);
+                            return true;
+                        });
+                        // 游标用原始返回最后一张推进（即使本批被过滤光也连续）
+                        lastPostId = newPosts[newPosts.length - 1].id;
+                        posts.push(...fresh);
+                        fresh.forEach(renderPost);
+
+                        // Filter-cascade guard: if the blacklist/rating filter dropped every
+                        // post on this page, the grid didn't grow — the user's scroll is still
+                        // within the 400px bottom threshold, so the scroll listener would
+                        // re-fire immediately. Hold isLoading for ~1.5s (still inside the try
+                        // block, before the finally clears it) to space out these "auto-skip"
+                        // fetches.
+                        if (filteredPosts.length === 0 && !reset) {
+                            await new Promise(r => setTimeout(r, 1500));
                         }
 
                     } catch (e) {
-                        if (!isPreload) {
-                            imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
-                        }
+                        imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
                     } finally {
                         isLoading = false;
-                        if (!isPreload) {
-                            refreshButton.classList.remove("loading");
-                            refreshButton.disabled = false;
-                            const indicator = imageGrid.querySelector('.danbooru-loading');
-                            if (indicator) {
-                                indicator.remove();
-                            }
-                        }
-
-                        // 加载完成后检查是否还需要继续加载
-                        if (!endOfResults) {
-                            setTimeout(() => {
-                                if (isLoading) return;
-
-                                // 1. 接近底部 → 正常加载一屏
-                                if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
-                                    fetchAndRender(false);
-                                    return;
-                                }
-
-                                // 2. 缓冲不足 → 预加载补充（滑一个补一张的"补"在这里发生）
-                                if (initialLoadComplete) {
-                                    const targetBufferSize = uiSettings.preload_count || 50;
-                                    const scrollableHeight = imageGrid.scrollHeight - imageGrid.clientHeight;
-                                    const scrollRatio = scrollableHeight > 0 ? imageGrid.scrollTop / scrollableHeight : 0;
-                                    const viewedCount = Math.floor(scrollRatio * posts.length);
-                                    const remainingBuffer = posts.length - viewedCount;
-
-                                    if (remainingBuffer < targetBufferSize) {
-                                        fetchAndRender(false, true, 20);
-                                    }
-                                }
-                            }, 100);
+                        refreshButton.classList.remove("loading");
+                        refreshButton.disabled = false;
+                        const indicator = imageGrid.querySelector('.danbooru-loading');
+                        if (indicator) {
+                            indicator.remove();
                         }
                     }
                 };
@@ -3252,10 +3248,22 @@ app.registerExtension({
 
                     // Reserve grid space up-front from the post's real dimensions so the
                     // waterfall is stable before thumbnails finish loading.
+                    // G 站公开抓取返回 image_width/height=0，算不出 span；此时给一个保底高度，
+                    // 否则 wrapper 只占 grid-auto-rows(1px)，整个网格塌成一条线 →
+                    // 永远到不了"距底部 400px" → 滚动加载再也不触发。
+                    let reservedSpans = 0;
                     if (post.image_width && post.image_height) {
-                        const spans = computeSpanFromDims(post.image_width, post.image_height);
-                        if (spans > 0) wrapper.style.gridRowEnd = `span ${spans}`;
+                        reservedSpans = computeSpanFromDims(post.image_width, post.image_height);
                     }
+                    if (reservedSpans <= 0) {
+                        // 保底：按列宽估一个近似正方形高度（图片 onload 后 resizeGrid 会修正为真实高度）
+                        const colW = getColumnWidth();
+                        const cs = window.getComputedStyle(imageGrid);
+                        const rowGap = parseInt(cs.gridRowGap) || parseInt(cs.rowGap) || 5;
+                        const rowHeight = parseInt(cs.gridAutoRows) || 1;
+                        reservedSpans = colW > 0 ? Math.ceil((colW + rowGap) / (rowHeight + rowGap)) : 200;
+                    }
+                    if (reservedSpans > 0) wrapper.style.gridRowEnd = `span ${reservedSpans}`;
 
                     // 首次创建post元素时，将原始post数据添加到 originalPostCache
                     if (!originalPostCache[post.id]) {
@@ -3271,7 +3279,7 @@ app.registerExtension({
 
                     const img = $el("img", {
                         src: `/danbooru_gallery/image_proxy?url=${encodeURIComponent(previewUrl)}`,
-                        loading: "lazy",
+                        loading: "eager",
                         onload: scheduleResizeGrid,
                         onerror: () => { wrapper.style.display = 'none'; },
                         onclick: async (e) => {
@@ -3605,23 +3613,8 @@ app.registerExtension({
 
                 let scrollTimeout;
                 imageGrid.addEventListener("scroll", () => {
-                    if (!isLoading && !endOfResults) {
-                        // 触底 → 正常加载一屏
-                        if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
-                            fetchAndRender(false);
-                        } else if (initialLoadComplete) {
-                            // 缓冲不足 → 后台预加载补充（滑一个补一张：前方始终保留 preload_count 张未看过的图）
-                            const targetBufferSize = uiSettings.preload_count || 50;
-                            const scrollableHeight = imageGrid.scrollHeight - imageGrid.clientHeight;
-                            if (scrollableHeight > 0) {
-                                const scrollRatio = imageGrid.scrollTop / scrollableHeight;
-                                const viewedCount = Math.floor(scrollRatio * posts.length);
-                                const remainingBuffer = posts.length - viewedCount;
-                                if (remainingBuffer < targetBufferSize) {
-                                    fetchAndRender(false, true, 20);
-                                }
-                            }
-                        }
+                    if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
+                        fetchAndRender(false);
                     }
 
                     // Debounced scroll logic for page indicator

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -2543,7 +2543,7 @@ app.registerExtension({
                             "gelbooru_dedup_mode": dedup,
                             "search[tags]": apiFormattedTags.trim(),
                             "search[rating]": ratingForServer,
-                            limit: "40",
+                            limit: "42",
                             page: currentPage,
                         });
 

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -2537,13 +2537,17 @@ app.registerExtension({
                         const selectedRatings = getSelectedRatings();
                         const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
                         const ratingForServer = sendAll ? "" : selectedRatings.join(",");
+                        // 首次加载取 40 + preload_count（上限 200 API），续加载统一 42
+                        const loadLimit = reset
+                            ? Math.min(40 + (parseInt(uiSettings.preload_count, 10) || 40), 200)
+                            : 42;
                         const params = new URLSearchParams({
                             "source": src,
                             "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
                             "gelbooru_dedup_mode": dedup,
                             "search[tags]": apiFormattedTags.trim(),
                             "search[rating]": ratingForServer,
-                            limit: "42",
+                            limit: String(loadLimit),
                             page: currentPage,
                         });
 

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -196,7 +196,6 @@ app.registerExtension({
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
                 let lastPostId = null;            // D 站游标分页：上一批最后一张的 id
                 const seenPostIds = new Set();    // 渲染前 id 去重兜底
-                let fillAnchor = 0;               // G 站续拉锚点：本轮自该 posts 数起凑够 fillTarget
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -1483,6 +1482,7 @@ app.registerExtension({
                         'prompt': { title: t('promptSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>', elements: [filterSection] },
                         'ui': { title: t('uiSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>', elements: [autocompleteSection, tooltipSection, selectionModeSection] },
                         'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
+                        'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
                     };
 
                     const setActiveSection = (key) => {
@@ -2295,13 +2295,21 @@ app.registerExtension({
                             params.set("force_public_detail", "1");
                         }
                         const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        const data = await response.json();
-                        if (data && data.length > 0) {
+                        // 防御性解析：避免非 JSON 响应抛裸 JSON.parse 异常刷屏
+                        const rawText = await response.text();
+                        let data;
+                        try {
+                            data = JSON.parse(rawText);
+                        } catch (parseErr) {
+                            logger.warn(`[fetchOriginalPost] id=${postId} 响应非 JSON(status=${response.status})，跳过`);
+                            return null;
+                        }
+                        if (Array.isArray(data) && data.length > 0) {
                             return data[0];
                         }
                         return null;
                     } catch (error) {
-                        logger.error("Failed to fetch original post data:", error);
+                        logger.warn(`[fetchOriginalPost] id=${postId} 详情抓取失败:`, error?.message || error);
                         return null;
                     }
                 };
@@ -2454,25 +2462,17 @@ app.registerExtension({
                     }).join(' ');
                 };
 
-                const fetchAndRender = async (reset = false, isContinuation = false) => {
+                const fetchAndRender = async (reset = false) => {
                     if (isLoading) {
                         return;
                     }
                     if (endOfResults && !reset) {
                         return;
                     }
-                    // G 站公开列表页每页固定约 42 张，单次请求凑不满较大的 preload_count。
-                    // 续拉机制：拿完一页后若本轮累计不足 fillTarget 且未到底，自动续拉下一页。
-                    // （D 站一次请求即可拿满 limit；G 站游标模式靠 lastPostId 翻批；均不续拉。）
                     const src = uiSettings.source_site || "danbooru";
-                    const dedupMode = uiSettings.gelbooru_dedup_mode || "off";
-                    const needAutoFill = (src === "gelbooru" && dedupMode === "off");
-                    const fillTarget = needAutoFill ? (parseInt(uiSettings.preload_count, 10) || 40) : 0;
-                    // 续拉锚点：新一轮（reset 或用户滚动触发的非续拉调用）以当前 posts 数为基准，
-                    // 续拉到 posts 比基准多出 fillTarget 张为止。续拉调用(isContinuation)沿用旧基准。
-                    if (!isContinuation) {
-                        fillAnchor = reset ? 0 : posts.length;
-                    }
+                    // G 站游标模式（防重复开启）：分页靠 id:<X 推进，pid 必须恒为 0，
+                    // 否则 page 偏移与游标双重推进会跳图。此时翻批不递增 currentPage。
+                    const gelbooruCursorMode = (src === "gelbooru" && (uiSettings.gelbooru_dedup_mode || "off") !== "off");
                     isLoading = true;
                     refreshButton.classList.add("loading");
                     refreshButton.disabled = true;
@@ -2562,9 +2562,25 @@ app.registerExtension({
                         }
 
                         const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        let newPosts = await response.json();
+                        // 防御性解析：后端偶发返回非 JSON（错误页/半截响应）时，
+                        // 不让裸 JSON.parse 异常冒泡导致整屏清空。
+                        let newPosts;
+                        let parseFailed = false;
+                        try {
+                            const rawText = await response.text();
+                            newPosts = JSON.parse(rawText);
+                        } catch (parseErr) {
+                            logger.warn(`[fetchAndRender] 响应解析失败(status=${response.status})，本次跳过:`, parseErr?.message || parseErr);
+                            parseFailed = true;
+                            newPosts = [];
+                        }
 
-                        if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
+                        if (!Array.isArray(newPosts)) newPosts = [];
+
+                        // 解析失败：不标记到底（可能只是偶发），保留已有内容，静默返回等下次触发
+                        if (parseFailed) {
+                            return;
+                        }
 
                         // 评分过滤已交给服务端，本地只做文件类型/黑名单过滤
                         const filteredPosts = newPosts.filter(post => !isPostFiltered(post));
@@ -2587,7 +2603,10 @@ app.registerExtension({
                             return;
                         }
 
-                        currentPage++;
+                        // 游标模式靠 id:<X 推进，pid 须恒为 0，不递增 page；其余模式正常翻页
+                        if (!gelbooruCursorMode) {
+                            currentPage++;
+                        }
                         // 渲染前 id 去重兜底（防游标边界残留重复）
                         const fresh = filteredPosts.filter(p => {
                             if (seenPostIds.has(p.id)) return false;
@@ -2598,6 +2617,14 @@ app.registerExtension({
                         lastPostId = newPosts[newPosts.length - 1].id;
                         posts.push(...fresh);
                         fresh.forEach(renderPost);
+
+                        // 防无限补货：本页返回了数据，但去重后 0 张新增（全是已见过的）。
+                        // 说明分页失效或到底（如 Gelbooru 空标签浏览时 pid 偏移无效，每页返回同样内容）。
+                        // 标记到底，停止后续补货，避免无限翻页空转。
+                        if (fresh.length === 0 && newPosts.length > 0 && !reset) {
+                            endOfResults = true;
+                            logger.warn(`[fetchAndRender] 本页 ${newPosts.length} 张全是重复，判定到底/分页失效，停止加载`);
+                        }
 
                         // Filter-cascade guard: if the blacklist/rating filter dropped every
                         // post on this page, the grid didn't grow — the user's scroll is still
@@ -2610,7 +2637,13 @@ app.registerExtension({
                         }
 
                     } catch (e) {
-                        imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
+                        // 仅首次加载(reset)时用整屏错误提示；滚动/续拉失败时保留已加载内容，
+                        // 不清屏（单次请求失败不该抹掉已经看到的图）。
+                        if (reset) {
+                            imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
+                        } else {
+                            logger.warn('[fetchAndRender] 加载失败，保留已有内容:', e?.message || e);
+                        }
                     } finally {
                         isLoading = false;
                         refreshButton.classList.remove("loading");
@@ -2621,13 +2654,27 @@ app.registerExtension({
                         }
                     }
 
-                    // G 站续拉：本轮（自 fillAnchor 起）累计不足 fillTarget 且未到底，自动拉下一页。
-                    // 条件含 posts.length > fillAnchor（确有进展），避免出错时无限重试。
-                    if (needAutoFill && !endOfResults &&
-                        posts.length > fillAnchor &&
-                        (posts.length - fillAnchor) < fillTarget) {
-                        // 异步触发续拉，让出调用栈（避免深递归）；isLoading 已在 finally 释放
-                        setTimeout(() => fetchAndRender(false, true), 0);
+                    // 加载完一页后，检查缓冲是否仍不足（前方未看的图 < preload_count），
+                    // 不足则继续补——渐进式补货，每次补一页，直到缓冲满或到底。
+                    maybeLoadMore();
+                };
+
+                // 统一的缓冲补货：估算"前方未看过的图片数"，不足 preload_count 就再加载一页。
+                // 两站、两档共用。reset 后首屏、滚动、每次加载完成都会调它。
+                const maybeLoadMore = () => {
+                    if (isLoading || endOfResults) return;
+                    const bufferTarget = parseInt(uiSettings.preload_count, 10) || 40;
+                    // 估算已浏览到的张数：按滚动位置比例 * 总数。grid 高度为 0（首屏未铺开）时按已看 0 处理。
+                    const scrollH = imageGrid.scrollHeight;
+                    let viewedCount = 0;
+                    if (scrollH > 0) {
+                        const viewedRatio = Math.min(1, (imageGrid.scrollTop + imageGrid.clientHeight) / scrollH);
+                        viewedCount = Math.floor(posts.length * viewedRatio);
+                    }
+                    const aheadBuffer = posts.length - viewedCount;  // 前方未看过的张数
+                    if (aheadBuffer < bufferTarget) {
+                        // 异步触发，让出调用栈避免深递归；isLoading 已释放
+                        setTimeout(() => fetchAndRender(false), 0);
                     }
                 };
 
@@ -3635,6 +3682,9 @@ app.registerExtension({
 
                 let scrollTimeout;
                 imageGrid.addEventListener("scroll", () => {
+                    // 滚动消耗了前方缓冲 → 检查是否需要补货（维持前方 preload_count 张未看）。
+                    // 同时保留"接近底部"作为兜底触发（缓冲估算在 0 尺寸图下可能偏差）。
+                    maybeLoadMore();
                     if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
                         fetchAndRender(false);
                     }

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -187,6 +187,9 @@ app.registerExtension({
                 let globalTooltip, globalTooltipTimeout;
                 let currentTooltipId = 0; // 用于追踪当前活动的tooltip请求
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
+                let lastPostId = null; // 游标分页：最后一张图的 id，下次请求传 before_id 防重复
+                let initialLoadComplete = false; // 首次加载（含预加载缓冲）是否完成
+                const seenPostIds = new Set(); // 跨批次去重兜底，防止任何重复图渲染
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -1678,6 +1681,7 @@ app.registerExtension({
 
                                 // 重新过滤当前已加载的帖子
                                 const filteredPosts = posts.filter(post => !isPostFiltered(post));
+                                posts = filteredPosts; // 同步数组，保证预加载缓冲计算准确
                                 imageGrid.innerHTML = "";
                                 filteredPosts.forEach(renderPost);
 
@@ -2393,7 +2397,7 @@ app.registerExtension({
                     }).join(' ');
                 };
 
-                const fetchAndRender = async (reset = false) => {
+                const fetchAndRender = async (reset = false, isPreload = false, preloadAmount = 0) => {
                     if (isLoading) {
                         return;
                     }
@@ -2401,16 +2405,23 @@ app.registerExtension({
                         return;
                     }
                     isLoading = true;
-                    refreshButton.classList.add("loading");
-                    refreshButton.disabled = true;
 
-                    const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
-                    if (!loadingIndicator) {
-                        imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
+                    // 只有非预加载时才显示加载动画（预加载是后台静默补缓冲）
+                    if (!isPreload) {
+                        refreshButton.classList.add("loading");
+                        refreshButton.disabled = true;
+
+                        const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
+                        if (!loadingIndicator) {
+                            imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
+                        }
                     }
 
                     if (reset) {
                         currentPage = filterState.startPage || 1;
+                        lastPostId = null; // 重置游标
+                        initialLoadComplete = false; // 重置首次加载标记
+                        seenPostIds.clear(); // 重置去重集合
                         posts = [];
                         endOfResults = false;
                         imageGrid.innerHTML = "";
@@ -2421,16 +2432,18 @@ app.registerExtension({
                     const isNetworkConnected = await checkNetworkStatus();
 
                     if (!isNetworkConnected) {
-                        // 网络连接失败，隐藏持久错误提示 - 本小姐才不想看到这些烦人的提示呢！
-                        // showError('网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接', true);
-                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");  // 仅在控制台记录
-                        imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
+                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");
+                        if (!isPreload) {
+                            imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
+                        }
                         isLoading = false;
-                        refreshButton.classList.remove("loading");
-                        refreshButton.disabled = false;
-                        const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) {
-                            indicator.remove();
+                        if (!isPreload) {
+                            refreshButton.classList.remove("loading");
+                            refreshButton.disabled = false;
+                            const indicator = imageGrid.querySelector('.danbooru-loading');
+                            if (indicator) {
+                                indicator.remove();
+                            }
                         }
                         return;
                     } else {
@@ -2445,10 +2458,9 @@ app.registerExtension({
                         const tagCount = tags.length;
 
                         // 如果超过2个tag，给用户提示
-                        if (tagCount > 2) {
+                        if (tagCount > 2 && !isPreload) {
                             showTagHint('搜索只考虑前两个tag，第三个及后续tag将被忽略', false);
-                        } else {
-                            // 清除之前的提示
+                        } else if (!isPreload) {
                             clearTagHint();
                         }
 
@@ -2465,64 +2477,138 @@ app.registerExtension({
                         const selectedRatings = getSelectedRatings();
                         const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
                         const ratingForServer = sendAll ? "" : selectedRatings.join(",");
-                        const params = new URLSearchParams({
-                            "source": uiSettings.source_site || "danbooru",
-                            "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
-                            "search[tags]": apiFormattedTags.trim(),
-                            "search[rating]": ratingForServer,
-                            limit: "40",
-                            page: currentPage,
-                        });
 
-                        const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        let newPosts = await response.json();
-
-                        if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
-
-                        // 评分过滤已交给服务端，本地只做文件类型/黑名单过滤
-                        const filteredPosts = newPosts.filter(post => !isPostFiltered(post));
-
-                        const filteredCount = newPosts.length - filteredPosts.length;
-
-                        // API returned nothing → no more pages. Flag it so scroll events stop
-                        // triggering fetches; otherwise the bottom-proximity check would keep
-                        // firing and walk off the end of the result set indefinitely.
-                        if (newPosts.length === 0) {
-                            endOfResults = true;
-                            if (reset) {
-                                imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
-                            }
-                            return;
+                        // 计算目标加载数量：
+                        // - 首次加载：先铺一屏(40) + 预加载缓冲，让用户一打开就有富余
+                        // - 预加载补充：只补指定的少量(滑一个补一张式的小批)
+                        // - 普通触底加载：一屏量
+                        let targetCount;
+                        if (!initialLoadComplete && !isPreload) {
+                            targetCount = 40 + (uiSettings.preload_count || 50);
+                        } else if (isPreload && preloadAmount > 0) {
+                            targetCount = preloadAmount;
+                        } else {
+                            targetCount = 40;
                         }
 
-                        if (filteredPosts.length === 0 && reset) {
+                        // 单次请求上限（未登录 Danbooru 每次最多 20）
+                        const MAX_PER_REQUEST = 20;
+                        let totalLoaded = 0;
+                        let consecutiveEmpty = 0; // 连续空结果计数，避免死循环
+
+                        // 循环请求直到达到目标数量或没有更多数据
+                        while (totalLoaded < targetCount && consecutiveEmpty < 3) {
+                            const remaining = targetCount - totalLoaded;
+                            const requestSize = Math.min(remaining, MAX_PER_REQUEST);
+
+                            const params = new URLSearchParams({
+                                "source": uiSettings.source_site || "danbooru",
+                                "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
+                                "search[tags]": apiFormattedTags.trim(),
+                                "search[rating]": ratingForServer,
+                                limit: requestSize.toString(),
+                                page: currentPage,
+                            });
+
+                            // 用 before_id 游标分页防重复（reset 后的第一次请求不带，从最新开始）
+                            if (lastPostId && !(reset && totalLoaded === 0)) {
+                                params.set("before_id", lastPostId);
+                            }
+
+                            const response = await fetch(`/danbooru_gallery/posts?${params}`);
+                            let newPosts = await response.json();
+
+                            if (!Array.isArray(newPosts)) throw new Error("API did not return a valid list of posts.");
+
+                            // 没有更多数据了
+                            if (newPosts.length === 0) {
+                                endOfResults = true;
+                                if (reset && totalLoaded === 0 && !isPreload) {
+                                    imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
+                                }
+                                break;
+                            }
+
+                            // 评分过滤交给服务端，本地做文件类型/黑名单过滤 + id 去重兜底
+                            const filteredPosts = newPosts.filter(post => {
+                                if (isPostFiltered(post)) return false;
+                                if (seenPostIds.has(post.id)) return false; // 跨批次重复图，丢弃
+                                seenPostIds.add(post.id);
+                                return true;
+                            });
+
+                            // 更新游标（用原始返回的最后一张，保证游标连续推进，
+                            // 即使这批全被过滤，下一批也能接着往后取）
+                            lastPostId = newPosts[newPosts.length - 1].id;
+                            currentPage++;
+
+                            if (filteredPosts.length > 0) {
+                                posts.push(...filteredPosts);
+                                filteredPosts.forEach(renderPost);
+                                totalLoaded += filteredPosts.length;
+                                consecutiveEmpty = 0;
+                            } else {
+                                // 这一批全被过滤了，继续请求下一批
+                                consecutiveEmpty++;
+                            }
+
+                            // API 返回数量少于请求数量，说明已到结果尾部
+                            if (newPosts.length < requestSize) {
+                                endOfResults = true;
+                                break;
+                            }
+                        }
+
+                        // 首次加载没有任何图片
+                        if (totalLoaded === 0 && reset && !isPreload) {
                             imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
                             return;
                         }
 
-                        currentPage++;
-                        posts.push(...filteredPosts);
-                        filteredPosts.forEach(renderPost);
-
-                        // Filter-cascade guard: if the blacklist/rating filter dropped every
-                        // post on this page, the grid didn't grow — the user's scroll is still
-                        // within the 400px bottom threshold, so the scroll listener would
-                        // re-fire immediately. Hold isLoading for ~1.5s (still inside the try
-                        // block, before the finally clears it) to space out these "auto-skip"
-                        // fetches.
-                        if (filteredPosts.length === 0 && !reset) {
-                            await new Promise(r => setTimeout(r, 1500));
+                        // 标记首次加载完成
+                        if (!initialLoadComplete && !isPreload && totalLoaded > 0) {
+                            initialLoadComplete = true;
                         }
 
                     } catch (e) {
-                        imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
+                        if (!isPreload) {
+                            imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
+                        }
                     } finally {
                         isLoading = false;
-                        refreshButton.classList.remove("loading");
-                        refreshButton.disabled = false;
-                        const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) {
-                            indicator.remove();
+                        if (!isPreload) {
+                            refreshButton.classList.remove("loading");
+                            refreshButton.disabled = false;
+                            const indicator = imageGrid.querySelector('.danbooru-loading');
+                            if (indicator) {
+                                indicator.remove();
+                            }
+                        }
+
+                        // 加载完成后检查是否还需要继续加载
+                        if (!endOfResults) {
+                            setTimeout(() => {
+                                if (isLoading) return;
+
+                                // 1. 接近底部 → 正常加载一屏
+                                if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
+                                    fetchAndRender(false);
+                                    return;
+                                }
+
+                                // 2. 缓冲不足 → 预加载补充（滑一个补一张的"补"在这里发生）
+                                if (initialLoadComplete) {
+                                    const targetBufferSize = uiSettings.preload_count || 50;
+                                    const scrollableHeight = imageGrid.scrollHeight - imageGrid.clientHeight;
+                                    const scrollRatio = scrollableHeight > 0 ? imageGrid.scrollTop / scrollableHeight : 0;
+                                    const viewedCount = Math.floor(scrollRatio * posts.length);
+                                    const remainingBuffer = posts.length - viewedCount;
+
+                                    if (remainingBuffer < targetBufferSize) {
+                                        fetchAndRender(false, true, 20);
+                                    }
+                                }
+                            }, 100);
                         }
                     }
                 };
@@ -3519,8 +3605,23 @@ app.registerExtension({
 
                 let scrollTimeout;
                 imageGrid.addEventListener("scroll", () => {
-                    if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
-                        fetchAndRender(false);
+                    if (!isLoading && !endOfResults) {
+                        // 触底 → 正常加载一屏
+                        if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
+                            fetchAndRender(false);
+                        } else if (initialLoadComplete) {
+                            // 缓冲不足 → 后台预加载补充（滑一个补一张：前方始终保留 preload_count 张未看过的图）
+                            const targetBufferSize = uiSettings.preload_count || 50;
+                            const scrollableHeight = imageGrid.scrollHeight - imageGrid.clientHeight;
+                            if (scrollableHeight > 0) {
+                                const scrollRatio = imageGrid.scrollTop / scrollableHeight;
+                                const viewedCount = Math.floor(scrollRatio * posts.length);
+                                const remainingBuffer = posts.length - viewedCount;
+                                if (remainingBuffer < targetBufferSize) {
+                                    fetchAndRender(false, true, 20);
+                                }
+                            }
+                        }
                     }
 
                     // Debounced scroll logic for page indicator

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -1,5520 +1,2107 @@
-import { app } from "/scripts/app.js";
-import { $el } from "/scripts/ui.js";
-import { globalAutocompleteCache } from "../global/autocomplete_cache.js";
-import { AutocompleteUI } from "../global/autocomplete_ui.js";
-import { toastManagerProxy } from "../global/toast_manager.js";
-import { globalMultiLanguageManager } from "../global/multi_language.js";
-
-import { createLogger, loggerClient } from '../global/logger_client.js';
-
-// 创建logger实例
-const logger = createLogger('danbooru_gallery');
-
-app.registerExtension({
-    name: "Comfy.DanbooruGallery",
-    async beforeRegisterNodeDef(nodeType, nodeData) {
-        if (nodeData.name === "DanbooruGalleryNode") {
-            // 使用全局多语言系统（danbooru命名空间）
-            const t = (key) => globalMultiLanguageManager.t(`danbooru.${key}`);
-
-            // 本地存储函数
-            const saveToLocalStorage = (key, value) => {
-                try {
-                    localStorage.setItem(`danbooru_gallery_${key}`, JSON.stringify(value));
-                } catch (e) {
-                    logger.warn(`[Danbooru Gallery] Failed to save to localStorage: ${key}`, e);
-                }
-            };
-
-            const loadFromLocalStorage = (key, defaultValue) => {
-                try {
-                    const item = localStorage.getItem(`danbooru_gallery_${key}`);
-                    return item ? JSON.parse(item) : defaultValue;
-                } catch (e) {
-                    logger.warn(`[Danbooru Gallery] Failed to load from localStorage: ${key}`, e);
-                    return defaultValue;
-                }
-            };
-
-            // 比较两个标签字符串是否相同（忽略标签顺序）
-            const compareTagStrings = (str1, str2) => {
-                // 处理null、undefined和空字符串的情况
-                if (!str1 && !str2) return true;
-                if (!str1 || !str2) return false;
-
-                // 分割、排序、比较
-                const tags1 = str1.trim().split(/\s+/).filter(t => t).sort();
-                const tags2 = str2.trim().split(/\s+/).filter(t => t).sort();
-
-                // 数量不同直接返回false
-                if (tags1.length !== tags2.length) return false;
-
-                // 逐个比较标签
-                return tags1.every((tag, index) => tag === tags2[index]);
-            };
-
-            const onNodeCreated = nodeType.prototype.onNodeCreated;
-            nodeType.prototype.onNodeCreated = function () {
-                onNodeCreated?.apply(this, arguments);
-                this.setSize([780, 938]);
-
-                // 保存节点实例引用
-                const nodeInstance = this;
-
-                // 存储每张图片的原始标签数据，用于重置和编辑状态判断
-                const originalPostCache = {};
-
-                // 创建隐藏的 selection_data widget（仍保留用于兼容/回退）
-                const selectionWidget = this.addWidget("text", "selection_data", JSON.stringify({}), () => { }, {
-                    serialize: true // 确保序列化
-                });
-
-                // 确保widget不可见
-                if (selectionWidget) {
-                    selectionWidget.computeSize = () => [0, -4]; // 返回0宽度和负高度来隐藏
-                    selectionWidget.draw = () => { }; // 覆盖draw方法，不绘制任何内容
-                    selectionWidget.type = "hidden"; // 设置为隐藏类型
-                    Object.defineProperty(selectionWidget, 'hidden', { value: true, writable: false }); // 标记为隐藏
-                }
-
-                // 创建隐藏的 filter_data widget
-                const filterWidget = this.addWidget("text", "filter_data", JSON.stringify({ startTime: null, endTime: null, startPage: null }), () => { }, {
-                    serialize: true // 确保序列化
-                });
-
-                // 确保widget不可见
-                if (filterWidget) {
-                    filterWidget.computeSize = () => [0, -4];
-                    filterWidget.draw = () => { };
-                    filterWidget.type = "hidden";
-                    Object.defineProperty(filterWidget, 'hidden', { value: true, writable: false });
-                }
-
-                const container = $el("div.danbooru-gallery");
-                container.style.boxSizing = "border-box";
-
-                // 添加错误显示区域
-                const errorDisplay = $el("div.danbooru-error-display", {
-                    style: {
-                        display: "none",
-                        color: "#dc3545",
-                        marginBottom: "10px",
-                        padding: "8px 12px",
-                        border: "1px solid #dc3545",
-                        borderRadius: "4px",
-                        backgroundColor: "rgba(220, 53, 69, 0.1)",
-                        fontSize: "14px",
-                        fontWeight: "500"
-                    }
-                });
-                container.appendChild(errorDisplay);
-
-                // 添加tag提示显示区域
-                const tagHintDisplay = $el("div.danbooru-tag-hint-display", {
-                    style: {
-                        display: "none",
-                        color: "#17a2b8",
-                        marginBottom: "5px",
-                        padding: "6px 10px",
-                        border: "1px solid #17a2b8",
-                        borderRadius: "4px",
-                        backgroundColor: "rgba(23, 162, 184, 0.1)",
-                        fontSize: "13px",
-                        fontWeight: "500"
-                    }
-                });
-                container.appendChild(tagHintDisplay);
-
-                // 显示错误信息的函数
-                const showError = (message, persistent = false, anchorElement = null) => {
-                    showToast(message, 'error');
-                };
-
-                // 清除错误信息的函数
-                const clearError = () => {
-                    errorDisplay.style.display = "none";
-                };
-
-                // 显示tag提示信息的函数
-                const showTagHint = (message, persistent = false) => {
-                    tagHintDisplay.textContent = message;
-                    tagHintDisplay.style.display = "block";
-                    if (!persistent) {
-                        // 3秒后自动隐藏
-                        setTimeout(() => {
-                            tagHintDisplay.style.display = "none";
-                        }, 3000);
-                    }
-                };
-
-                // 清除tag提示信息的函数
-                const clearTagHint = () => {
-                    tagHintDisplay.style.display = "none";
-                };
-
-                // 检查网络连接状态（30s TTL：上次成功且 30s 内则跳过完整网络往返）
-                const NETWORK_CHECK_TTL = 30000;
-                const checkNetworkStatus = async () => {
-                    if (networkStatus.connected && networkStatus.lastChecked &&
-                        (Date.now() - networkStatus.lastChecked) < NETWORK_CHECK_TTL) {
-                        return true;
-                    }
-                    try {
-                        const source = uiSettings.source_site || "danbooru";
-                        const response = await fetch(`/danbooru_gallery/check_network?source=${encodeURIComponent(source)}`);
-                        const data = await response.json();
-                        const isConnected = data.success && data.connected;
-                        const now = Date.now();
-
-                        // 更新网络状态
-                        networkStatus.connected = isConnected;
-                        networkStatus.lastChecked = now;
-
-                        return isConnected;
-                    } catch (e) {
-                        logger.warn('网络检测失败:', e);
-                        networkStatus.connected = false;
-                        networkStatus.lastChecked = Date.now();
-                        return false;
-                    }
-                };
-
-                this.addDOMWidget("danbooru_gallery_widget", "div", container, {
-                    onDraw: () => { }
-                });
-
-
-                // 确保在 widget 渲染后调整大小
-                setTimeout(() => {
-                    this.onResize(this.size);
-                }, 10);
-
-                let globalTooltip, globalTooltipTimeout;
-                let currentTooltipId = 0; // 用于追踪当前活动的tooltip请求
-                let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
-                let lastPostId = null;
-                let scrollAnchorPostId = null;
-                const seenPostIds = new Set();
-                let selectionQueueId = 0; // FIFO 队列唯一 ID 计数器
-                let filterState = { startTime: null, endTime: null, startPage: null };
-                let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
-                let userFavorites = []; // 用户收藏列表，确保字符串
-                let networkStatus = { connected: true, lastChecked: 0 }; // 网络状态跟踪
-                let previousSearchValue = ""; // 跟踪搜索框之前的值，用于检测清空操作
-                let temporaryTagEdits = {}; // Keyed by post.id
-
-                // 用户认证管理功能
-                const loadUserAuth = async () => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/user_auth');
-                        const data = await response.json();
-                        userAuth = data;
-                        return data;
-                    } catch (e) {
-                        logger.warn("加载用户认证信息失败:", e);
-                        userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false };
-                        return userAuth;
-                    }
-                };
-
-                const saveUserAuth = async (username, api_key, gelbooru_user_id = "", gelbooru_api_key = "") => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/user_auth', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({ username: username, api_key: api_key, gelbooru_user_id, gelbooru_api_key })
-                        });
-                        const data = await response.json();
-                        if (data.success) {
-                            userAuth = {
-                                username,
-                                api_key,
-                                has_auth: Boolean(username && api_key),
-                                gelbooru_user_id,
-                                gelbooru_api_key,
-                                gelbooru_has_auth: Boolean(gelbooru_user_id && gelbooru_api_key)
-                            };
-                        }
-                        return data;
-                    } catch (e) {
-                        logger.warn("保存用户认证信息失败:", e);
-                        return { success: false, error: "网络错误" };
-                    }
-                };
-
-                // 显示提示消息功能
-                const showToast = (message, type = 'info', anchorElement = null) => {
-                    // 使用全局toast管理器，并根据类型设置对应的等级
-                    const toastLevel = getToastLevel(type);
-                    const options = anchorElement ? { targetElement: anchorElement } : {};
-
-                    toastManagerProxy.showToast(message, toastLevel, 3000, options);
-                };
-
-                const currentSource = () => uiSettings.source_site || "danbooru";
-                const hasFavoriteAuth = () => (
-                    currentSource() === "gelbooru"
-                        ? Boolean(userAuth.gelbooru_has_auth)
-                        : Boolean(userAuth.has_auth)
-                );
-                const currentFavoriteTag = () => (
-                    currentSource() === "gelbooru"
-                        ? `fav:${userAuth.gelbooru_user_id || ""}`
-                        : `ordfav:${userAuth.username || ""}`
-                );
-
-                const getToastLevel = (type) => {
-                    // 将toast类型映射到全局toast管理器的等级
-                    const levelMap = {
-                        'success': 'success',
-                        'error': 'error',
-                        'warning': 'warning',
-                        'info': 'info'
-                    };
-                    return levelMap[type] || 'info';
-                };
-
-                // 收藏管理功能
-                const addToFavorites = async (postId, button = null) => {
-                    if (!hasFavoriteAuth()) {
-                        showToast(t('authRequired'), 'warning');
-                        return { success: false, error: t('authRequired') };
-                    }
-
-                    // 显示加载状态
-                    if (button) {
-                        button.disabled = true;
-                        const originalHTML = button.innerHTML;
-                        button.innerHTML = '<div class="spinner"></div>';
-                        button.dataset.originalHTML = originalHTML;
-                    }
-
-                    try {
-                        const response = await fetch('/danbooru_gallery/favorites/add', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({ post_id: postId, source: currentSource() })
-                        });
-                        const data = await response.json();
-
-                        // 恢复按钮状态
-                        if (button) {
-                            button.disabled = false;
-                            if (data.success || data.message === "已收藏，无需重复操作") {
-                                button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="#DC3545" stroke="#DC3545" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-                                </svg>`;
-                                button.title = t('unfavorite');
-                                button.classList.add('favorited');
-                                if (!userFavorites.includes(String(postId))) {
-                                    userFavorites.push(String(postId));
-                                }
-                                // 显示收藏成功提示
-                                showToast(t('favorite') + '成功', 'success', button);
-                            } else {
-                                button.innerHTML = button.dataset.originalHTML || originalHTML;
-                            }
-                            delete button.dataset.originalHTML;
-                        }
-
-                        if (!data.success) {
-                            let errorMsg = data.error || "未知错误";
-                            if (data.error.includes("网络错误")) {
-                                showError(`${errorMsg} - 请检查网络连接`);
-                            } else if (data.error.includes("认证") || data.error.includes("401")) {
-                                errorMsg = `${errorMsg}\n\n${t('authRequired')}`;
-                                if (confirm(errorMsg + "\n\n是否打开设置？")) {
-                                    showSettingsDialog();
-                                }
-                            } else if (data.error.includes("Rate Limited") || data.error.includes("429")) {
-                                showError(`${errorMsg} - 请稍后重试`);
-                            } else {
-                                showError(errorMsg);
-                            }
-                        }
-
-                        return data;
-                    } catch (e) {
-                        logger.warn("添加收藏失败:", e);
-                        showError(`网络错误 - 无法连接到${currentSource() === "gelbooru" ? "Gelbooru" : "Danbooru"}服务器`);
-                        if (button) {
-                            button.disabled = false;
-                            button.innerHTML = button.dataset.originalHTML || '<svg>...</svg>';  // 恢复
-                            delete button.dataset.originalHTML;
-                        }
-                        return { success: false, error: "网络错误" };
-                    }
-                };
-
-                const removeFromFavorites = async (postId, button = null) => {
-                    if (!hasFavoriteAuth()) {
-                        showToast(t('authRequired'), 'warning');
-                        return { success: false, error: t('authRequired') };
-                    }
-
-                    // 显示加载状态
-                    if (button) {
-                        button.disabled = true;
-                        const originalHTML = button.innerHTML;
-                        button.innerHTML = '<div class="spinner"></div>';
-                        button.dataset.originalHTML = originalHTML;
-                    }
-
-                    try {
-                        const response = await fetch('/danbooru_gallery/favorites/remove', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({ post_id: postId, source: currentSource() })
-                        });
-                        let data;
-                        if (response.status === 204) {
-                            // 204 No Content 表示成功，但没有响应体
-                            data = { success: true, message: "取消收藏成功" };
-                        } else {
-                            data = await response.json();
-                        }
-
-                        // 恢复按钮状态
-                        if (button) {
-                            button.disabled = false;
-                            if (data.success) {
-                                button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-                                </svg>`;
-                                button.title = t('favorite');
-                                button.classList.remove('favorited');
-                                const index = userFavorites.indexOf(String(postId));
-                                if (index > -1) {
-                                    userFavorites.splice(index, 1);
-                                }
-                                // 显示取消收藏成功提示
-                                showToast(t('unfavorite') + '成功', 'success', button);
-                            } else {
-                                button.innerHTML = button.dataset.originalHTML || originalHTML;
-                            }
-                            delete button.dataset.originalHTML;
-                        }
-
-                        if (!data.success) {
-                            let errorMsg = data.error || "未知错误";
-                            if (data.error.includes("网络错误")) {
-                                showError(`${errorMsg} - 请检查网络连接`);
-                            } else if (data.error.includes("认证") || data.error.includes("401")) {
-                                errorMsg = `${errorMsg}\n\n${t('authRequired')}`;
-                                if (confirm(errorMsg + "\n\n是否打开设置？")) {
-                                    showSettingsDialog();
-                                }
-                            } else if (data.error.includes("Rate Limited") || data.error.includes("429")) {
-                                showError(`${errorMsg} - 请稍后重试`);
-                            } else {
-                                showError(errorMsg);
-                            }
-                        }
-
-                        return data;
-                    } catch (e) {
-                        logger.warn("移除收藏失败:", e);
-                        showError(`网络错误 - 无法连接到${currentSource() === "gelbooru" ? "Gelbooru" : "Danbooru"}服务器`);
-                        if (button) {
-                            button.disabled = false;
-                            button.innerHTML = button.dataset.originalHTML || '<svg>...</svg>';
-                            delete button.dataset.originalHTML;
-                        }
-                        return { success: false, error: "网络错误" };
-                    }
-                };
-
-                const loadFavorites = async () => {
-                    try {
-                        const response = await fetch(`/danbooru_gallery/favorites?source=${encodeURIComponent(currentSource())}`);
-                        const data = await response.json();
-                        if (!data.success) {
-                            const errorMsg = data.error || "收藏列表读取失败";
-                            logger.warn("加载收藏列表失败:", errorMsg);
-                            if (hasFavoriteAuth()) {
-                                showToast(errorMsg, "warning");
-                            }
-                            userFavorites = [];
-                            return userFavorites;
-                        }
-                        userFavorites = (data.favorites || []).map(id => String(id));
-                        return userFavorites;
-                    } catch (e) {
-                        logger.warn("加载收藏列表失败:", e);
-                        userFavorites = [];
-                        return userFavorites;
-                    }
-                };
-
-                // 语言管理功能
-                const loadLanguage = async () => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/language');
-                        const data = await response.json();
-                        globalMultiLanguageManager.setLanguage(data.language || 'zh', true);
-                    } catch (e) {
-                        logger.warn("加载语言设置失败:", e);
-                        globalMultiLanguageManager.setLanguage('zh', true);
-                    }
-                };
-
-                const saveLanguage = async (language) => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/language', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({ language: language })
-                        });
-                        const data = await response.json();
-                        return data.success;
-                    } catch (e) {
-                        logger.warn("保存语言设置失败:", e);
-                        return false;
-                    }
-                };
-
-                // 更新界面文本
-                const updateInterfaceTexts = () => {
-                    // 更新搜索框
-                    searchInput.placeholder = t('searchPlaceholder');
-
-                    // 更新按钮文本和提示
-                    const categoryButton = categoryDropdown.querySelector('.danbooru-category-button');
-                    if (categoryButton) {
-                        categoryButton.innerHTML = `${t('categories')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
-                        categoryButton.title = t('categoriestooltip');
-                    }
-
-                    const formattingButton = formattingDropdown.querySelector('.danbooru-category-button');
-                    if (formattingButton) {
-                        formattingButton.innerHTML = `${t('formatting')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
-                        formattingButton.title = t('formattingTooltip');
-                    }
-
-                    const ratingButton = ratingSelect.querySelector('.danbooru-category-button');
-                    if (ratingButton) {
-                        ratingButton.title = t('ratingTooltip');
-                        updateRatingButtonLabel();
-                    }
-
-                    // 更新分级选项
-                    const ratingLabels = ratingSelect.querySelectorAll('.danbooru-category-item label');
-                    ratingLabels.forEach((label) => {
-                        const key = label.dataset.ratingKey;
-                        if (key) {
-                            label.textContent = t(key);
-                        }
-                    });
-
-                    // 更新类别标签
-                    const categoryItems = categoryDropdown.querySelectorAll('.danbooru-category-item label');
-                    const categoryKeys = ['artist', 'copyright', 'character', 'general', 'meta'];
-                    categoryItems.forEach((label, index) => {
-                        if (categoryKeys[index]) {
-                            label.textContent = t(categoryKeys[index]);
-                        }
-                    });
-
-                    // 更新格式选项
-                    const formatItems = formattingDropdown.querySelectorAll('.danbooru-category-item label');
-                    if (formatItems.length >= 2) {
-                        formatItems[0].textContent = t('escapeBrackets');
-                        formatItems[1].textContent = t('replaceUnderscores');
-                    }
-
-                    // 更新按钮tooltip
-                    rankingButton.title = t('rankingTooltip');
-                    favoritesButton.title = t('favorites');
-                    refreshButton.title = t('refreshTooltip');
-                    settingsButton.title = t('settings');
-                    filterButton.title = t('filterTooltip');
-
-                    // 更新排行榜按钮文本
-                    const rankingIcon = rankingButton.querySelector('.icon');
-                    if (rankingIcon) {
-                        rankingButton.innerHTML = rankingIcon.outerHTML + t('ranking');
-                    }
-
-                    // 更新收藏夹按钮文本
-                    const favoritesIcon = favoritesButton.querySelector('.icon');
-                    if (favoritesIcon) {
-                        favoritesButton.innerHTML = favoritesIcon.outerHTML + t('favorites');
-                    }
-
-                    // 更新加载状态文本
-                    const loadingElement = imageGrid.querySelector('.danbooru-loading');
-                    if (loadingElement) {
-                        loadingElement.textContent = t('loading');
-                    }
-
-                    // 更新侧边栏按钮文本（如果设置对话框已打开）
-                    const sidebarButtons = document.querySelectorAll('.sidebar-button');
-                    sidebarButtons.forEach(button => {
-                        const key = button.dataset.key;
-                        if (key) {
-                            const titleSpan = button.querySelector('.sidebar-button-title');
-                            if (titleSpan) {
-                                titleSpan.textContent = t(key + 'Section');
-                            }
-                        }
-                    });
-                };
-
-                const searchInput = $el("input.danbooru-search-input", { type: "text", placeholder: t('searchPlaceholder'), title: t('searchPlaceholder') });
-                const SOURCE_SITES = [
-                    { value: "danbooru", label: "Danbooru" },
-                    { value: "gelbooru", label: "Gelbooru" },
-                ];
-                const sourceSelect = $el("select.danbooru-source-select", {
-                    title: t('sourceTooltip')
-                }, SOURCE_SITES.map(site => $el("option", {
-                    value: site.value,
-                    textContent: site.label
-                })));
-                const displayAllSiteContentToggle = $el("label.danbooru-gelbooru-display-all-toggle", {
-                    title: t('displayAllSiteContentTooltip'),
-                    style: { display: "none" }
-                }, [
-                    $el("input", { type: "checkbox" }),
-                    $el("span", { textContent: t('displayAllSiteContent') })
-                ]);
-                const updateSourceState = () => {
-                    const selectedSource = uiSettings.source_site || "danbooru";
-                    sourceSelect.value = selectedSource;
-                    const favoritesDisabled = false;
-                    favoritesButton.disabled = favoritesDisabled;
-                    favoritesButton.style.opacity = favoritesDisabled ? "0.45" : "";
-                    favoritesButton.title = favoritesDisabled ? t('sourceFavoritesUnsupported') : t('favorites');
-                    displayAllSiteContentToggle.style.display = selectedSource === "gelbooru" ? "inline-flex" : "none";
-                    const displayAllInput = displayAllSiteContentToggle.querySelector("input");
-                    if (displayAllInput) {
-                        displayAllInput.checked = Boolean(uiSettings.gelbooru_display_all_site_content);
-                    }
-                };
-                const RATING_VALUES = ["general", "sensitive", "questionable", "explicit"];
-                const TAG_CATEGORY_ORDER = ["artist", "copyright", "character", "general", "meta"];
-                const normalizePostRating = (rating) => {
-                    const map = { g: "general", s: "sensitive", q: "questionable", e: "explicit" };
-                    return map[rating] || rating;
-                };
-                const createRatingDropdown = () => {
-                    const createRatingCheckbox = (name, checked = false) => {
-                        const id = `danbooru-rating-${name}`;
-                        const checkbox = $el("input", {
-                            type: "checkbox",
-                            id,
-                            name,
-                            checked,
-                            className: "danbooru-category-checkbox danbooru-rating-checkbox"
-                        });
-
-                        return $el("div.danbooru-category-item", [
-                            checkbox,
-                            $el("label", { htmlFor: id, textContent: t(name), dataset: { ratingKey: name } })
-                        ]);
-                    };
-
-                    const allId = "danbooru-rating-all";
-                    const allCheckbox = $el("input", {
-                        type: "checkbox",
-                        id: allId,
-                        name: "__all__",
-                        checked: true,
-                        className: "danbooru-category-checkbox danbooru-rating-checkbox danbooru-rating-all-checkbox"
-                    });
-                    const allItem = $el("div.danbooru-category-item", [
-                        allCheckbox,
-                        $el("label", { htmlFor: allId, textContent: t('all'), dataset: { ratingKey: 'all' } })
-                    ]);
-
-                    const listItems = [
-                        allItem,
-                        createRatingCheckbox("general"),
-                        createRatingCheckbox("sensitive"),
-                        createRatingCheckbox("questionable"),
-                        createRatingCheckbox("explicit")
-                    ];
-
-                    const dropdown = $el("div.danbooru-rating-dropdown.danbooru-category-dropdown", [
-                        $el("button.danbooru-category-button", {
-                            innerHTML: `${t('all')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`,
-                            title: t('ratingTooltip')
-                        }),
-                        $el("div.danbooru-category-list", {}, listItems)
-                    ]);
-
-                    return dropdown;
-                };
-
-                const ratingSelect = createRatingDropdown();
-                const getSelectedRatings = () => {
-                    return Array.from(ratingSelect.querySelectorAll(".danbooru-rating-checkbox:checked"))
-                        .map(i => i.name)
-                        .filter(name => name !== "__all__");
-                };
-                const updateRatingButtonLabel = () => {
-                    const ratingButton = ratingSelect.querySelector('.danbooru-category-button');
-                    if (!ratingButton) return;
-
-                    const selectedRatings = getSelectedRatings();
-                    let buttonText = t('all');
-                    if (selectedRatings.length === 1) {
-                        buttonText = t(selectedRatings[0]);
-                    } else if (selectedRatings.length > 1 && selectedRatings.length < RATING_VALUES.length) {
-                        buttonText = selectedRatings.map(r => t(r)).join(" / ");
-                    }
-
-                    ratingButton.dataset.values = JSON.stringify(selectedRatings);
-                    ratingButton.innerHTML = `${buttonText} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
-                };
-                const applySelectedRatings = (selectedRatings = RATING_VALUES) => {
-                    const targetRatings = (Array.isArray(selectedRatings) && selectedRatings.length > 0)
-                        ? selectedRatings.filter(v => RATING_VALUES.includes(v))
-                        : [...RATING_VALUES];
-
-                    const allCheckbox = ratingSelect.querySelector('.danbooru-rating-all-checkbox');
-                    const ratingCheckboxes = ratingSelect.querySelectorAll('.danbooru-rating-checkbox:not(.danbooru-rating-all-checkbox)');
-                    ratingCheckboxes.forEach((checkbox) => {
-                        checkbox.checked = targetRatings.includes(checkbox.name);
-                    });
-                    if (allCheckbox) {
-                        allCheckbox.checked = targetRatings.length === RATING_VALUES.length;
-                    }
-                    updateRatingButtonLabel();
-                };
-                const bindRatingDropdownEvents = () => {
-                    const allCheckbox = ratingSelect.querySelector('.danbooru-rating-all-checkbox');
-                    const ratingCheckboxes = ratingSelect.querySelectorAll('.danbooru-rating-checkbox:not(.danbooru-rating-all-checkbox)');
-
-                    if (allCheckbox) {
-                        allCheckbox.addEventListener('change', () => {
-                            const checked = allCheckbox.checked;
-                            ratingCheckboxes.forEach(cb => { cb.checked = checked; });
-                            updateRatingButtonLabel();
-                            saveToLocalStorage('ratingValues', checked ? [...RATING_VALUES] : []);
-                            ratingSelect.dispatchEvent(new Event('change'));
-                        });
-                    }
-
-                    ratingCheckboxes.forEach((checkbox) => {
-                        checkbox.addEventListener('change', () => {
-                            const selectedRatings = getSelectedRatings();
-                            if (allCheckbox) {
-                                allCheckbox.checked = selectedRatings.length === RATING_VALUES.length;
-                            }
-                            updateRatingButtonLabel();
-                            saveToLocalStorage('ratingValues', selectedRatings);
-                            ratingSelect.dispatchEvent(new Event('change'));
-                        });
-                    });
-                };
-                bindRatingDropdownEvents();
-                applySelectedRatings(RATING_VALUES);
-
-                const createCategoryCheckbox = (name, checked = false) => { // Default to false, will be set later
-                    const id = `danbooru-category-${name}`;
-                    const checkbox = $el("input", { type: "checkbox", id, name, checked: checked, className: "danbooru-category-checkbox" });
-                    checkbox.addEventListener('change', async () => {
-                        const newSelectedCategories = Array.from(categoryDropdown.querySelectorAll("input:checked")).map(i => i.name);
-                        uiSettings.selected_categories = newSelectedCategories;
-                        saveToLocalStorage('selectedCategories', newSelectedCategories);
-                        await saveUiSettings(uiSettings);
-                        updateSelectionData();
-                    });
-                    return $el("div.danbooru-category-item", [
-                        checkbox,
-                        $el("label", { htmlFor: id, textContent: t(name) })
-                    ]);
-                };
-
-                const categoryDropdown = $el("div.danbooru-category-dropdown", [
-                    $el("button.danbooru-category-button", {
-                        innerHTML: `${t('categories')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`,
-                        title: t('categoriestooltip')
-                    }),
-                    $el("div.danbooru-category-list", {}, [
-                        createCategoryCheckbox("artist"),
-                        createCategoryCheckbox("copyright"),
-                        createCategoryCheckbox("character"),
-                        createCategoryCheckbox("general"),
-                        createCategoryCheckbox("meta")
-                    ])
-                ]);
-
-                const createFormattingCheckbox = (name, label, checked = true) => {
-                    const id = `danbooru-format-${name}`;
-                    const checkbox = $el("input", { type: "checkbox", id, name, checked, className: "danbooru-format-checkbox" });
-                    checkbox.addEventListener('change', async () => {
-                        const newFormattingOptions = {
-                            escapeBrackets: formattingDropdown.querySelector('[name="escapeBrackets"]').checked,
-                            replaceUnderscores: formattingDropdown.querySelector('[name="replaceUnderscores"]').checked,
-                        };
-                        uiSettings.formatting = newFormattingOptions;
-                        saveToLocalStorage('formatting', newFormattingOptions);
-                        await saveUiSettings(uiSettings);
-                        updateSelectionData();
-                    });
-                    return $el("div.danbooru-category-item", [
-                        checkbox,
-                        $el("label", { htmlFor: id, textContent: label })
-                    ]);
-                };
-
-                const formattingDropdown = $el("div.danbooru-formatting-dropdown.danbooru-category-dropdown", [
-                    $el("button.danbooru-category-button", {
-                        innerHTML: `${t('formatting')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`,
-                        title: t('formattingTooltip')
-                    }),
-                    $el("div.danbooru-category-list", {}, [
-                        createFormattingCheckbox("escapeBrackets", t('escapeBrackets')),
-                        createFormattingCheckbox("replaceUnderscores", t('replaceUnderscores')),
-                    ])
-                ]);
-
-                sourceSelect.addEventListener('change', async () => {
-                    uiSettings.source_site = sourceSelect.value;
-                    saveToLocalStorage('sourceSite', uiSettings.source_site);
-                    await saveUiSettings(uiSettings);
-                    await loadFavorites();
-                    updateSourceState();
-                    searchAutocomplete.source = uiSettings.source_site;
-                    posts = [];
-                    Object.keys(originalPostCache).forEach(key => delete originalPostCache[key]);
-                    temporaryTagEdits = {};
-                    updateSelectionData();
-                    fetchAndRender(true);
-                });
-
-                displayAllSiteContentToggle.querySelector("input").addEventListener('change', async (event) => {
-                    uiSettings.gelbooru_display_all_site_content = Boolean(event.target.checked);
-                    saveToLocalStorage('gelbooruDisplayAllSiteContent', uiSettings.gelbooru_display_all_site_content);
-                    await saveUiSettings(uiSettings);
-                    if ((uiSettings.source_site || "danbooru") === "gelbooru") {
-                        posts = [];
-                        Object.keys(originalPostCache).forEach(key => delete originalPostCache[key]);
-                        temporaryTagEdits = {};
-                        updateSelectionData();
-                        fetchAndRender(true);
-                    }
-                });
-
-                document.addEventListener("click", (e) => {
-                    const dropdowns = [categoryDropdown, formattingDropdown, ratingSelect];
-                    dropdowns.forEach(dropdown => {
-                        const list = dropdown.querySelector(".danbooru-category-list");
-                        const button = dropdown.querySelector(".danbooru-category-button");
-
-                        if (!button || !list) return;
-
-                        if (!dropdown.contains(e.target)) {
-                            list.classList.remove("show");
-                            button.classList.remove("open");
-                        } else if (e.target.closest(".danbooru-category-button")) {
-                            // Close other dropdowns
-                            dropdowns.forEach(otherDropdown => {
-                                if (otherDropdown !== dropdown) {
-                                    otherDropdown.querySelector(".danbooru-category-list")?.classList.remove("show");
-                                    const otherButton = otherDropdown.querySelector(".danbooru-category-button");
-                                    otherButton?.classList.remove("open");
-                                }
-                            });
-                            list.classList.toggle("show");
-                            button.classList.toggle("open");
-                        }
-                    });
-                });
-
-                // 排行榜按钮
-                const rankingButton = $el("button.danbooru-ranking-button", {
-                    title: t('rankingTooltip')
-                });
-                rankingButton.innerHTML = `
-                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
-                       <path d="M16 6L19 9L16 12"></path>
-                       <path d="M8 12L5 9L8 6"></path>
-                       <path d="M12 2V22"></path>
-                       <path d="M3 9H21"></path>
-                   </svg>
-                   ${t('ranking')}`;
-
-                // 收藏夹按钮
-                const favoritesButton = $el("button.danbooru-favorites-button", {
-                    title: t('favorites')
-                });
-                favoritesButton.innerHTML = `
-                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
-                       <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-                   </svg>
-                   ${t('favorites')}`;
-
-                // 导出设置
-                const exportSettings = () => {
-                    const settingsToExport = {
-                        language: globalMultiLanguageManager.getLanguage(),
-                        blacklist: currentBlacklist,
-                        prompt_filter: {
-                            enabled: filterEnabled,
-                            tags: currentFilterTags,
-                        },
-                        ui: {
-                            ...uiSettings,
-                            source_site: uiSettings.source_site || "danbooru",
-                            // Ensure formatting is included from the checkboxes directly
-                            formatting: {
-                                escapeBrackets: formattingDropdown.querySelector('[name="escapeBrackets"]').checked,
-                                replaceUnderscores: formattingDropdown.querySelector('[name="replaceUnderscores"]').checked,
-                            }
-                        },
-                    };
-
-                    const blob = new Blob([JSON.stringify(settingsToExport, null, 2)], { type: 'application/json' });
-                    const url = URL.createObjectURL(blob);
-                    const a = document.createElement('a');
-                    a.href = url;
-                    a.download = 'danbooru_gallery_settings.json';
-                    document.body.appendChild(a);
-                    a.click();
-                    document.body.removeChild(a);
-                    URL.revokeObjectURL(url);
-
-                    showToast(t('exportSuccess'), 'success');
-                };
-
-                // 导入设置
-                const importSettings = (dialog) => {
-                    const input = document.createElement('input');
-                    input.type = 'file';
-                    input.accept = '.json';
-                    input.onchange = (e) => {
-                        const file = e.target.files[0];
-                        if (!file) return;
-                        const reader = new FileReader();
-                        reader.onload = async (event) => {
-                            try {
-                                const s = JSON.parse(event.target.result);
-
-                                const promises = [];
-                                if (s.language && i18n[s.language]) {
-                                    promises.push(saveLanguage(s.language));
-                                }
-                                if (Array.isArray(s.blacklist)) {
-                                    promises.push(saveBlacklist(s.blacklist));
-                                }
-                                if (s.prompt_filter && typeof s.prompt_filter.enabled === 'boolean' && Array.isArray(s.prompt_filter.tags)) {
-                                    promises.push(saveFilterTags(s.prompt_filter.tags, s.prompt_filter.enabled));
-                                }
-                                if (s.ui) {
-                                    // Merge formatting settings correctly
-                                    const newUiSettings = { ...uiSettings, ...s.ui };
-                                    if (s.ui.formatting) {
-                                        newUiSettings.formatting = { ...uiSettings.formatting, ...s.ui.formatting };
-                                    }
-                                    promises.push(saveUiSettings(newUiSettings));
-                                }
-
-                                const results = await Promise.all(promises);
-
-                                if (results.some(res => res === false)) {
-                                    showToast(t('saveFailed'), 'error');
-                                    return;
-                                }
-
-                                showToast(t('importSuccess'), 'success');
-                                dialog.remove();
-
-                                await initializeApp();
-                                showSettingsDialog();
-
-                            } catch (error) {
-                                logger.error("Failed to import settings:", error);
-                                showToast(t('importError'), 'error');
-                            }
-                        };
-                        reader.readAsText(file);
-                    };
-                    input.click();
-                };
-
-                // 创建设置页面对话框
-                const showSettingsDialog = (initialState = {}) => {
-                    const dialog = $el("div.danbooru-settings-dialog", {
-                        style: {
-                            position: "fixed",
-                            top: "0",
-                            left: "0",
-                            width: "100%",
-                            height: "100%",
-                            backgroundColor: "rgba(0, 0, 0, 0.7)",
-                            zIndex: "10000",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center"
-                        }
-                    });
-
-                    const dialogContent = $el("div.danbooru-settings-dialog-content", {
-                        style: {
-                            backgroundColor: "var(--comfy-menu-bg)",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "12px",
-                            padding: "24px",
-                            width: "800px",
-                            maxWidth: "90vw",
-                            height: "600px",
-                            maxHeight: "90vh",
-                            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)",
-                            display: "flex",
-                            flexDirection: "column"
-                        }
-                    });
-
-                    const mainContainer = $el("div", {
-                        style: {
-                            display: "flex",
-                            flex: "1",
-                            gap: "20px",
-                            overflow: "hidden"
-                        }
-                    });
-
-
-                    const sidebar = $el("div.danbooru-settings-sidebar", {
-                        style: {
-                            width: "180px",
-                            flexShrink: "0",
-                            borderRight: "1px solid var(--input-border-color)"
-                        }
-                    });
-
-
-                    const scrollContainer = $el("div.danbooru-settings-scroll-container", {
-                        style: {
-                            flex: "1",
-                            overflowY: "auto",
-                            padding: "0 16px"
-                        }
-                    });
-
-                    const title = $el("h2", {
-                        textContent: t('settings'),
-                        style: {
-                            margin: "0 0 20px 0",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "1.5em",
-                            fontWeight: "600",
-                            borderBottom: "2px solid var(--input-border-color)",
-                            paddingBottom: "12px"
-                        }
-                    });
-
-                    // 语言设置部分
-                    const languageSection = $el("div.danbooru-settings-section", {
-                        style: {
-                            marginBottom: "20px",
-                            padding: "16px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "8px",
-                            backgroundColor: "var(--comfy-input-bg)"
-                        }
-                    });
-
-                    const languageTitle = $el("h3", {
-                        textContent: t('languageSettings'),
-                        style: {
-                            margin: "0 0 12px 0",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "1.1em",
-                            fontWeight: "500",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "8px"
-                        }
-                    });
-
-                    const languageIcon = $el("span", {
-                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <circle cx="12" cy="12" r="10"></circle>
-                            <line x1="2" y1="12" x2="22" y2="12"></line>
-                            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
-                        </svg>`
-                    });
-
-                    languageTitle.insertBefore(languageIcon, languageTitle.firstChild);
-
-                    const languageOptions = $el("div", {
-                        style: {
-                            display: "flex",
-                            gap: "12px"
-                        }
-                    });
-
-                    const createLanguageButton = (lang, text) => {
-                        const isActive = globalMultiLanguageManager.getLanguage() === lang;
-                        const button = $el("button", {
-                            textContent: text,
-                            className: `danbooru-language-select-button ${isActive ? 'active' : ''}`,
-                            dataset: { lang: lang } // Store lang in dataset
-                        });
-                        return button;
-                    };
-
-                    const zhButton = createLanguageButton('zh', '中文');
-                    const enButton = createLanguageButton('en', 'English');
-
-                    languageOptions.appendChild(zhButton);
-                    languageOptions.appendChild(enButton);
-
-
-                    languageSection.appendChild(languageTitle);
-                    languageSection.appendChild(languageOptions);
-
-
-                    // 黑名单设置部分
-                    const blacklistSection = $el("div.danbooru-settings-section", {
-                        style: {
-                            marginBottom: "20px",
-                            padding: "16px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "8px",
-                            backgroundColor: "var(--comfy-input-bg)"
-                        }
-                    });
-
-                    const blacklistTitle = $el("h3", {
-                        textContent: t('blacklistSettings'),
-                        style: {
-                            margin: "0 0 8px 0",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "1.1em",
-                            fontWeight: "500",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "8px"
-                        }
-                    });
-
-                    const blacklistIcon = $el("span", {
-                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M3 6h18l-1.5 14H4.5L3 6z"></path>
-                            <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-                            <line x1="10" y1="11" x2="10" y2="17"></line>
-                            <line x1="14" y1="11" x2="14" y2="17"></line>
-                        </svg>`
-                    });
-
-                    blacklistTitle.insertBefore(blacklistIcon, blacklistTitle.firstChild);
-
-                    const blacklistDescription = $el("p", {
-                        textContent: t('blacklistDescription'),
-                        style: {
-                            margin: "0 0 12px 0",
-                            color: "#888",
-                            fontSize: "0.9em"
-                        }
-                    });
-
-                    const blacklistTextarea = $el("textarea", {
-                        placeholder: t('blacklistPlaceholder'),
-                        value: initialState.blacklist ?? currentBlacklist.join('\n'),
-                        style: {
-                            width: "100%",
-                            height: "120px",
-                            padding: "12px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "6px",
-                            backgroundColor: "var(--comfy-menu-bg)",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "14px",
-                            resize: "vertical",
-                            fontFamily: "monospace",
-                            lineHeight: "1.4"
-                        }
-                    });
-
-                    blacklistSection.appendChild(blacklistTitle);
-                    blacklistSection.appendChild(blacklistDescription);
-                    blacklistSection.appendChild(blacklistTextarea);
-
-                    // 提示词过滤设置部分
-                    const filterSection = $el("div.danbooru-settings-section", {
-                        style: {
-                            marginBottom: "20px",
-                            padding: "16px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "8px",
-                            backgroundColor: "var(--comfy-input-bg)"
-                        }
-                    });
-
-                    const filterTitle = $el("h3", {
-                        textContent: t('promptFilterSettings'),
-                        style: {
-                            margin: "0 0 8px 0",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "1.1em",
-                            fontWeight: "500",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "8px"
-                        }
-                    });
-
-                    const filterIcon = $el("span", {
-                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
-                        </svg>`
-                    });
-
-                    filterTitle.insertBefore(filterIcon, filterTitle.firstChild);
-
-                    const filterEnableDiv = $el("div", {
-                        style: {
-                            marginBottom: "12px",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "8px"
-                        }
-                    });
-
-                    const filterEnableCheckbox = $el("input", {
-                        type: "checkbox",
-                        id: "filterEnableCheckbox",
-                        checked: initialState.filterEnabled ?? filterEnabled,
-                        style: {
-                            width: "16px",
-                            height: "16px"
-                        }
-                    });
-
-                    const filterEnableLabel = $el("label", {
-                        htmlFor: "filterEnableCheckbox",
-                        textContent: t('promptFilterEnable'),
-                        style: {
-                            cursor: "pointer",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "0.9em",
-                            fontWeight: "500"
-                        }
-                    });
-
-                    filterEnableDiv.appendChild(filterEnableCheckbox);
-                    filterEnableDiv.appendChild(filterEnableLabel);
-
-                    const filterDescription = $el("p", {
-                        textContent: t('promptFilterDescription'),
-                        style: {
-                            margin: "0 0 12px 0",
-                            color: "#888",
-                            fontSize: "0.9em"
-                        }
-                    });
-
-                    const filterTextarea = $el("textarea", {
-                        placeholder: t('promptFilterPlaceholder'),
-                        value: initialState.filterTags ?? currentFilterTags.join('\n'),
-                        style: {
-                            width: "100%",
-                            height: "120px",
-                            padding: "12px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "6px",
-                            backgroundColor: "var(--comfy-menu-bg)",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "14px",
-                            resize: "vertical",
-                            fontFamily: "monospace",
-                            lineHeight: "1.4"
-                        }
-                    });
-
-                    filterSection.appendChild(filterTitle);
-                    filterSection.appendChild(filterEnableDiv);
-                    filterSection.appendChild(filterDescription);
-                    filterSection.appendChild(filterTextarea);
-
-                    // 用户认证设置部分
-                    const authSection = $el("div.danbooru-settings-section", {
-                        style: {
-                            marginBottom: "20px",
-                            padding: "16px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "8px",
-                            backgroundColor: "var(--comfy-input-bg)"
-                        }
-                    });
-
-                    const authTitle = $el("h3", {
-                        textContent: t('userAuth'),
-                        style: {
-                            margin: "0 0 8px 0",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "1.1em",
-                            fontWeight: "500",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "8px"
-                        }
-                    });
-
-                    const authIcon = $el("span", {
-                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M9 12l2 2 4-4"></path>
-                            <path d="M21 12c-1 0-3-1-3-3s2-3 3-3 3 1 3 3-2 3-3 3"></path>
-                            <path d="M3 12c1 0 3-1 3-3s-2-3-3-3-3 1-3 3 2 3 3 3"></path>
-                            <path d="M12 3v6m0 6v6"></path>
-                        </svg>`
-                    });
-
-                    authTitle.insertBefore(authIcon, authTitle.firstChild);
-
-                    const authDescription = $el("p", {
-                        textContent: t('authDescription'),
-                        style: {
-                            margin: "0 0 12px 0",
-                            color: "#888",
-                            fontSize: "0.9em"
-                        }
-                    });
-
-                    const usernameInput = $el("input", {
-                        type: "text",
-                        placeholder: t('authPlaceholderUsername'),
-                        value: (initialState.username ?? userAuth.username) || "",
-                        style: {
-                            width: "100%",
-                            padding: "8px 12px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "6px",
-                            backgroundColor: "var(--comfy-menu-bg)",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "14px",
-                            marginBottom: "8px"
-                        }
-                    });
-
-                    const apiKeyInput = $el("input", {
-                        type: "password",
-                        placeholder: t('authPlaceholderApiKey'),
-                        value: (initialState.apiKey ?? userAuth.api_key) || "",
-                        style: {
-                            width: "100%",
-                            padding: "8px 12px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "6px",
-                            backgroundColor: "var(--comfy-menu-bg)",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "14px",
-                            marginBottom: "8px"
-                        }
-                    });
-
-                    const gelbooruAuthDescription = $el("p", {
-                        textContent: t('gelbooruAuthDescription'),
-                        style: {
-                            margin: "12px 0 8px 0",
-                            color: "#888",
-                            fontSize: "0.9em"
-                        }
-                    });
-
-                    const gelbooruUserIdInput = $el("input", {
-                        type: "text",
-                        placeholder: t('gelbooruUserIdPlaceholder'),
-                        value: (initialState.gelbooruUserId ?? userAuth.gelbooru_user_id) || "",
-                        style: {
-                            width: "100%",
-                            padding: "8px 12px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "6px",
-                            backgroundColor: "var(--comfy-menu-bg)",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "14px",
-                            marginBottom: "8px"
-                        }
-                    });
-
-                    const gelbooruApiKeyInput = $el("input", {
-                        type: "password",
-                        placeholder: t('gelbooruApiKeyPlaceholder'),
-                        value: (initialState.gelbooruApiKey ?? userAuth.gelbooru_api_key) || "",
-                        style: {
-                            width: "100%",
-                            padding: "8px 12px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "6px",
-                            backgroundColor: "var(--comfy-menu-bg)",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "14px",
-                            marginBottom: "8px"
-                        }
-                    });
-
-                    const apiKeyHelpButton = $el("button", {
-                        textContent: t('apiKeyHelp'),
-                        title: t('apiKeyTooltip'),
-                        style: {
-                            padding: "6px 12px",
-                            border: "1px solid #5865F2",
-                            borderRadius: "4px",
-                            backgroundColor: "transparent",
-                            color: "#5865F2",
-                            cursor: "pointer",
-                            fontSize: "12px",
-                            fontWeight: "500",
-                            transition: "all 0.2s ease"
-                        },
-                        onclick: () => {
-                            window.open('https://danbooru.donmai.us/profile', '_blank');
-                        }
-                    });
-
-                    authSection.appendChild(authTitle);
-                    authSection.appendChild(authDescription);
-                    authSection.appendChild(usernameInput);
-                    authSection.appendChild(apiKeyInput);
-                    authSection.appendChild(gelbooruAuthDescription);
-                    authSection.appendChild(gelbooruUserIdInput);
-                    authSection.appendChild(gelbooruApiKeyInput);
-                    authSection.appendChild(apiKeyHelpButton);
-
-                    // 自动补全设置
-                    const autocompleteSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
-                    const autocompleteTitle = $el("h3", { textContent: t('autocompleteSettings'), style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
-                    const autocompleteDesc = $el("p", { textContent: t('autocompleteEnableDescription'), style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
-                    const autocompleteEnableCheckbox = $el("input", { type: "checkbox", id: "autocompleteEnableCheckbox", checked: initialState.autocompleteEnabled ?? uiSettings.autocomplete_enabled, style: { width: "16px", height: "16px" } });
-                    autocompleteEnableCheckbox.onchange = (e) => { /* 用户界面中的临时状态，无需处理 */ };
-                    const autocompleteEnableLabel = $el("label", { htmlFor: "autocompleteEnableCheckbox", textContent: t('autocompleteEnable'), style: { cursor: "pointer", color: "var(--comfy-input-text)", fontSize: "1em", fontWeight: "500" } });
-                    const autocompleteEnableDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [autocompleteEnableCheckbox, autocompleteEnableLabel]);
-
-                    // 新增：最大补全数量
-                    const autocompleteMaxResultsLabel = $el("label", { htmlFor: "autocompleteMaxResultsInput", textContent: t('autocompleteMaxResults'), style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
-                    const autocompleteMaxResultsInput = $el("input", {
-                        type: "number",
-                        id: "autocompleteMaxResultsInput",
-                        title: t('autocompleteEnableDescription'),
-                        value: (initialState.autocompleteMaxResults ?? uiSettings.autocomplete_max_results) || 20,
-                        min: "1",
-                        max: "50",
-                        style: { width: "60px", padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
-                    });
-                    const autocompleteMaxResultsDiv = $el("div", { style: { display: "flex", alignItems: "center" } }, [autocompleteMaxResultsLabel, autocompleteMaxResultsInput]);
-
-                    autocompleteSection.appendChild(autocompleteTitle);
-                    autocompleteSection.appendChild(autocompleteDesc);
-                    autocompleteSection.appendChild(autocompleteEnableDiv);
-                    autocompleteSection.appendChild(autocompleteMaxResultsDiv);
-
-                    // 悬浮提示设置
-                    const tooltipSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
-                    const tooltipTitle = $el("h3", { textContent: t('tooltipSettings'), style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
-                    const tooltipDesc = $el("p", { textContent: t('tooltipEnableDescription'), style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
-                    const tooltipEnableCheckbox = $el("input", { type: "checkbox", id: "tooltipEnableCheckbox", checked: initialState.tooltipEnabled ?? uiSettings.tooltip_enabled, style: { width: "16px", height: "16px" } });
-                    tooltipEnableCheckbox.onchange = (e) => { /* 用户界面中的临时状态，无需处理 */ };
-                    const tooltipEnableLabel = $el("label", { htmlFor: "tooltipEnableCheckbox", textContent: t('tooltipEnable'), style: { cursor: "pointer", color: "var(--comfy-input-text)", fontSize: "1em", fontWeight: "500" } });
-                    const tooltipEnableDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px" } }, [tooltipEnableCheckbox, tooltipEnableLabel]);
-                    tooltipSection.appendChild(tooltipTitle);
-                    tooltipSection.appendChild(tooltipDesc);
-                    tooltipSection.appendChild(tooltipEnableDiv);
-
-                    // 多选模式设置
-                    const selectionModeSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
-                    const selectionModeTitle = $el("h3", { textContent: t('selectionModeSettings'), style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
-                    const selectionModeDesc = $el("p", { textContent: t('selectionModeDescription'), style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
-                    const multiSelectCheckbox = $el("input", { type: "checkbox", id: "multiSelectCheckbox", checked: initialState.multiSelectEnabled ?? uiSettings.multi_select_enabled ?? false, style: { width: "16px", height: "16px" } });
-                    multiSelectCheckbox.onchange = (e) => { /* 用户界面中的临时状态，无需处理 */ };
-                    const multiSelectLabel = $el("label", { htmlFor: "multiSelectCheckbox", textContent: t('multiSelectEnable'), style: { cursor: "pointer", color: "var(--comfy-input-text)", fontSize: "1em", fontWeight: "500" } });
-                    const multiSelectDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px" } }, [multiSelectCheckbox, multiSelectLabel]);
-                    selectionModeSection.appendChild(selectionModeTitle);
-                    selectionModeSection.appendChild(selectionModeDesc);
-                    selectionModeSection.appendChild(multiSelectDiv);
-
-                    // 预加载设置
-                    const preloadSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
-                    const preloadTitle = $el("h3", { textContent: "预加载 / 去重", style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
-                    preloadSection.appendChild(preloadTitle);
-
-                    // 每次增加张数
-                    const preloadCountLabel = $el("label", { htmlFor: "preloadCountInput", textContent: "每次增加缓冲张数：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
-                    const preloadCountInput = $el("input", {
-                        type: "number", id: "preloadCountInput", min: "20", max: "200",
-                        value: (initialState.preloadCount !== undefined ? initialState.preloadCount : uiSettings.preload_count) || 40,
-                        style: { width: "60px", padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
-                    });
-                    const preloadCountDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [preloadCountLabel, preloadCountInput]);
-
-                    // G站防重复模式
-                    const gelbooruDedupLabel = $el("label", { htmlFor: "gelbooruDedupSelect", textContent: "G站防重复：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
-                    const gelbooruDedupSelect = $el("select", {
-                        id: "gelbooruDedupSelect",
-                        style: { padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
-                    }, [
-                        $el("option", { value: "off", textContent: "关闭（可使用2个tag）" }),
-                        $el("option", { value: "on", textContent: "开启（限1个tag）" }),
-                        $el("option", { value: "on_auth", textContent: "开启·已配密钥（多tag可用）" }),
-                    ]);
-                    gelbooruDedupSelect.value = initialState.gelbooruDedupMode !== undefined ? initialState.gelbooruDedupMode : (uiSettings.gelbooru_dedup_mode || "off");
-                    const gelbooruDedupDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [gelbooruDedupLabel, gelbooruDedupSelect]);
-
-                    // 全局日志
-                    const globalLogLabel = $el("label", { htmlFor: "globalLogCheck", textContent: "启用全局日志：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
-                    const globalLogCheck = $el("input", {
-                        type: "checkbox", id: "globalLogCheck",
-                        checked: initialState.globalLogging !== undefined ? initialState.globalLogging : (uiSettings.global_logging || false),
-                        style: { width: "16px", height: "16px" }
-                    });
-                    const globalLogDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "8px" } }, [globalLogCheck, globalLogLabel]);
-
-                    preloadSection.appendChild(preloadCountDiv);
-                    preloadSection.appendChild(gelbooruDedupDiv);
-                    preloadSection.appendChild(globalLogDiv);
-
-                    // 创建侧边栏按钮和内容区域的映射
-                    const sections = {
-                        'general': { title: t('generalSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>', elements: [languageSection] },
-                        'user': { title: t('userSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>', elements: [authSection] },
-                        'content': { title: t('contentSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18l-1.5 14H4.5L3 6z"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>', elements: [blacklistSection] },
-                        'prompt': { title: t('promptSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>', elements: [filterSection] },
-                        'ui': { title: t('uiSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>', elements: [autocompleteSection, tooltipSection, selectionModeSection] },
-                        'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
-                    };
-
-                    const setActiveSection = (key) => {
-                        // 更新按钮样式
-                        sidebar.querySelectorAll('.sidebar-button').forEach(btn => {
-                            if (btn.dataset.key === key) {
-                                btn.classList.add('active');
-                            } else {
-                                btn.classList.remove('active');
-                            }
-                        });
-
-
-                        // 显示对应的内容
-                        scrollContainer.innerHTML = '';
-                        if (sections[key] && sections[key].elements.length > 0) {
-                            sections[key].elements.forEach(el => scrollContainer.appendChild(el));
-                        }
-                    };
-
-                    // 创建侧边栏按钮
-                    Object.keys(sections).forEach(key => {
-                        const section = sections[key];
-                        const button = $el("button.sidebar-button", {
-                            dataset: { key: key },
-                            onclick: () => setActiveSection(key),
-                        });
-                        button.appendChild($el("div.sidebar-button-icon", { innerHTML: section.icon }));
-                        button.appendChild($el("span.sidebar-button-title", { textContent: section.title }));
-                        sidebar.appendChild(button);
-                    });
-
-                    // 设置初始活动区域
-                    setActiveSection('general');
-
-                    // 社交按钮
-                    const githubButton = $el("button", {
-                        innerHTML: `
-                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
-                            </svg>
-                            <span style="margin-left: 8px;">GitHub</span>
-                        `,
-                        title: t('githubTooltip'),
-                        style: {
-                            padding: "10px 16px",
-                            border: "1px solid #24292e",
-                            borderRadius: "6px",
-                            backgroundColor: "#24292e",
-                            color: "white",
-                            cursor: "pointer",
-                            fontSize: "14px",
-                            fontWeight: "500",
-                            transition: "all 0.2s ease",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            minWidth: "80px"
-                        },
-                        onclick: () => {
-                            window.open('https://github.com/Aaalice233/ComfyUI-Danbooru-Gallery', '_blank');
-                        }
-                    });
-
-                    const discordButton = $el("button", {
-                        innerHTML: `
-                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.196.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.30z"></path>
-                            </svg>
-                            <span style="margin-left: 8px;">Discord</span>
-                        `,
-                        title: t('discordTooltip'),
-                        style: {
-                            padding: "10px 16px",
-                            border: "1px solid #5865F2",
-                            borderRadius: "6px",
-                            backgroundColor: "#5865F2",
-                            color: "white",
-                            cursor: "pointer",
-                            fontSize: "14px",
-                            fontWeight: "500",
-                            transition: "all 0.2s ease",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            minWidth: "80px"
-                        },
-                        onclick: () => {
-                            window.open('https://discord.gg/aaalice', '_blank');
-                        }
-                    });
-
-                    // 按钮区域
-                    const buttonContainer = $el("div", {
-                        style: {
-                            display: "flex",
-                            gap: "12px",
-                            marginTop: "24px",
-                            justifyContent: "space-between",
-                            alignItems: "center"
-                        }
-                    });
-
-                    // 左侧社交按钮容器
-                    const socialButtonsContainer = $el("div", {
-                        style: {
-                            display: "flex",
-                            gap: "8px"
-                        }
-                    });
-
-                    socialButtonsContainer.appendChild(githubButton);
-                    socialButtonsContainer.appendChild(discordButton);
-
-                    // 右侧主要按钮容器
-                    const mainButtonsContainer = $el("div", {
-                        style: {
-                            display: "flex",
-                            gap: "12px"
-                        }
-                    });
-
-                    const importExportButtonStyle = {
-                        padding: "10px 20px",
-                        border: "1px solid var(--input-border-color)",
-                        borderRadius: "6px",
-                        backgroundColor: "var(--comfy-input-bg)",
-                        color: "var(--comfy-input-text)",
-                        cursor: "pointer",
-                        fontSize: "14px",
-                        fontWeight: "500",
-                        transition: "all 0.2s ease"
-                    };
-
-                    const importButton = $el("button", {
-                        textContent: t('importSettings'),
-                        style: importExportButtonStyle,
-                        onclick: () => importSettings(dialog)
-                    });
-
-                    const exportButton = $el("button", {
-                        textContent: t('exportSettings'),
-                        style: importExportButtonStyle,
-                        onclick: exportSettings
-                    });
-
-                    const cancelButton = $el("button", {
-                        textContent: t('cancel'),
-                        style: {
-                            padding: "10px 20px",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "6px",
-                            backgroundColor: "var(--comfy-input-bg)",
-                            color: "var(--comfy-input-text)",
-                            cursor: "pointer",
-                            fontSize: "14px",
-                            fontWeight: "500",
-                            transition: "all 0.2s ease"
-                        },
-                        onclick: () => dialog.remove()
-                    });
-
-                    const saveButton = $el("button", {
-                        textContent: t('save'),
-                        style: {
-                            padding: "10px 20px",
-                            border: "2px solid #7B68EE",
-                            borderRadius: "6px",
-                            backgroundColor: "#7B68EE",
-                            color: "white",
-                            cursor: "pointer",
-                            fontSize: "14px",
-                            fontWeight: "600",
-                            transition: "all 0.2s ease"
-                        },
-                        onclick: async () => {
-                            const blacklistText = blacklistTextarea.value.trim();
-                            const newBlacklist = blacklistText ? blacklistText.split('\n').map(tag => tag.trim()).filter(tag => tag) : [];
-
-                            const filterText = filterTextarea.value.trim();
-                            const newFilterTags = filterText ? filterText.split('\n').map(tag => tag.trim()).filter(tag => tag) : [];
-                            const newFilterEnabled = filterEnableCheckbox.checked;
-
-                            // 保存用户认证信息
-                            const newUsername = usernameInput.value.trim();
-                            const newApiKey = apiKeyInput.value.trim();
-                            const newGelbooruUserId = gelbooruUserIdInput.value.trim();
-                            const newGelbooruApiKey = gelbooruApiKeyInput.value.trim();
-                            let authSuccess = true;
-                            if (
-                                newUsername !== userAuth.username ||
-                                newApiKey !== userAuth.api_key ||
-                                newGelbooruUserId !== userAuth.gelbooru_user_id ||
-                                newGelbooruApiKey !== userAuth.gelbooru_api_key
-                            ) {
-                                const authResult = await saveUserAuth(newUsername, newApiKey, newGelbooruUserId, newGelbooruApiKey);
-                                authSuccess = authResult.success;
-                                if (authSuccess) {
-                                    await loadFavorites(); // 登录成功后重新加载收藏夹
-                                } else {
-                                    showToast(authResult.error || "保存认证信息失败", 'error');
-                                    return;
-                                }
-                            }
-
-                            const newAutocompleteEnabled = autocompleteEnableCheckbox.checked;
-                            const newTooltipEnabled = tooltipEnableCheckbox.checked;
-                            const newAutocompleteMaxResults = parseInt(autocompleteMaxResultsInput.value, 10);
-                            const newSelectedCategories = Array.from(categoryDropdown.querySelectorAll("input:checked")).map(i => i.name);
-                            const newMultiSelectEnabled = multiSelectCheckbox.checked;
-
-                            // 保存所有设置
-                            const [blacklistSuccess, filterSuccess, uiSettingsSuccess] = await Promise.all([
-                                saveBlacklist(newBlacklist),
-                                saveFilterTags(newFilterTags, newFilterEnabled),
-                                saveUiSettings({
-                                    autocomplete_enabled: newAutocompleteEnabled,
-                                    tooltip_enabled: newTooltipEnabled,
-                                    autocomplete_max_results: newAutocompleteMaxResults,
-                                    selected_categories: newSelectedCategories,
-                                    multi_select_enabled: newMultiSelectEnabled,
-                                    source_site: uiSettings.source_site || "danbooru",
-                                    gelbooru_display_all_site_content: uiSettings.gelbooru_display_all_site_content || false
-                                })
-                            ]);
-
-                            if (blacklistSuccess && filterSuccess && authSuccess && uiSettingsSuccess) {
-                                // 同步本地状态
-                                currentBlacklist = newBlacklist;
-                                currentFilterTags = newFilterTags;
-                                filterEnabled = newFilterEnabled;
-                                uiSettings.autocomplete_enabled = newAutocompleteEnabled;
-                                uiSettings.tooltip_enabled = newTooltipEnabled;
-                                uiSettings.autocomplete_max_results = newAutocompleteMaxResults;
-                                uiSettings.selected_categories = newSelectedCategories;
-                                uiSettings.multi_select_enabled = newMultiSelectEnabled;
-                                uiSettings.source_site = sourceSelect.value || uiSettings.source_site || "danbooru";
-
-                                // 保存 preload/dedup/global_logging
-                                let newPreloadCount = parseInt(preloadCountInput.value, 10);
-                                if (isNaN(newPreloadCount)) newPreloadCount = 40;
-                                newPreloadCount = Math.min(Math.max(newPreloadCount, 20), 200);
-                                uiSettings.preload_count = newPreloadCount;
-                                saveToLocalStorage('preload_count', newPreloadCount);
-
-                                const newGelbooruDedupMode = ["off", "on", "on_auth"].includes(gelbooruDedupSelect.value) ? gelbooruDedupSelect.value : "off";
-                                uiSettings.gelbooru_dedup_mode = newGelbooruDedupMode;
-                                saveToLocalStorage('gelbooru_dedup_mode', newGelbooruDedupMode);
-
-                                const newGlobalLogging = globalLogCheck.checked;
-                                uiSettings.global_logging = newGlobalLogging;
-                                saveToLocalStorage('global_logging', newGlobalLogging);
-                                loggerClient.setConsoleOutput(newGlobalLogging);
-                                updateSelectionData();
-
-                                dialog.remove();
-                                showToast(t('saveSuccess'), 'success');
-
-                                // 重新过滤当前已加载的帖子
-                                const filteredPosts = posts.filter(post => !isPostFiltered(post));
-                                imageGrid.innerHTML = "";
-                                filteredPosts.forEach(renderPost);
-
-                                // 如果过滤后帖子太少，自动加载更多
-                                if (filteredPosts.length < 20) {
-                                    fetchAndRender(false);
-                                }
-                            } else {
-                                showToast(t('saveFailed'), 'error');
-                            }
-                        }
-                    });
-
-                    mainButtonsContainer.appendChild(importButton);
-                    mainButtonsContainer.appendChild(exportButton);
-                    mainButtonsContainer.appendChild(cancelButton);
-                    mainButtonsContainer.appendChild(saveButton);
-
-                    buttonContainer.appendChild(socialButtonsContainer);
-                    buttonContainer.appendChild(mainButtonsContainer);
-
-                    dialogContent.appendChild(title);
-                    mainContainer.appendChild(sidebar);
-                    mainContainer.appendChild(scrollContainer);
-                    dialogContent.appendChild(mainContainer);
-                    dialogContent.appendChild(buttonContainer);
-
-                    dialog.appendChild(dialogContent);
-
-                    // 点击背景关闭对话框
-                    dialog.addEventListener('click', (e) => {
-                        if (e.target === dialog) {
-                            dialog.remove();
-                        }
-                    });
-
-                    // ESC键关闭对话框
-                    const escHandler = (e) => {
-                        if (e.key === 'Escape') {
-                            dialog.remove();
-                            document.removeEventListener('keydown', escHandler);
-                        }
-                    };
-                    document.addEventListener('keydown', escHandler);
-
-                    document.body.appendChild(dialog);
-                    blacklistTextarea.focus();
-
-                    // Add event listeners after all elements are defined
-                    dialog.querySelectorAll('.danbooru-language-select-button').forEach(button => {
-                        button.onclick = async () => {
-                            const lang = button.dataset.lang;
-                            if (globalMultiLanguageManager.getLanguage() === lang) return;
-
-                            // Preserve state
-                            const currentState = {
-                                blacklist: blacklistTextarea.value,
-                                filterTags: filterTextarea.value,
-                                filterEnabled: filterEnableCheckbox.checked,
-                                username: usernameInput.value,
-                                apiKey: apiKeyInput.value,
-                                gelbooruUserId: gelbooruUserIdInput.value,
-                                gelbooruApiKey: gelbooruApiKeyInput.value,
-                                autocompleteEnabled: autocompleteEnableCheckbox.checked,
-                                tooltipEnabled: tooltipEnableCheckbox.checked,
-                                autocompleteMaxResults: autocompleteMaxResultsInput.value,
-                            };
-
-                            const success = await saveLanguage(lang);
-                            if (success) {
-                                globalMultiLanguageManager.setLanguage(lang);
-                                updateInterfaceTexts(); // Update main UI
-                                dialog.remove(); // Close current dialog
-                                showSettingsDialog(currentState); // Re-open with new language and preserved state
-                            } else {
-                                showToast('Failed to save language setting.', 'error');
-                            }
-                        };
-                    });
-                };
-
-                // 创建设置按钮
-                const settingsButton = $el("button.danbooru-settings-button", {
-                    innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
-                        <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
-                        <circle cx="12" cy="12" r="3"></circle>
-                    </svg>`,
-                    title: t('settings'),
-                    onclick: () => {
-                        showSettingsDialog();
-                    }
-                });
-
-                // 创建筛选按钮
-                const filterButton = $el("button.danbooru-filter-button", {
-                    innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
-                        <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
-                    </svg>`,
-                    title: t('filterTooltip'),
-                    onclick: () => {
-                        showFilterDialog();
-                    }
-                });
-
-                const refreshButton = $el("button.danbooru-refresh-button", {
-                    title: t('refreshTooltip')
-                });
-                refreshButton.innerHTML = `
-                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
-                       <polyline points="23 4 23 10 17 10"></polyline>
-                       <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
-                   </svg>`;
-
-
-                const imageGrid = $el("div.danbooru-image-grid");
-
-                // 创建筛选对话框
-                const showFilterDialog = () => {
-                    const dialog = $el("div.danbooru-settings-dialog", {
-                        style: {
-                            position: "absolute",
-                            top: "0",
-                            left: "0",
-                            width: "100%",
-                            height: "100%",
-                            backgroundColor: "rgba(0, 0, 0, 0.7)",
-                            zIndex: "1000",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center"
-                        },
-                        onclick: (e) => { if (e.target === dialog) dialog.remove(); }
-                    });
-
-                    const content = $el("div.danbooru-settings-dialog-content", {
-                        style: {
-                            width: "420px",
-                            padding: "20px",
-                            backgroundColor: "var(--comfy-menu-bg)",
-                            border: "1px solid var(--input-border-color)",
-                            borderRadius: "12px",
-                            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)",
-                            display: "flex",
-                            flexDirection: "column",
-                            gap: "20px",
-                            position: "relative", // 确保内容在对话框内
-                            zIndex: "1001", // 确保内容在背景之上
-                        }
-                    });
-
-                    const title = $el("h2", {
-                        textContent: t('filter'),
-                        style: {
-                            margin: "0",
-                            color: "var(--comfy-input-text)",
-                            fontSize: "1.3em",
-                            borderBottom: "1px solid var(--input-border-color)",
-                            paddingBottom: "15px"
-                        }
-                    });
-
-                    const body = $el("div", { style: { display: "flex", flexDirection: "column", gap: "20px" } });
-
-                    // 筛选类型选择
-                    const filterType = filterState.startPage ? 'page' : 'time';
-
-                    const createRadio = (name, value, label, checked) => {
-                        const radioId = `filter-type-${value}`;
-                        const radio = $el("input", { type: "radio", name, value, id: radioId, checked, style: { display: 'none' } });
-                        const indicator = $el("span.danbooru-radio-indicator");
-                        const radioLabel = $el("label.danbooru-radio-label", {
-                            htmlFor: radioId,
-                            className: checked ? 'checked' : ''
-                        }, [
-                            indicator,
-                            $el("span", { textContent: label, style: { zIndex: '1', position: 'relative' } })
-                        ]);
-
-                        // Set initial styles for checked state
-                        // The container now IS the label, which contains the hidden radio button.
-                        const container = $el("div.danbooru-radio-button-wrapper", {}, [radio, radioLabel]);
-
-                        return container;
-                    };
-
-                    const timeRadio = createRadio("filter-type", "time", t('filterByTime'), filterType === 'time');
-                    const pageRadio = createRadio("filter-type", "page", t('filterByPage'), filterType === 'page');
-
-                    const radioGroup = $el("div", {
-                        className: "danbooru-radio-group",
-                        style: {
-                            display: "flex",
-                            justifyContent: "center",
-                            alignItems: "center",
-                            gap: "20px",
-                            margin: "10px 0"
-                        }
-                    }, [timeRadio, pageRadio]);
-
-
-                    // 时间范围筛选
-                    const timeSection = $el("div.danbooru-settings-section");
-                    const createInputRow = (label, input) => {
-                        const row = $el("div.danbooru-input-row", {}, [
-                            $el("label", { textContent: label, style: { color: "#ccc", fontSize: "0.9em", userSelect: "none" } }),
-                            input
-                        ]);
-                        // Make the whole row clickable to open the date/time picker
-                        row.addEventListener('click', () => {
-                            try {
-                                input.showPicker();
-                            } catch (e) {
-                                logger.warn("input.showPicker() is not supported on this browser.", e);
-                            }
-                        });
-                        return row;
-                    };
-
-                    const startTimeInput = $el("input", { type: "datetime-local", id: "startTime", value: filterState.startTime || '' });
-                    const endTimeInput = $el("input", { type: "datetime-local", id: "endTime", value: filterState.endTime || '' });
-
-                    timeSection.append(
-                        $el("div", { style: { display: "flex", flexDirection: "column", gap: "10px" } }, [
-                            createInputRow(t('startTime'), startTimeInput),
-                            createInputRow(t('endTime'), endTimeInput)
-                        ])
-                    );
-
-                    // 起始页码筛选
-                    const pageSection = $el("div.danbooru-settings-section");
-                    const startPageInput = $el("input", { type: "number", id: "startPage", min: "1", placeholder: "1", value: filterState.startPage || '' });
-                    pageSection.append(
-                        createInputRow(t('startPage'), startPageInput)
-                    );
-
-                    body.append(radioGroup, timeSection, pageSection);
-
-                    const toggleSections = (type) => {
-                        if (type === 'time') {
-                            timeSection.style.display = 'block';
-                            pageSection.style.display = 'none';
-                        } else {
-                            timeSection.style.display = 'none';
-                            pageSection.style.display = 'block';
-                        }
-                    };
-
-                    toggleSections(filterType);
-
-                    radioGroup.addEventListener('change', (e) => {
-                        if (e.target.name === 'filter-type') {
-
-                            // New robust logic: Iterate through radios and update their labels
-                            radioGroup.querySelectorAll('input[type="radio"]').forEach(radio => {
-                                const label = radioGroup.querySelector(`label[for="${radio.id}"]`);
-                                if (label) {
-                                    const indicator = label.querySelector('.danbooru-radio-indicator');
-
-                                    if (radio.checked) {
-                                        label.classList.add('checked');
-                                        // FORCE INLINE STYLES FOR DEBUGGING
-                                        label.style.setProperty('border-color', '#7B68EE', 'important');
-                                        if (indicator) {
-                                            indicator.style.setProperty('background-color', '#7B68EE', 'important');
-                                            indicator.style.setProperty('border-color', '#7B68EE', 'important');
-                                        }
-                                    } else {
-                                        label.classList.remove('checked');
-                                        // CLEAR INLINE STYLES
-                                        label.style.borderColor = '';
-                                        if (indicator) {
-                                            indicator.style.backgroundColor = '';
-                                            indicator.style.borderColor = '';
-                                        }
-                                    }
-
-                                    // Use a timeout to allow the browser to apply styles before we log them
-                                    setTimeout(() => {
-                                        if (indicator) {
-                                        }
-                                    }, 0);
-
-                                } else {
-                                }
-                            });
-
-                            const selectedValue = e.target.value;
-                            toggleSections(selectedValue);
-                        }
-                    });
-
-                    // 按钮
-                    const footer = $el("div", { style: { display: "flex", justifyContent: "flex-end", gap: "12px", paddingTop: "15px", borderTop: "1px solid var(--input-border-color)" } });
-
-                    const cancelButton = $el("button.danbooru-dialog-button--secondary", {
-                        textContent: t('cancel'),
-                        onclick: () => dialog.remove()
-                    });
-
-                    const resetButton = $el("button.danbooru-dialog-button--secondary", {
-                        textContent: t('reset'),
-                        onclick: () => {
-                            filterState = { startTime: null, endTime: null, startPage: null };
-                            saveToLocalStorage('filterData', filterState);
-                            filterWidget.value = JSON.stringify(filterState);
-                            filterButton.classList.remove('active');
-                            dialog.remove();
-                            fetchAndRender(true);
-                        }
-                    });
-                    const applyButton = $el("button.danbooru-dialog-button--primary", {
-                        textContent: t('apply'),
-                        onclick: () => {
-                            const selectedType = radioGroup.querySelector('input[name="filter-type"]:checked').value;
-
-                            if (selectedType === 'time') {
-                                const startTime = startTimeInput.value;
-                                const endTime = endTimeInput.value;
-                                if (startTime && endTime && new Date(startTime) > new Date(endTime)) {
-                                    showError("结束时间不能早于开始时间。");
-                                    return;
-                                }
-                                filterState.startTime = startTime || null;
-                                filterState.endTime = endTime || null;
-                                filterState.startPage = null;
-                            } else { // page
-                                const startPage = parseInt(startPageInput.value, 10);
-                                if (startPageInput.value && (isNaN(startPage) || startPage < 1)) {
-                                    showError("起始页码必须是大于0的整数。");
-                                    return;
-                                }
-                                filterState.startTime = null;
-                                filterState.endTime = null;
-                                filterState.startPage = isNaN(startPage) ? null : startPage;
-                            }
-
-                            saveToLocalStorage('filterData', filterState);
-                            filterWidget.value = JSON.stringify(filterState);
-
-                            if (filterState.startTime || filterState.endTime || filterState.startPage) {
-                                filterButton.classList.add('active');
-                            } else {
-                                filterButton.classList.remove('active');
-                            }
-
-                            dialog.remove();
-                            fetchAndRender(true);
-                        }
-                    });
-                    footer.append(cancelButton, resetButton, applyButton);
-
-                    content.append(title, body, footer);
-                    dialog.append(content);
-                    container.appendChild(dialog);
-
-                    // Manually trigger change event to set initial visual state
-                    const initialCheckedRadio = radioGroup.querySelector('input[type="radio"]:checked');
-                    if (initialCheckedRadio) {
-                        initialCheckedRadio.dispatchEvent(new Event('change', { bubbles: true }));
-                    }
-                };
-
-                // 黑名单功能
-                let currentBlacklist = [];
-
-                // 提示词过滤功能
-                let currentFilterTags = [];
-                let filterEnabled = true; // 默认开启过滤功能
-                let uiSettings = {
-                    autocomplete_enabled: true,
-                    tooltip_enabled: true,
-                    autocomplete_max_results: 20,
-                    selected_categories: ["copyright", "character", "general"],
-                    multi_select_enabled: false,
-                    source_site: "danbooru",
-                    gelbooru_display_all_site_content: false,
-                    formatting: {
-                        escapeBrackets: true,
-                        replaceUnderscores: true,
-                    }
-                };
-
-                const loadUiSettings = async () => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/ui_settings');
-                        const data = await response.json();
-                        if (data.success) {
-                            uiSettings = {
-                                autocomplete_enabled: data.settings.autocomplete_enabled,
-                                tooltip_enabled: data.settings.tooltip_enabled,
-                                autocomplete_max_results: data.settings.autocomplete_max_results || 20,
-                                selected_categories: data.settings.selected_categories || ["copyright", "character", "general"],
-                                multi_select_enabled: data.settings.multi_select_enabled || false,
-                                source_site: data.settings.source_site || "danbooru",
-                                gelbooru_display_all_site_content: data.settings.gelbooru_display_all_site_content || false,
-                                formatting: data.settings.formatting || { escapeBrackets: true, replaceUnderscores: true }
-                            };
-                        }
-                    } catch (e) {
-                        logger.warn("加载UI设置失败:", e);
-                    }
-                };
-
-                const saveUiSettings = async (settings) => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/ui_settings', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify(settings)
-                        });
-                        const data = await response.json();
-                        return data.success;
-                    } catch (e) {
-                        logger.warn("保存UI设置失败:", e);
-                        return false;
-                    }
-                };
-
-                const loadBlacklist = async () => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/blacklist');
-                        const data = await response.json();
-                        currentBlacklist = data.blacklist || [];
-                    } catch (e) {
-                        logger.warn("加载黑名单失败:", e);
-                        currentBlacklist = [];
-                    }
-                };
-
-                const saveBlacklist = async (blacklistItems) => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/blacklist', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({ blacklist: blacklistItems })
-                        });
-                        const data = await response.json();
-                        return data.success;
-                    } catch (e) {
-                        logger.warn("保存黑名单失败:", e);
-                        return false;
-                    }
-                };
-
-                const loadFilterTags = async () => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/filter_tags');
-                        const data = await response.json();
-                        currentFilterTags = data.filter_tags || [];
-                        filterEnabled = data.filter_enabled !== undefined ? data.filter_enabled : true;
-                    } catch (e) {
-                        logger.warn("加载提示词过滤设置失败:", e);
-                        currentFilterTags = [];
-                        filterEnabled = true; // 默认开启
-                    }
-                };
-
-                const saveFilterTags = async (filterTags, enabled) => {
-                    try {
-                        const response = await fetch('/danbooru_gallery/filter_tags', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({ filter_tags: filterTags, filter_enabled: enabled })
-                        });
-                        const data = await response.json();
-                        return data.success;
-                    } catch (e) {
-                        logger.warn("保存提示词过滤设置失败:", e);
-                        return false;
-                    }
-                };
-
-
-                // 文件类型过滤函数 - 只允许静态图像
-                const isValidImageType = (post) => {
-                    // 允许的静态图像文件扩展名
-                    const allowedImageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'bmp', 'tiff', 'tif'];
-
-                    if (post.source_site === "gelbooru" && post._gelbooru_preview_only) {
-                        return true;
-                    }
-
-                    // 检查文件扩展名
-                    if (post.file_ext) {
-                        const fileExt = post.file_ext.toLowerCase();
-                        return allowedImageExtensions.includes(fileExt);
-                    }
-
-                    // 如果没有file_ext字段，尝试从file_url中提取扩展名
-                    if (post.file_url) {
-                        const url = post.file_url.toLowerCase();
-                        const extMatch = url.match(/\.([^.?#]+)(?:\?|#|$)/);
-                        if (extMatch) {
-                            const fileExt = extMatch[1];
-                            return allowedImageExtensions.includes(fileExt);
-                        }
-                    }
-
-                    // 如果无法确定文件类型，默认拒绝
-                    return false;
-                };
-
-                // 本地黑名单过滤函数
-                const isPostBlacklisted = (post) => {
-                    if (!currentBlacklist || currentBlacklist.length === 0) {
-                        return false;
-                    }
-
-                    // 获取帖子的所有标签
-                    const allTags = [];
-                    if (post.tag_string) allTags.push(...post.tag_string.split(' '));
-                    if (post.tag_string_artist) allTags.push(...post.tag_string_artist.split(' '));
-                    if (post.tag_string_copyright) allTags.push(...post.tag_string_copyright.split(' '));
-                    if (post.tag_string_character) allTags.push(...post.tag_string_character.split(' '));
-                    if (post.tag_string_general) allTags.push(...post.tag_string_general.split(' '));
-                    if (post.tag_string_meta) allTags.push(...post.tag_string_meta.split(' '));
-
-                    // 检查是否包含黑名单中的任何标签
-                    for (const blacklistTag of currentBlacklist) {
-                        const normalizedBlacklistTag = blacklistTag.trim().toLowerCase();
-                        if (normalizedBlacklistTag && allTags.some(tag => tag.toLowerCase() === normalizedBlacklistTag)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                };
-
-                // 综合过滤函数 - 检查文件类型和黑名单
-                const isPostFiltered = (post) => {
-                    // 首先检查是否为有效的图像类型
-                    if (!isValidImageType(post)) {
-                        return true; // 如果不是有效图像类型，则过滤掉
-                    }
-
-                    // 然后检查黑名单
-                    return isPostBlacklisted(post);
-                };
-
-                // 获取单个帖子的原始数据
-                const fetchOriginalPost = async (postId) => {
-                    try {
-                        const params = new URLSearchParams({
-                            source: uiSettings.source_site || "danbooru",
-                            "search[tags]": `id:${postId}`,
-                            limit: "1",
-                            page: "1",
-                        });
-                        params.set("gelbooru_display_all_site_content", uiSettings.gelbooru_display_all_site_content ? "1" : "0");
-                        if ((uiSettings.source_site || "danbooru") === "gelbooru") {
-                            params.set("force_public_detail", "1");
-                        }
-                        const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        const data = await response.json();
-                        if (data && data.length > 0) {
-                            return data[0];
-                        }
-                        return null;
-                    } catch (error) {
-                        logger.error("Failed to fetch original post data:", error);
-                        return null;
-                    }
-                };
-
-                // 反向转换函数：将显示格式的标签转换回Danbooru API格式
-                const splitTagString = (value) => String(value || "").split(/\s+/).map(tag => tag.trim()).filter(Boolean);
-
-                const hasCategorizedTags = (postData) => Boolean(
-                    postData?.tag_string_artist ||
-                    postData?.tag_string_copyright ||
-                    postData?.tag_string_character ||
-                    postData?.tag_string_meta
-                );
-
-                const isUsableOriginalUrl = (postData, url) => Boolean(
-                    url &&
-                    !postData?._gelbooru_preview_only &&
-                    !(postData?.source_site === "gelbooru" && postData?.preview_file_url && url === postData.preview_file_url)
-                );
-
-                const hydrateGelbooruPost = async (postData) => {
-                    const hasUsableOriginal = isUsableOriginalUrl(postData, postData?.file_url);
-                    if (!postData || postData.source_site !== "gelbooru" || postData._gelbooru_hydrated || (hasCategorizedTags(postData) && hasUsableOriginal)) {
-                        return postData;
-                    }
-
-                    const cachedPost = originalPostCache[postData.id];
-                    const cachedHasUsableOriginal = isUsableOriginalUrl(cachedPost, cachedPost?.file_url);
-                    if (cachedPost && (cachedPost._gelbooru_hydrated || (hasCategorizedTags(cachedPost) && cachedHasUsableOriginal))) {
-                        return originalPostCache[postData.id];
-                    }
-
-                    const hydratedPost = await fetchOriginalPost(postData.id);
-                    if (!hydratedPost) {
-                        return postData;
-                    }
-
-                    const mergedPost = { ...postData, ...hydratedPost, _gelbooru_hydrated: true };
-                    const postIndex = posts.findIndex(p => p.id == postData.id);
-                    if (postIndex !== -1) {
-                        posts[postIndex] = mergedPost;
-                    }
-                    originalPostCache[postData.id] = JSON.parse(JSON.stringify(mergedPost));
-                    return mergedPost;
-                };
-
-                const hydrateGelbooruTooltipPost = hydrateGelbooruPost;
-
-                const getBestImageUrl = (postData, allowPreviewFallback = true) => {
-                    if (!postData) return "";
-                    if (isUsableOriginalUrl(postData, postData.file_url)) return postData.file_url;
-                    if (isUsableOriginalUrl(postData, postData.large_file_url)) return postData.large_file_url;
-                    return allowPreviewFallback ? (postData.preview_file_url || "") : "";
-                };
-
-                const getPostWithOriginalMedia = (postData) => {
-                    const basePost = temporaryTagEdits[postData.id] || postData;
-                    // 同步：帖子在加载时已完成 hydrate，选图时无需再 await 网络请求
-                    return basePost;
-                };
-
-                const proxiedMediaUrl = (url) => `/danbooru_gallery/image_proxy?url=${encodeURIComponent(url)}`;
-
-                const getImageExtension = (postData, imageUrl) => {
-                    if (postData?.file_ext) return postData.file_ext;
-                    const match = String(imageUrl || "").toLowerCase().match(/\.([a-z0-9]+)(?:[?#]|$)/);
-                    return match ? match[1] : "jpg";
-                };
-
-                const getSelectedPromptCategories = () => {
-                    const selected = Array.from(categoryDropdown.querySelectorAll("input:checked"))
-                        .map(i => i.name)
-                        .filter(name => TAG_CATEGORY_ORDER.includes(name));
-                    return selected.length > 0 ? selected : [...TAG_CATEGORY_ORDER];
-                };
-
-                const buildCategorizedTagLists = (postData) => {
-                    const categorizedTags = Object.fromEntries(TAG_CATEGORY_ORDER.map(category => [category, []]));
-                    const seen = new Set();
-
-                    const addTag = (category, tag) => {
-                        const cleanTag = String(tag || "").trim();
-                        if (!cleanTag || seen.has(cleanTag)) return;
-                        categorizedTags[category].push(cleanTag);
-                        seen.add(cleanTag);
-                    };
-
-                    TAG_CATEGORY_ORDER.forEach(category => {
-                        splitTagString(postData?.[`tag_string_${category}`]).forEach(tag => addTag(category, tag));
-                    });
-
-                    if (Object.values(categorizedTags).every(tags => tags.length === 0)) {
-                        splitTagString(postData?.tag_string).forEach(tag => addTag("general", tag));
-                    }
-
-                    return categorizedTags;
-                };
-
-                const normalizeTagForFilter = (tag) => String(tag || "")
-                    .trim()
-                    .toLowerCase()
-                    .replace(/\\([()])/g, '$1')
-                    .replace(/[,\s]+/g, '_')
-                    .replace(/^_+|_+$/g, '');
-
-                const getFilterTagSet = () => {
-                    if (!filterEnabled || currentFilterTags.length === 0) {
-                        return null;
-                    }
-                    return new Set(currentFilterTags.map(normalizeTagForFilter).filter(Boolean));
-                };
-
-                const shouldKeepPromptTag = (tag, filterTagSet) => {
-                    if (!filterTagSet) return true;
-                    return !filterTagSet.has(normalizeTagForFilter(tag));
-                };
-
-                const formatPromptTag = (tag) => {
-                    const escapeBrackets = formattingDropdown.querySelector('[name="escapeBrackets"]')?.checked ?? true;
-                    const replaceUnderscores = formattingDropdown.querySelector('[name="replaceUnderscores"]')?.checked ?? true;
-                    let processedTag = String(tag || "").trim();
-                    if (!processedTag) return "";
-                    if (replaceUnderscores) {
-                        processedTag = processedTag.replace(/_/g, ' ');
-                    }
-                    if (escapeBrackets) {
-                        processedTag = processedTag.replaceAll('(', '\\(').replaceAll(')', '\\)');
-                    }
-                    return processedTag;
-                };
-
-                const convertTagsToApiFormat = (tagsString) => {
-                    if (!tagsString) return "";
-
-                    // 只按逗号分割标签，保持空格作为标签名称的一部分
-                    const tags = tagsString.split(',').filter(tag => tag.trim() !== '');
-
-                    return tags.map(tag => {
-                        let convertedTag = tag.trim();
-
-                        // 1. 反转义括号：\( -> (, \) -> )
-                        convertedTag = convertedTag.replace(/\\([()])/g, '$1');
-
-                        // 2. 空格转换为下划线（如果包含空格且不是特殊tag）
-                        // 特殊tag通常以冒号开头（如 order:rank, ordfav:username）
-                        if (!convertedTag.includes(':')) {
-                            convertedTag = convertedTag.replace(/\s+/g, '_');
-                        }
-
-                        return convertedTag;
-                    }).join(' ');
-                };
-
-                let currentTags = ""; // 追踪当前搜索条件，用于决定是否重置游标（搜索条件变化时清空 lastPostId）
-
-                const fetchAndRender = async (reset = false) => {
-                    if (isLoading) return;
-                    if (endOfResults && !reset) return;
-                    isLoading = true;
-                    refreshButton.classList.add("loading");
-                    refreshButton.disabled = true;
-
-                    const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
-                    if (!loadingIndicator) {
-                        imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
-                    }
-
-                    if (reset) {
-                        currentPage = filterState.startPage || 1;
-                        const newTags = searchInput.value.trim();
-                        if (newTags !== currentTags) {
-                            lastPostId = null;
-                            scrollAnchorPostId = null;
-                            seenPostIds.clear();
-                        } else if (scrollAnchorPostId) {
-                            // 搜索条件没变 + 有锚点 → 用锚点做游标，往下接
-                            lastPostId = scrollAnchorPostId;
-                        }
-                        currentTags = newTags;
-
-                        posts = [];
-                        endOfResults = false;
-                        imageGrid.innerHTML = "";
-                        imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
-                    }
-
-                    // 网络检查
-                    const isNetworkConnected = await checkNetworkStatus();
-                    if (!isNetworkConnected) {
-                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");
-                        imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
-                        isLoading = false;
-                        refreshButton.classList.remove("loading");
-                        refreshButton.disabled = false;
-                        const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) indicator.remove();
-                        return;
-                    } else {
-                        clearError();
-                    }
-
-                    let parseFailed = false;
-                    try {
-                        const searchValue = searchInput.value.trim();
-                        const tags = searchValue.split(',').filter(tag => tag.trim() !== '');
-                        const tagCount = tags.length;
-
-                        if (tagCount > 2) {
-                            showTagHint('搜索只考虑前两个tag，第三个及后续tag将被忽略', false);
-                        } else {
-                            clearTagHint();
-                        }
-
-                        let apiFormattedTags = convertTagsToApiFormat(searchValue);
-
-                        // 添加日期筛选
-                        if (filterState.startTime || filterState.endTime) {
-                            const start = filterState.startTime ? new Date(filterState.startTime).toISOString().split('T')[0] : '';
-                            const end = filterState.endTime ? new Date(filterState.endTime).toISOString().split('T')[0] : '';
-                            apiFormattedTags += ` date:${start}..${end}`;
-                        }
-
-                        const src = uiSettings.source_site || "danbooru";
-                        const dedup = uiSettings.gelbooru_dedup_mode || "off";
-                        const selectedRatings = getSelectedRatings();
-                        const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
-                        const ratingForServer = sendAll ? "" : selectedRatings.join(",");
-                        const params = new URLSearchParams({
-                            "source": src,
-                            "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
-                            "gelbooru_dedup_mode": dedup,
-                            "search[tags]": apiFormattedTags.trim(),
-                            "search[rating]": ratingForServer,
-                            limit: "40",
-                            page: currentPage,
-                        });
-
-                        // 游标分页：D站始终用游标；G站仅当 dedup 非 off 时
-                        const useCursor = src === "danbooru" || (src === "gelbooru" && dedup !== "off");
-                        if (useCursor && lastPostId) {
-                            params.set("before_id", lastPostId);
-                        }
-
-                        // G站游标模式下 pid 恒为 0，不允许当前页推进
-                        const gelbooruCursorMode = (src === "gelbooru" && dedup !== "off");
-
-                        const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        const rawText = await response.text();
-
-                        // 防御性 JSON 解析：后端偶发返回非 JSON（错误页/半截响应），此时不销毁已有内容
-                        let newPosts;
-                        try {
-                            newPosts = JSON.parse(rawText);
-                        } catch (parseErr) {
-                            logger.warn(`[fetchAndRender] 响应解析失败(status=${response.status})，本次跳过:`, parseErr?.message || parseErr);
-                            parseFailed = true;
-                            newPosts = [];
-                        }
-                        if (!Array.isArray(newPosts)) newPosts = [];
-
-                        if (parseFailed) {
-                            if (reset) {
-                                imageGrid.innerHTML = `<p class="danbooru-status error">响应解析失败(status=${response.status})</p>`;
-                                return;
-                            }
-                            renderPost({ error: `响应解析失败(status=${response.status})` });
-                            return;
-                        }
-
-                        // 先分离 error 占位格与正常 post
-                        const errorPosts = newPosts.filter(p => p && p.error);
-                        const normalRaw = newPosts.filter(p => !p || !p.error);
-
-                        // 去重：seenPostIds 中已存在的跳过（防止 G站 pid 失效产生的重复被加入 posts 数组）
-                        const freshRaw = normalRaw.filter(p => !seenPostIds.has(String(p.id)));
-                        freshRaw.forEach(p => seenPostIds.add(String(p.id)));
-
-                        // 对正常格做过滤
-                        const filteredPosts = freshRaw.filter(post => !isPostFiltered(post));
-
-                        if (errorPosts.length > 0) {
-                            if (reset && filteredPosts.length === 0 && freshRaw.length === 0) {
-                                // 首次加载全是 error 格：整屏错误
-                                imageGrid.innerHTML = `<p class="danbooru-status error">${errorPosts[0].error}</p>`;
-                                return;
-                            }
-                            // 续加载/混合正常格：追加 error 格
-                            errorPosts.forEach(renderPost);
-                        }
-
-                        if (newPosts.length === 0 && errorPosts.length === 0) {
-                            endOfResults = true;
-                            if (reset) {
-                                imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
-                            }
-                            return;
-                        }
-
-                        if (filteredPosts.length === 0 && freshRaw.length === 0 && reset && errorPosts.length === 0) {
-                            imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
-                            return;
-                        }
-
-                        // 确保即使在 cursor 模式下过滤掉了所有正常图片也能推进游标
-                        if (normalRaw.length > 0) {
-                            lastPostId = normalRaw[normalRaw.length - 1].id;
-                        }
-
-                        // G站游标模式下 pid 恒定不推进；D站正常推进 page
-                        if (!gelbooruCursorMode) {
-                            currentPage++;
-                        }
-
-                        posts.push(...filteredPosts);
-                        filteredPosts.forEach(renderPost);
-
-                        // 去重陷阱检测：本页有返回值但全部是已见过的 → 判定到底
-                        if (freshRaw.length === 0 && normalRaw.length > 0 && !reset) {
-                            endOfResults = true;
-                            logger.warn(`[fetchAndRender] 本页 ${newPosts.length} 张全是重复，判定到底/分页失效，停止加载`);
-                            return;
-                        }
-
-                        // Filter-cascade guard
-                        if (filteredPosts.length === 0 && !reset) {
-                            await new Promise(r => setTimeout(r, 1500));
-                        }
-
-                    } catch (e) {
-                        // 首次加载→整屏错误；滚动续拉→保留内容+加错误格
-                        if (reset) {
-                            imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
-                        } else {
-                            logger.warn('[fetchAndRender] 加载失败，保留已有内容:', e?.message || e);
-                            renderPost({ error: `请求失败: ${e.message}` });
-                        }
-                    } finally {
-                        isLoading = false;
-                        refreshButton.classList.remove("loading");
-                        refreshButton.disabled = false;
-                        const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) indicator.remove();
-                        // 刷新后还原滚动位置
-                        if (reset && scrollAnchorPostId) {
-                            // 等 maybeLoadMore 链走完（多个 setTimeout(…,0)）后尝试还原
-                            const attemptScroll = (retries = 8) => {
-                                const target = imageGrid.querySelector(`[data-post-id="${scrollAnchorPostId}"]`);
-                                if (target) {
-                                    target.scrollIntoView({ block: "start", behavior: "instant" });
-                                    return;
-                                }
-                                if (retries > 0) {
-                                    setTimeout(() => attemptScroll(retries - 1), 150);
-                                }
-                            };
-                            setTimeout(() => attemptScroll(), 300);
-                        }
-                        // 每次加载完成后检查是否需要补充更多（maybeLoadMore）
-                        if (!endOfResults && !parseFailed) {
-                            maybeLoadMore();
-                        }
-                    }
-                };
-
-                const maybeLoadMore = () => {
-                    if (isLoading || endOfResults) return;
-                    const bufferTarget = parseInt(uiSettings.preload_count, 10) || 40;
-                    const scrollH = imageGrid.scrollHeight;
-                    let viewedCount = 0;
-                    if (scrollH > 0) {
-                        const viewedRatio = Math.min(1, (imageGrid.scrollTop + imageGrid.clientHeight) / scrollH);
-                        viewedCount = Math.floor(posts.length * viewedRatio);
-                    }
-                    const aheadBuffer = posts.length - viewedCount;
-                    if (aheadBuffer < bufferTarget) {
-                        // 异步触发避免递归撑爆调用栈
-                        setTimeout(() => fetchAndRender(false), 0);
-                    }
-                };
-
-                // Queue 按钮拦截：每次点击时将当前选中快照推入后端 FIFO 队列
-                const _hookQueueButton = () => {
-                    // 兼容不同 ComfyUI 前端版本：data-testid（新版）/ #comfy-queue-btn（旧版）
-                    const queueBtn = document.querySelector('[data-testid="queue-button"]') || document.getElementById("comfy-queue-btn");
-                    if (!queueBtn) { setTimeout(_hookQueueButton, 500); return; }
-                    queueBtn.addEventListener("click", async () => {
-                        const selectedWrappers = imageGrid.querySelectorAll('.danbooru-image-wrapper.selected');
-                        if (selectedWrappers.length === 0) return;
-                        const selections = [];
-                        for (const wrapper of selectedWrappers) {
-                            const postId = wrapper.dataset.postId;
-                            const postData = posts.find(p => p.id == postId) || temporaryTagEdits[postId];
-                            if (postData) {
-                                const prompt = buildPromptForPost(postData);
-                                const mediaPost = getPostWithOriginalMedia(postData);
-                                const imageUrl = getBestImageUrl(mediaPost, false);
-                                selections.push({ post_id: postId, prompt, image_url: imageUrl });
-                            }
-                        }
-                        if (selections.length === 0) return;
-                        selectionQueueId++;
-                        await fetch("/danbooru_gallery/selection_queue_push", {
-                            method: "POST",
-                            headers: { "Content-Type": "application/json" },
-                            body: JSON.stringify({ item: { selections, _queue_id: selectionQueueId } })
-                        });
-                    }, true); // useCapture = true：在原始 onclick 之前触发
-                };
-                setTimeout(_hookQueueButton, 1000);
-
-                const resizeGrid = () => {
-                    try {
-                        const cs = window.getComputedStyle(imageGrid);
-                        const rowGap = parseInt(cs.getPropertyValue('grid-row-gap')) || parseInt(cs.rowGap) || 5;
-                        const rowHeight = parseInt(cs.getPropertyValue('grid-auto-rows')) || 1;
-
-                        Array.from(imageGrid.children).forEach((wrapper) => {
-                            const img = wrapper.querySelector('img');
-                            if (img && img.clientHeight > 0) {
-                                const spans = Math.ceil((img.clientHeight + rowGap) / (rowHeight + rowGap));
-                                wrapper.style.gridRowEnd = `span ${spans}`;
-                            }
-                        });
-                    } catch (e) {
-                        // 计算失败不影响主体流程
-                    }
-                }
-
-                // Pre-reserve grid space from post dimensions so rate-limited async loads
-                // don't cause the waterfall to jump every time an image arrives.
-                let cachedColumnWidth = 0;
-                const getColumnWidth = () => {
-                    if (cachedColumnWidth > 0) return cachedColumnWidth;
-                    try {
-                        const cs = window.getComputedStyle(imageGrid);
-                        const template = cs.gridTemplateColumns;
-                        if (template && template !== 'none') {
-                            const cols = template.split(' ');
-                            const px = parseFloat(cols[0]);
-                            if (px > 0) cachedColumnWidth = px;
-                        }
-                    } catch (e) {}
-                    return cachedColumnWidth || 150; // grid 未 layout 时保底 150px
-                };
-                const computeSpanFromDims = (imgW, imgH) => {
-                    const colW = getColumnWidth();
-                    if (!colW || !imgW || !imgH) return 0;
-                    const cs = window.getComputedStyle(imageGrid);
-                    const rowGap = parseInt(cs.gridRowGap) || parseInt(cs.rowGap) || 5;
-                    const rowHeight = parseInt(cs.gridAutoRows) || 1;
-                    const renderedH = colW * (imgH / imgW);
-                    return Math.ceil((renderedH + rowGap) / (rowHeight + rowGap));
-                };
-                // Coalesce rapid onload calls (rate-limited loads fire 200ms apart; batching
-                // to one reflow per frame avoids N² layout work as the page fills in).
-                let resizeGridTimer = null;
-                const scheduleResizeGrid = () => {
-                    if (resizeGridTimer) return;
-                    resizeGridTimer = requestAnimationFrame(() => {
-                        resizeGridTimer = null;
-                        resizeGrid();
-                    });
-                };
-
-                const showEditPanel = (post) => {
-                    // 在打开编辑面板时，检查当前图像是否被选中
-                    // 强制将当前编辑的图像设置为选中状态，并更新 selectionWidget
-                    const currentSelectedElement = imageGrid.querySelector('.danbooru-image-wrapper.selected');
-                    if (currentSelectedElement && currentSelectedElement.dataset.postId && currentSelectedElement.dataset.postId != post.id) { // 检查 dataset.postId 是否存在
-                        currentSelectedElement.classList.remove('selected');
-
-                    }
-                    const targetWrapper = imageGrid.querySelector(`.danbooru-image-wrapper[data-post-id="${post.id}"]`);
-                    if (targetWrapper) {
-                        targetWrapper.classList.add('selected');
-                        // 触发一次点击事件来更新 selectionWidget
-                        // 注意：这里直接调用 onclick 可能会导致事件冒泡问题，
-                        // 更好的方式是直接更新 selectionWidget 的值
-                        // targetWrapper.querySelector('img').click();
-                        // 而是直接更新 selectionWidget
-                        updateSelectionData();
-                    }
-                    const isPostCurrentlySelected = true; // 因为我们已经强制选中了
-
-
-                    if (!temporaryTagEdits[post.id]) {
-                        // Create a deep copy for editing if it doesn't exist
-                        temporaryTagEdits[post.id] = JSON.parse(JSON.stringify(post));
-                    }
-                    const editablePost = temporaryTagEdits[post.id];
-
-                    // Panel container
-                    const panel = $el("div.danbooru-edit-panel", {
-                        style: {
-                            position: "fixed", top: "0", left: "0", width: "100%", height: "100%",
-                            backgroundColor: "rgba(0, 0, 0, 0.7)", zIndex: "10001",
-                            display: "flex", alignItems: "center", justifyContent: "center"
-                        }
-                    });
-
-                    // Panel content
-                    const content = $el("div.danbooru-edit-panel-content", {
-                        style: {
-                            backgroundColor: "var(--comfy-menu-bg)", border: "1px solid var(--input-border-color)",
-                            borderRadius: "12px", padding: "20px", width: "700px", maxWidth: "90vw",
-                            maxHeight: "80vh", display: "flex", flexDirection: "column",
-                            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)"
-                        }
-                    });
-
-                    // Title
-                    const titleBar = $el("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "15px" } }, [
-                        $el("h2", { textContent: t('editPanelTitle'), style: { margin: "0", color: "var(--comfy-input-text)", fontSize: "1.3em" } }),
-                        $el("button.danbooru-edit-panel-close-button", {
-                            innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`,
-                            title: t('close'),
-                            onclick: () => closePanel(isPostCurrentlySelected) // 将捕获到的选中状态传递给 closePanel
-                        })
-                    ]);
-
-                    const tagsContainer = $el("div.danbooru-edit-tags-container", { style: { overflowY: "auto", flex: "1", paddingRight: "10px" } });
-
-                    const closePanel = async (wasSelectedOnOpen) => { // 接收打开面板时的选中状态
-                        panel.remove();
-                        const currentPostInArray = posts.find(p => p.id == post.id); // 获取posts数组中最新的post数据
-                        if (!currentPostInArray) {
-                            return;
-                        }
-
-                        // 准备数据，如果被编辑过则使用临时数据
-                        let postDataToRender = temporaryTagEdits[post.id];
-
-                        // 获取原始数据，用于比较
-                        const originalPost = originalPostCache[post.id];
-
-                        // 检查是否有实际编辑
-                        let hasActualEdits = false;
-                        if (postDataToRender && originalPost) {
-                            const categories = ["artist", "copyright", "character", "general", "meta"];
-                            for (const category of categories) {
-                                if (!compareTagStrings(originalPost[`tag_string_${category}`], postDataToRender[`tag_string_${category}`])) {
-                                    hasActualEdits = true;
-                                    break;
-                                }
-                            }
-                            if (!hasActualEdits && !compareTagStrings(originalPost.tag_string, postDataToRender.tag_string)) {
-                                hasActualEdits = true;
-                            }
-                        }
-
-                        if (hasActualEdits) {
-                            // 如果有实际编辑，用编辑后的数据更新posts数组
-                            const postIndex = posts.findIndex(p => p.id == post.id);
-                            if (postIndex !== -1) {
-                                posts[postIndex] = JSON.parse(JSON.stringify(postDataToRender)); // 确保深拷贝
-                            }
-                        } else {
-                            // 如果没有实际编辑，清理临时副本
-                            temporaryTagEdits[post.id] = undefined;
-                            postDataToRender = currentPostInArray; // 确保渲染时使用 posts 数组中的当前数据
-                        }
-
-                        // 重新渲染该post
-                        const oldPostElement = imageGrid.querySelector(`.danbooru-image-wrapper[data-post-id="${post.id}"]`);
-
-                        const postIndex = posts.findIndex(p => p.id == post.id);
-                        const newPostElement = createPostElement(posts[postIndex]); // 使用 posts 数组中的最新数据
-                        if (newPostElement) {
-                            if (oldPostElement && oldPostElement.parentNode) {
-                                oldPostElement.parentNode.replaceChild(newPostElement, oldPostElement);
-                            } else {
-                                imageGrid.prepend(newPostElement);
-                            }
-                            resizeGrid();
-                        } else {
-                            if (oldPostElement) {
-                                oldPostElement.remove();
-                            }
-                        }
-
-                        // 无论是否编辑，如果打开面板时是选中状态，都强制更新selectionWidget和选中样式
-                        if (wasSelectedOnOpen) {
-                            // 重新给新元素添加选中状态
-                            if (newPostElement) {
-                                newPostElement.classList.add('selected');
-
-                            }
-                            updateSelectionData();
-                        } else { // 如果打开面板时未选中，则清除所有选中的图像和提示词
-
-                            imageGrid.querySelectorAll('.danbooru-image-wrapper.selected').forEach(w => {
-
-                                w.classList.remove('selected');
-                            });
-                            if (nodeInstance && nodeInstance.widgets) {
-                                const selectionWidget = nodeInstance.widgets.find(w => w.name === "selection_data");
-                                if (selectionWidget) {
-                                    selectionWidget.value = JSON.stringify({});
-                                    selectionWidget.callback();
-
-                                }
-                            }
-                        }
-
-                        // 重新计算 isTrulyEdited 状态并更新指示器 (这里调用 updateEditedStatus 会基于新的逻辑进行判断)
-                        // 注意：这里不再需要手动删除 temporaryTagEdits，因为 updateEditedStatus 会在判断为未编辑时将其设置为 undefined
-                        let indicator = newPostElement ? newPostElement.querySelector('.danbooru-edited-indicator') : null;
-                        if (newPostElement) {
-                            // 确保 newPostElement 已经添加到 DOM 中，updateEditedStatus 才能找到 indicator
-                            // 或者直接传递 isTrulyEdited 状态
-                            updateEditedStatus(newPostElement, post.id); // 调用更新函数
-                        }
-                    };
-
-                    content.appendChild(titleBar);
-                    content.appendChild(tagsContainer);
-
-                    // Add a footer for action buttons
-                    const editPanelFooter = $el("div", {
-                        style: {
-                            display: "flex",
-                            justifyContent: "flex-end", // Changed to align items to the end (right)
-                            alignItems: "center",
-                            marginTop: "15px",
-                            paddingTop: "15px",
-                            borderTop: "1px solid var(--input-border-color)",
-                            gap: "10px", // Add some gap between buttons
-                        }
-                    });
-
-                    // "Copy Tags to Clipboard" button
-                    const copyTagsButton = $el("button", {
-                        innerHTML: `📋 ${t('copyTags')}`,
-                        style: {
-                            padding: "8px 15px",
-                            border: "1px solid #7B68EE",
-                            borderRadius: "6px",
-                            backgroundColor: "transparent",
-                            color: "#7B68EE",
-                            cursor: "pointer",
-                            fontSize: "14px",
-                            fontWeight: "500",
-                            transition: "all 0.2s ease"
-                        },
-                        onclick: async () => {
-                            // Collect selected categories from checkboxes
-                            const selectedCategoriesCheckboxes = panel.querySelectorAll('.danbooru-edit-category-checkbox:checked');
-                            const selectedCategoriesToCopy = Array.from(selectedCategoriesCheckboxes).map(cb => cb.name);
-
-                            const postToCopy = temporaryTagEdits[post.id] || post;
-                            const formattedTags = buildPromptForPost(postToCopy, selectedCategoriesToCopy);
-
-                            if (formattedTags) {
-                                try {
-                                    await navigator.clipboard.writeText(formattedTags);
-                                    showToast(t('copyTagsSuccess'), 'success', copyTagsButton);
-                                } catch (err) {
-                                    showToast(t('copyTagsFail'), 'error', copyTagsButton);
-                                    logger.error('Failed to copy: ', err);
-                                }
-                            } else {
-                                showToast(t('noTagsToCopy'), 'info', copyTagsButton);
-                            }
-                        }
-                    });
-                    editPanelFooter.appendChild(copyTagsButton);
-
-                    // "Reset Tags" button (moved and restyled)
-                    const resetTagsButton = $el("button.danbooru-reset-tags-button", {
-                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg> ${t('resetTags')}`,
-                        title: t('resetTags'),
-                        onclick: async () => {
-                            // 1. 从缓存中获取原始post数据
-                            const originalPostData = originalPostCache[post.id];
-
-                            if (originalPostData) {
-                                // 2. Update posts array with original data
-                                const postIndex = posts.findIndex(p => p.id === post.id);
-                                if (postIndex !== -1) {
-                                    posts[postIndex] = JSON.parse(JSON.stringify(originalPostData)); // 确保深拷贝
-                                }
-
-                                // 3. Clear temporaryTagEdits for this post
-                                temporaryTagEdits[post.id] = undefined;
-
-                                // 4. Re-render tags in the panel with the original data
-                                renderTagsInPanel(tagsContainer, originalPostData, panel);
-
-                                // 5. Update "edited" indicator on the main grid item
-                                const wrapperElement = imageGrid.querySelector(`.danbooru-image-wrapper[data-post-id="${post.id}"]`);
-                                if (wrapperElement) {
-                                    updateEditedStatus(wrapperElement, originalPostData.id);
-                                }
-
-                                // 6. Update selectionWidget if the post is currently selected
-                                if (isPostCurrentlySelected) {
-                                    updateSelectionData();
-                                }
-                                showToast(t('resetTags') + '成功', 'success', resetTagsButton);
-                            } else {
-                                // 如果缓存中没有原始数据，尝试从服务器获取一次
-                                const fetchedOriginalPost = await fetchOriginalPost(post.id);
-                                if (fetchedOriginalPost) {
-                                    originalPostCache[post.id] = JSON.parse(JSON.stringify(fetchedOriginalPost)); // 缓存获取到的数据
-                                    // 再次调用自身，以使用缓存中的数据进行重置
-                                    showToast('已从服务器获取原始标签，请再次点击重置。', 'info', resetTagsButton);
-                                    // 重新渲染面板
-                                    renderTagsInPanel(tagsContainer, originalPostCache[post.id], panel);
-                                } else {
-                                    showError('未能获取原始标签，请检查网络或稍后重试。', false, resetTagsButton);
-                                }
-                            }
-                        }
-                    });
-                    editPanelFooter.appendChild(resetTagsButton);
-
-                    content.appendChild(editPanelFooter);
-                    panel.appendChild(content);
-
-                    // Close panel when clicking background
-                    panel.addEventListener('click', (e) => {
-                        if (e.target === panel) {
-                            closePanel();
-                        }
-                    });
-
-                    document.body.appendChild(panel);
-
-                    renderTagsInPanel(tagsContainer, editablePost, panel);
-                };
-
-                const renderTagsInPanel = async (tagsContainer, postData, panel) => {
-                    tagsContainer.innerHTML = ''; // Clear existing tags
-
-                    const createClickableTagSpan = (tag, category, translation = null) => {
-                        const displayText = translation ? `${tag} [${translation}]` : tag;
-                        const span = $el("span", {
-                            textContent: displayText,
-                            className: `danbooru-tooltip-tag danbooru-clickable-tag tag-category-${category}`,
-                        });
-
-                        const removeExistingMenus = () => {
-                            document.querySelectorAll('.danbooru-tag-context-menu').forEach(menu => menu.remove());
-                        };
-
-                        span.addEventListener('click', (e) => {
-                            e.stopPropagation();
-                            removeExistingMenus();
-
-                            const menu = $el("div.danbooru-tag-context-menu", {
-                                style: {
-                                    position: 'absolute',
-                                    zIndex: '10002',
-                                    backgroundColor: 'var(--comfy-menu-bg)',
-                                    border: '1px solid var(--input-border-color)',
-                                    borderRadius: '6px',
-                                    boxShadow: '0 2px 10px rgba(0,0,0,0.3)',
-                                    padding: '5px',
-                                }
-                            });
-
-                            const searchOption = $el("div.danbooru-context-menu-item", {
-                                textContent: '🔍 ' + t('search'),
-                                onclick: () => {
-                                    const currentVal = searchInput.value.trim();
-                                    const apiTag = tag.replace(/\s+/g, '_');
-                                    let newValue;
-                                    if (currentVal && !/,\s*$/.test(currentVal)) {
-                                        newValue = `${currentVal}, ${apiTag}, `;
-                                    } else if (currentVal) {
-                                        newValue = `${currentVal} ${apiTag}, `;
-                                    } else {
-                                        newValue = `${apiTag}, `;
-                                    }
-                                    searchInput.value = newValue;
-                                    searchInput.dispatchEvent(new Event('input'));
-                                    fetchAndRender(true);
-                                    menu.remove();
-                                }
-                            });
-
-                            const deleteOption = $el("div.danbooru-context-menu-item", {
-                                textContent: '🗑️ ' + t('delete'),
-                                onclick: () => {
-                                    if (postData[`tag_string_${category}`]) {
-                                        const tags = postData[`tag_string_${category}`].split(' ');
-                                        const index = tags.indexOf(tag);
-                                        if (index > -1) {
-                                            tags.splice(index, 1);
-                                            postData[`tag_string_${category}`] = tags.join(' ');
-                                        }
-                                    }
-                                    // 强制重新渲染以更新状态
-                                    renderTagsInPanel(tagsContainer, temporaryTagEdits[postData.id] || postData, panel);
-                                    menu.remove();
-                                }
-                            });
-
-                            menu.appendChild(searchOption);
-                            menu.appendChild(deleteOption);
-
-                            document.body.appendChild(menu);
-
-                            const rect = span.getBoundingClientRect();
-                            menu.style.left = `${rect.left}px`;
-                            menu.style.top = `${rect.bottom + 5}px`;
-
-                            const closeMenuHandler = (event) => {
-                                if (!menu.contains(event.target)) {
-                                    menu.remove();
-                                    document.removeEventListener('click', closeMenuHandler, true);
-                                }
-                            };
-                            document.addEventListener('click', closeMenuHandler, true);
-                        });
-
-                        return span;
-                    };
-
-                    const categoryOrder = TAG_CATEGORY_ORDER;
-                    const categorizedTags = { artist: new Set(), copyright: new Set(), character: new Set(), general: new Set(), meta: new Set() };
-
-                    if (postData.tag_string_artist) postData.tag_string_artist.split(' ').forEach(t => categorizedTags.artist.add(t));
-                    if (postData.tag_string_copyright) postData.tag_string_copyright.split(' ').forEach(t => categorizedTags.copyright.add(t));
-                    if (postData.tag_string_character) postData.tag_string_character.split(' ').forEach(t => categorizedTags.character.add(t));
-                    if (postData.tag_string_general) postData.tag_string_general.split(' ').forEach(t => categorizedTags.general.add(t));
-                    if (postData.tag_string_meta) postData.tag_string_meta.split(' ').forEach(t => categorizedTags.meta.add(t));
-
-                    if (Object.values(categorizedTags).every(s => s.size === 0) && postData.tag_string) {
-                        postData.tag_string.split(' ').forEach(t => categorizedTags.general.add(t));
-                    }
-
-                    const allTags = Array.from(new Set(categoryOrder.flatMap(cat => Array.from(categorizedTags[cat])))).filter(Boolean);
-
-                    let translations = {};
-                    if (globalMultiLanguageManager.getLanguage() === 'zh' && allTags.length > 0) {
-                        try {
-                            const response = await fetch('/danbooru_gallery/translate_tags_batch', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ tags: allTags })
-                            });
-                            const data = await response.json();
-                            if (data.success) translations = data.translations;
-                        } catch (error) { logger.warn("Tag translation failed for edit panel:", error); }
-                    }
-
-                    categoryOrder.forEach(categoryName => {
-                        const tags = categorizedTags[categoryName];
-                        if (tags.size > 0) {
-                            const section = $el("div.danbooru-edit-panel-section"); // Changed class name for clarity
-
-                            // Add a checkbox for each category in the edit panel
-                            const categoryCheckboxId = `edit-panel-category-${categoryName}`;
-                            const categoryCheckbox = $el("input", {
-                                type: "checkbox",
-                                id: categoryCheckboxId,
-                                name: categoryName,
-                                checked: getSelectedPromptCategories().includes(categoryName),
-                                className: "danbooru-edit-category-checkbox"
-                            });
-                            const categoryLabel = $el("label", {
-                                htmlFor: categoryCheckboxId,
-                                textContent: t(categoryName),
-                                style: { marginLeft: "5px", fontWeight: "600", color: "#b0b3b8" } // Style to match header
-                            });
-
-                            const categoryHeader = $el("div", { style: { display: "flex", alignItems: "center", marginBottom: "4px" } }, [categoryCheckbox, categoryLabel]);
-                            section.appendChild(categoryHeader);
-                            const tagsWrapper = $el("div.danbooru-tooltip-tags-wrapper");
-                            tags.forEach(tag => {
-                                if (!tag) return;
-                                const translation = translations[tag];
-                                tagsWrapper.appendChild(createClickableTagSpan(tag, categoryName, translation));
-                            });
-
-                            // Add "+" button for adding new tags
-                            const addButton = $el("button.danbooru-add-tag-button", {
-                                textContent: "+",
-                                title: t('addTag'),
-                                onclick: (e) => {
-                                    e.stopPropagation();
-                                    addButton.style.display = 'none'; // Hide the add button
-
-                                    const inputContainer = $el("div.danbooru-add-tag-container");
-                                    const input = $el("input.danbooru-add-tag-input", { type: "text", placeholder: t('addTag') + "..." });
-
-                                    inputContainer.appendChild(input);
-                                    tagsWrapper.appendChild(inputContainer);
-
-                                    input.focus();
-
-                                    // 创建智能补全实例
-                                    const tagAutocomplete = new AutocompleteUI({
-                                        inputElement: input,
-                                        language: globalMultiLanguageManager.getLanguage(),
-                                        source: uiSettings.source_site || "danbooru",
-                                        maxSuggestions: uiSettings.autocomplete_max_results || 20,
-                                        customClass: 'danbooru-tag-editor-autocomplete',
-                                        formatTag: (tag) => {
-                                            // 应用格式化设置
-                                            let processedTag = tag;
-                                            if (uiSettings.formatting && uiSettings.formatting.replaceUnderscores) {
-                                                processedTag = processedTag.replace(/_/g, ' ');
-                                            }
-                                            if (uiSettings.formatting && uiSettings.formatting.escapeBrackets) {
-                                                processedTag = processedTag.replaceAll('(', '\\(').replaceAll(')', '\\)');
-                                            }
-                                            return processedTag;
-                                        },
-                                        onSelect: (selectedTag) => {
-                                            const newTag = selectedTag.trim().replace(/\s/g, '_');
-                                            if (newTag) {
-                                                const tagStringKey = `tag_string_${categoryName}`;
-                                                const currentTags = postData[tagStringKey] ? postData[tagStringKey].split(' ') : [];
-                                                if (!currentTags.includes(newTag)) {
-                                                    currentTags.push(newTag);
-                                                    postData[tagStringKey] = currentTags.join(' ');
-                                                }
-                                                // 强制重新渲染以更新状态
-                                                renderTagsInPanel(tagsContainer, temporaryTagEdits[postData.id] || postData, panel);
-                                            }
-                                            tagAutocomplete.destroy();
-                                            inputContainer.remove();
-                                            addButton.style.display = 'inline-flex';
-                                        }
-                                    });
-
-                                    input.addEventListener('keydown', (e) => {
-                                        if (e.key === 'Enter' && input.value.trim()) {
-                                            const newTag = input.value.trim().replace(/\s/g, '_');
-                                            if (newTag) {
-                                                const tagStringKey = `tag_string_${categoryName}`;
-                                                const currentTags = postData[tagStringKey] ? postData[tagStringKey].split(' ') : [];
-                                                if (!currentTags.includes(newTag)) {
-                                                    currentTags.push(newTag);
-                                                    postData[tagStringKey] = currentTags.join(' ');
-                                                }
-                                                renderTagsInPanel(tagsContainer, temporaryTagEdits[postData.id] || postData, panel);
-                                            }
-                                            tagAutocomplete.destroy();
-                                            inputContainer.remove();
-                                            addButton.style.display = 'inline-flex';
-                                        } else if (e.key === 'Escape') {
-                                            tagAutocomplete.destroy();
-                                            inputContainer.remove();
-                                            addButton.style.display = 'inline-flex';
-                                        }
-                                    });
-
-                                    const blurHandler = () => {
-                                        // 延迟以便点击建议能够注册
-                                        setTimeout(() => {
-                                            if (!inputContainer.contains(document.activeElement)) {
-                                                tagAutocomplete.destroy();
-                                                inputContainer.remove();
-                                                addButton.style.display = 'inline-flex';
-                                            }
-                                        }, 200);
-                                    };
-                                    input.addEventListener('blur', blurHandler);
-                                }
-                            });
-                            tagsWrapper.appendChild(addButton);
-
-                            section.appendChild(tagsWrapper);
-                            tagsContainer.appendChild(section);
-                        }
-                    });
-
-                    // After rendering, check if the post is edited and update the main grid item
-                    const postElement = imageGrid.querySelector(`.danbooru-image-wrapper[data-post-id="${postData.id}"]`);
-                    if (postElement) {
-                        updateEditedStatus(postElement, postData.id);
-                    }
-                };
-
-                // 辅助函数：为单个帖子构建提示词
-                const buildPromptForPost = (postData, selectedCategoriesOverride = null) => {
-                    // 同步：G站在加载时已完成 hydrate，选图时 tag_xxx 已就绪，无需再 await 网络请求
-                    const promptPost = temporaryTagEdits[postData.id] || postData;
-
-                    const promptCategories = Array.isArray(selectedCategoriesOverride)
-                        ? selectedCategoriesOverride.filter(name => TAG_CATEGORY_ORDER.includes(name))
-                        : getSelectedPromptCategories();
-                    const categoriesToUse = promptCategories.length > 0 ? promptCategories : [...TAG_CATEGORY_ORDER];
-                    const categorizedPromptTags = buildCategorizedTagLists(promptPost);
-                    const filterTagSet = getFilterTagSet();
-
-                    const orderedFilteredTags = categoriesToUse.flatMap(category => categorizedPromptTags[category] || [])
-                        .filter(tag => shouldKeepPromptTag(tag, filterTagSet));
-
-                    return orderedFilteredTags.map(formatPromptTag).filter(Boolean).join(', ');
-                };
-
-                // 辅助函数：收集所有选中图片的数据并更新 widget
-                const updateSelectionData = () => {
-                    const selectedWrappers = imageGrid.querySelectorAll('.danbooru-image-wrapper.selected');
-                    const selections = [];
-
-                    for (const wrapper of selectedWrappers) {
-                        const postId = wrapper.dataset.postId;
-                        const postData = posts.find(p => p.id == postId) || temporaryTagEdits[postId];
-                        if (postData) {
-                            const prompt = buildPromptForPost(postData);
-                            const updatedPostData = posts.find(p => p.id == postId) || temporaryTagEdits[postId] || postData;
-                            const mediaPost = getPostWithOriginalMedia(updatedPostData);
-                            const imageUrl = getBestImageUrl(mediaPost, false);
-                            selections.push({
-                                post_id: postId,
-                                prompt: prompt,
-                                image_url: imageUrl
-                            });
-                        }
-                    }
-
-                    const selectionData = { selections: selections };
-
-                    // 更新 widget（仍保留用于兼容回退）
-                    if (nodeInstance && nodeInstance.widgets) {
-                        const selectionWidget = nodeInstance.widgets.find(w => w.name === "selection_data");
-                        if (selectionWidget) {
-                            selectionWidget.value = JSON.stringify(selectionData);
-                            selectionWidget.callback();
-                        }
-                    }
-
-                    // 更新选中计数显示
-                    updateSelectionCount(selections.length);
-                };
-
-                // 辅助函数：更新选中计数显示
-                const updateSelectionCount = (count) => {
-                    const countBadge = document.querySelector('.danbooru-selection-count');
-                    if (countBadge) {
-                        if (count > 0 && uiSettings.multi_select_enabled) {
-                            countBadge.textContent = t('selectedCount').replace('{count}', count);
-                            countBadge.style.display = 'inline-block';
-                        } else {
-                            countBadge.style.display = 'none';
-                        }
-                    }
-                };
-
-                // 辅助函数：清除所有选中
-                const clearAllSelections = () => {
-                    imageGrid.querySelectorAll('.danbooru-image-wrapper.selected').forEach(w => {
-                        w.classList.remove('selected');
-                    });
-                    updateSelectionData();
-                };
-
-                const createPostElement = (post) => {
-                    // error 占位格：红色边框，直接显示错误文本
-                    if (post && post.error) {
-                        const wrapper = $el("div.danbooru-image-wrapper", {
-                            style: { border: '1px solid #ff4444', minHeight: '80px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#ff4444', fontSize: '0.85em', padding: '8px', textAlign: 'center' }
-                        });
-                        wrapper.dataset.postId = `err_${post.pid || post.page || '?'}`;
-                        wrapper.textContent = post.error;
-                        return wrapper;
-                    }
-
-                    if (!post.id || !post.preview_file_url) return null;
-
-                    const wrapper = $el("div.danbooru-image-wrapper");
-                    wrapper.dataset.postId = post.id; // 显式设置 data-post-id
-
-                    // Reserve grid space up-front from the post's real dimensions so the
-                    // waterfall is stable before thumbnails finish loading.
-                    // G公开页返回的 post 经常 image_width/height=0，按列宽的估算方形保底高度
-                    let reservedSpans = 0;
-                    if (post.image_width && post.image_height) {
-                        reservedSpans = computeSpanFromDims(post.image_width, post.image_height);
-                    }
-                    if (reservedSpans <= 0) {
-                        const colW = getColumnWidth();
-                        const rowGap = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-row-gap')) || parseInt(window.getComputedStyle(imageGrid).rowGap) || 5;
-                        const rowHeight = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-auto-rows')) || 1;
-                        reservedSpans = colW > 0 ? Math.ceil((colW + rowGap) / (rowHeight + rowGap)) : 200;
-                    }
-                    if (reservedSpans > 0) wrapper.style.gridRowEnd = `span ${reservedSpans}`;
-
-                    // 首次创建post元素时，将原始post数据添加到 originalPostCache
-                    if (!originalPostCache[post.id]) {
-                        originalPostCache[post.id] = JSON.parse(JSON.stringify(post));
-                    }
-
-                    // Check and apply edited status on creation
-                    updateEditedStatus(wrapper, post.id);
-
-                    const previewUrl = (post.source_site === "gelbooru")
-                        ? post.preview_file_url
-                        : `${post.preview_file_url}?v=${post.md5}`;
-
-                    const img = $el("img", {
-                        src: `/danbooru_gallery/image_proxy?url=${encodeURIComponent(previewUrl)}`,
-                        onload: scheduleResizeGrid,
-                        onerror: () => { wrapper.style.display = 'none'; },
-                        onclick: async (e) => {
-                            e.stopPropagation(); // Prevent event from bubbling up and potentially causing issues
-                            const isSelected = wrapper.classList.contains('selected');
-                            const isMultiSelectMode = uiSettings.multi_select_enabled;
-
-                            // 单选模式下，先清除所有其他图像的选中状态
-                            if (!isMultiSelectMode) {
-                                imageGrid.querySelectorAll('.danbooru-image-wrapper').forEach(w => {
-                                    if (w !== wrapper) {
-                                        w.classList.remove('selected');
-                                    }
-                                });
-                            }
-
-                            // 切换当前图像的选中状态
-                            if (!isSelected) {
-                                wrapper.classList.add('selected');
-                            } else {
-                                wrapper.classList.remove('selected');
-                            }
-
-                            // 收集所有选中图片的数据并更新 widget
-                            updateSelectionData();
-                        },
-                    });
-
-                    // 创建下载按钮
-                    const downloadButton = $el("button.danbooru-download-button", {
-                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                            <polyline points="7 10 12 15 17 10"></polyline>
-                            <line x1="12" y1="15" x2="12" y2="3"></line>
-                        </svg>`,
-                        title: t('download'),
-                        onclick: async (e) => {
-                            e.stopPropagation(); // 阻止事件冒泡，避免触发图片选择
-
-                            try {
-                                const mediaPost = getPostWithOriginalMedia(post);
-                                const imageUrl = getBestImageUrl(mediaPost, false);
-                                if (!imageUrl) {
-                                    return;
-                                }
-
-                                // 获取图片文件扩展名
-                                const fileExt = getImageExtension(mediaPost, imageUrl);
-                                const fileName = `danbooru_${post.id}.${fileExt}`;
-
-                                // 通过后端代理下载，避免被 Cloudflare 按 cross-site referer 拦截
-                                const proxyUrl = proxiedMediaUrl(imageUrl);
-                                const response = await fetch(proxyUrl);
-                                const blob = await response.blob();
-                                const url = window.URL.createObjectURL(blob);
-
-                                const a = document.createElement('a');
-                                a.href = url;
-                                a.download = fileName;
-                                document.body.appendChild(a);
-                                a.click();
-                                document.body.removeChild(a);
-                                window.URL.revokeObjectURL(url);
-                            } catch (error) {
-                                // 下载失败，静默处理
-                            }
-                        }
-                    });
-
-                    // 使用全局tooltip实例
-                    if (!globalTooltip) {
-                        globalTooltip = $el("div.danbooru-tag-tooltip", { style: { display: "none", position: "absolute", zIndex: "1000" } });
-                        const tagsContainer = $el("div", { className: "danbooru-tooltip-tags" });
-                        globalTooltip.appendChild(tagsContainer);
-                        document.body.appendChild(globalTooltip);
-                    }
-
-                    const createTagSpan = (tag, category, translation = null) => {
-                        const displayText = translation ? `${tag} [${translation}]` : tag;
-                        return $el("span", {
-                            textContent: displayText,
-                            className: `danbooru-tooltip-tag tag-category-${category}`,
-                        });
-                    };
-
-                    let currentClickHandler = null;
-
-                    wrapper.addEventListener("mouseenter", async (e) => {
-                        if (!uiSettings.tooltip_enabled) return;
-
-                        // 生成新的tooltip ID，使之前的异步请求失效
-                        currentTooltipId++;
-                        const thisTooltipId = currentTooltipId;
-
-                        clearTimeout(globalTooltipTimeout);
-
-                        const tagsContainer = globalTooltip.querySelector('.danbooru-tooltip-tags');
-                        tagsContainer.innerHTML = '';
-                        const postForTooltip = await hydrateGelbooruTooltipPost(post);
-                        if (thisTooltipId !== currentTooltipId) {
-                            return;
-                        }
-
-                        // Details Section
-                        const detailsSection = $el("div.danbooru-tooltip-section");
-                        detailsSection.appendChild($el("div.danbooru-tooltip-category-header", { textContent: t('details') }));
-                        if (postForTooltip.created_at) {
-                            const date = new Date(postForTooltip.created_at);
-                            const formattedDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
-                            detailsSection.appendChild($el("div", { textContent: `${t('uploaded')}: ${formattedDate}`, className: "danbooru-tooltip-upload-date" }));
-                        }
-                        if (postForTooltip.image_width && postForTooltip.image_height) {
-                            detailsSection.appendChild($el("div", { textContent: `${t('resolution')}: ${postForTooltip.image_width}×${postForTooltip.image_height}`, className: "danbooru-tooltip-upload-date" }));
-                        }
-                        tagsContainer.appendChild(detailsSection);
-
-                        // Tags Processing
-                        const categoryOrder = TAG_CATEGORY_ORDER;
-                        const categorizedTags = {
-                            artist: new Set(),
-                            copyright: new Set(),
-                            character: new Set(),
-                            general: new Set(),
-                            meta: new Set()
-                        };
-
-                        if (postForTooltip.tag_string_artist) postForTooltip.tag_string_artist.split(' ').forEach(t => categorizedTags.artist.add(t));
-                        if (postForTooltip.tag_string_copyright) postForTooltip.tag_string_copyright.split(' ').forEach(t => categorizedTags.copyright.add(t));
-                        if (postForTooltip.tag_string_character) postForTooltip.tag_string_character.split(' ').forEach(t => categorizedTags.character.add(t));
-                        if (postForTooltip.tag_string_general) postForTooltip.tag_string_general.split(' ').forEach(t => categorizedTags.general.add(t));
-                        if (postForTooltip.tag_string_meta) postForTooltip.tag_string_meta.split(' ').forEach(t => categorizedTags.meta.add(t));
-
-                        // Fallback for older posts or different tag string formats
-                        if (Object.values(categorizedTags).every(s => s.size === 0) && postForTooltip.tag_string) {
-                            postForTooltip.tag_string.split(' ').forEach(t => categorizedTags.general.add(t));
-                        }
-
-                        // 收集所有tags用于批量翻译
-                        const allTags = [];
-                        categoryOrder.forEach(categoryName => {
-                            if (categorizedTags[categoryName].size > 0) {
-                                allTags.push(...Array.from(categorizedTags[categoryName]));
-                            }
-                        });
-
-                        // 批量获取翻译（仅在中文模式下）
-                        let translations = {};
-                        if (globalMultiLanguageManager.getLanguage() === 'zh') {
-                            try {
-                                if (allTags.length > 0) {
-                                    const response = await fetch('/danbooru_gallery/translate_tags_batch', {
-                                        method: 'POST',
-                                        headers: { 'Content-Type': 'application/json' },
-                                        body: JSON.stringify({ tags: allTags })
-                                    });
-                                    const data = await response.json();
-                                    if (data.success) {
-                                        translations = data.translations;
-                                    }
-                                }
-                            } catch (error) {
-                                // 翻译获取失败，继续显示英文标签
-                            }
-                        }
-
-                        // 检查tooltip ID是否仍然有效（防止快速切换时显示过期的tooltip）
-                        if (thisTooltipId !== currentTooltipId) {
-                            return; // 用户已经移动到另一张图片，放弃显示此tooltip
-                        }
-
-                        // Render all tag categories with translations
-                        categoryOrder.forEach(categoryName => {
-                            if (categorizedTags[categoryName].size > 0) {
-                                const section = $el("div.danbooru-tooltip-section");
-                                section.appendChild($el("div.danbooru-tooltip-category-header", { textContent: t(categoryName) }));
-                                const tagsWrapper = $el("div.danbooru-tooltip-tags-wrapper");
-                                categorizedTags[categoryName].forEach(tag => {
-                                    const translation = translations[tag];
-                                    tagsWrapper.appendChild(createTagSpan(tag, categoryName, translation));
-                                });
-                                section.appendChild(tagsWrapper);
-                                tagsContainer.appendChild(section);
-                            }
-                        });
-
-                        globalTooltip.style.display = "block";
-
-                        // 添加点击其他地方隐藏tooltip的保护机制
-                        currentClickHandler = (e) => {
-                            if (!wrapper.contains(e.target) && globalTooltip.style.display !== 'none') {
-                                globalTooltip.style.display = "none";
-                                document.removeEventListener('click', currentClickHandler);
-                                currentClickHandler = null;
-                            }
-                        };
-
-                        // 延迟添加点击监听器，避免立即触发
-                        setTimeout(() => {
-                            if (currentClickHandler) {
-                                document.addEventListener('click', currentClickHandler);
-                            }
-                        }, 10);
-                    });
-
-                    wrapper.addEventListener("mouseleave", () => {
-                        // 增加tooltip ID，使当前的异步请求失效
-                        currentTooltipId++;
-
-                        // 鼠标离开图像时立即隐藏tooltip
-                        globalTooltip.style.display = "none";
-
-                        // 移除点击监听器
-                        if (currentClickHandler) {
-                            document.removeEventListener('click', currentClickHandler);
-                            currentClickHandler = null;
-                        }
-                    });
-
-                    wrapper.addEventListener("mousemove", (e) => {
-                        if (globalTooltip.style.display !== 'block') return;
-                        const rect = globalTooltip.getBoundingClientRect();
-                        const buffer = 15;
-                        let newLeft = e.clientX + buffer, newTop = e.clientY + buffer;
-                        if (newLeft + rect.width > window.innerWidth) newLeft = e.clientX - rect.width - buffer;
-                        if (newTop + rect.height > window.innerHeight) newTop = e.clientY - rect.height - buffer;
-                        globalTooltip.style.left = `${newLeft + window.scrollX}px`;
-                        globalTooltip.style.top = `${newTop + window.scrollY}px`;
-                    });
-
-                    // 总是创建收藏按钮，无论用户是否登录
-                    const currentSearch = searchInput.value.trim();
-                    const postFavoriteTag = currentFavoriteTag();
-                    const inFavoritesMode = hasFavoriteAuth() && postFavoriteTag && currentSearch.includes(postFavoriteTag);
-                    const isFavorited = inFavoritesMode || userFavorites.includes(String(post.id));
-                    const favoriteButton = $el("button.danbooru-favorite-button", {
-                        "data-post-id": post.id,
-                        innerHTML: isFavorited ?
-                            `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="#DC3545" stroke="#DC3545" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-                            </svg>` :
-                            `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-                            </svg>`,
-                        title: isFavorited ? t('unfavorite') : t('favorite'),
-                        className: isFavorited ? 'favorited' : '',
-                        onclick: async (e) => {
-                            e.stopPropagation(); // 阻止事件冒泡，避免触发图片选择
-
-                            // 如果用户未登录，提示登录
-                            if (!hasFavoriteAuth()) {
-                                showToast(t('authRequired'), 'warning');
-                                return;
-                            }
-
-                            // 在操作收藏前验证用户名和API Key的有效性
-
-                            const currentlyFavorited = userFavorites.includes(String(post.id)) || inFavoritesMode;
-                            let result;
-
-                            if (currentlyFavorited) {
-                                // 取消收藏
-                                result = await removeFromFavorites(post.id, favoriteButton);
-                                if (result.success) {
-                                    // 如果在收藏夹视图中，直接移除元素
-                                    const currentSearch = searchInput.value.trim();
-                                    if (postFavoriteTag && currentSearch.includes(postFavoriteTag)) {
-                                        wrapper.remove();
-                                    }
-                                }
-                            } else {
-                                // 添加收藏
-                                result = await addToFavorites(post.id, favoriteButton);
-                            }
-
-                            // 错误已在函数内处理
-                        }
-                    });
-
-                    // 创建按钮容器
-                    const buttonsContainer = $el("div.danbooru-image-buttons");
-
-                    // 创建编辑模式按钮
-                    const editButton = $el("button.danbooru-edit-button", {
-                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-                            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-                        </svg>`,
-                        title: t('editMode'),
-                        onclick: (e) => {
-                            e.stopPropagation();
-                            showEditPanel(post);
-                        }
-                    });
-
-                    const viewImageButton = $el("button.danbooru-view-image-button", {
-                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`,
-                        title: t('viewImage'),
-                        onclick: async (e) => {
-                            e.stopPropagation();
-                            const mediaPost = getPostWithOriginalMedia(post);
-                            const imageUrl = getBestImageUrl(mediaPost, false);
-                            if (imageUrl) {
-                                window.open(proxiedMediaUrl(imageUrl), '_blank', 'noreferrer');
-                            }
-                        }
-                    });
-
-                    buttonsContainer.appendChild(viewImageButton);
-                    buttonsContainer.appendChild(editButton);
-                    buttonsContainer.appendChild(downloadButton);
-                    buttonsContainer.appendChild(favoriteButton);
-
-                    wrapper.appendChild(img);
-                    wrapper.appendChild(buttonsContainer);
-
-                    return wrapper;
-                };
-
-                const renderPost = (post) => {
-                    const element = createPostElement(post);
-                    if (element) {
-                        imageGrid.appendChild(element);
-                    }
-                };
-
-                const observer = new ResizeObserver(() => {
-                    cachedColumnWidth = 0;
-                    resizeGrid();
-                });
-                observer.observe(imageGrid);
-
-                let scrollTimeout;
-                let scrollAnchorTimeout; // 锚点记录的防抖
-                imageGrid.addEventListener("scroll", () => {
-                    if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
-                        fetchAndRender(false);
-                    }
-
-                    // Debounced scroll logic for page indicator
-                    clearTimeout(scrollTimeout);
-                    scrollTimeout = setTimeout(updateCurrentPageIndicator, 150);
-
-                    // 记录滚动锚点（每秒；取视野最上方的图往前 8 张，刷新时用其 id 做游标往下接）
-                    clearTimeout(scrollAnchorTimeout);
-                    scrollAnchorTimeout = setTimeout(() => {
-                        const scrollRect = imageGrid.getBoundingClientRect();
-                        let closestIdx = -1, closestDist = Infinity;
-                        const children = Array.from(imageGrid.children);
-                        children.forEach((w, i) => {
-                            const rect = w.getBoundingClientRect();
-                            const dist = Math.abs(rect.top - scrollRect.top);
-                            if (dist < closestDist) { closestDist = dist; closestIdx = i; }
-                        });
-                        if (closestIdx >= 0) {
-                            const anchorIdx = Math.max(0, closestIdx - 8);
-                            const anchorEl = children[anchorIdx];
-                            if (anchorEl && anchorEl.dataset.postId) {
-                                scrollAnchorPostId = anchorEl.dataset.postId;
-                                saveToLocalStorage('scrollAnchorPostId', scrollAnchorPostId);
-                            }
-                        }
-                    }, 1000);
-                });
-
-                searchInput.addEventListener("keydown", (e) => {
-                    if (e.key === "Enter") {
-                        saveToLocalStorage('searchValue', searchInput.value.trim());
-                        fetchAndRender(true);
-                    }
-                });
-                ratingSelect.addEventListener("change", () => {
-                    if (globalTooltip) {
-                        globalTooltip.style.display = 'none';
-                    }
-                    fetchAndRender(true); // 保留，因为改变评分需要重新加载
-                });
-                // 检查和更新排行榜按钮状态的函数
-                const updateRankingButtonState = () => {
-                    const currentValue = searchInput.value.trim();
-                    const hasRanking = currentValue.includes('order:rank');
-
-                    if (hasRanking) {
-                        rankingButton.classList.add('active');
-                    } else {
-                        rankingButton.classList.remove('active');
-                    }
-                };
-
-                // 排行榜按钮点击事件
-                rankingButton.addEventListener("click", () => {
-                    const currentValue = searchInput.value.trim();
-                    const hasRanking = currentValue.includes('order:rank');
-
-                    if (hasRanking) {
-                        // 移除 order:rank，并清理残留的逗号
-                        let newValue = currentValue.replace(/\s*order:rank\s*/g, '');
-                        // 清理多余的逗号和空格
-                        newValue = newValue.replace(/,\s*,/g, ',').replace(/,\s*$/g, '').replace(/^\s*,/g, '').replace(/\s+/g, ' ').trim();
-                        searchInput.value = newValue;
-                        rankingButton.classList.remove('active');
-                    } else {
-                        // 添加 order:rank
-                        let newValue;
-                        if (currentValue) {
-                            // 如果前面已经有内容，用逗号分隔，但检查末尾是否已有逗号（后面可能有空格）
-                            const hasTrailingComma = /\s*,\s*$/.test(currentValue);
-                            const separator = hasTrailingComma ? ' ' : ', ';
-                            newValue = `${currentValue}${separator}order:rank`;
-                        } else {
-                            newValue = 'order:rank';
-                        }
-                        searchInput.value = newValue;
-                        rankingButton.classList.add('active');
-                    }
-
-                    // 刷新图像
-                    saveToLocalStorage('searchValue', searchInput.value);
-                    fetchAndRender(true);
-                });
-
-                // 监听搜索框变化，更新排行榜按钮状态
-                // 更新收藏夹按钮状态
-                const updateFavoritesButtonState = () => {
-                    // 始终显示收藏夹按钮
-                    favoritesButton.style.display = 'flex';
-
-                    if (!hasFavoriteAuth()) {
-                        favoritesButton.classList.remove('active');
-                        return;
-                    }
-
-                    const currentValue = searchInput.value.trim();
-                    const favTag = currentFavoriteTag();
-                    const hasFavs = Boolean(favTag) && currentValue.includes(favTag);
-                    if (hasFavs) {
-                        favoritesButton.classList.add('active');
-                    } else {
-                        favoritesButton.classList.remove('active');
-                    }
-                };
-
-                // 统一的搜索框输入处理函数
-                const handleSearchInput = () => {
-                    const currentValue = searchInput.value.trim();
-                    if (previousSearchValue !== "" && currentValue === "") {
-                        saveToLocalStorage('searchValue', '');
-                        fetchAndRender(true); // 清空搜索框时自动刷新
-                    }
-                    previousSearchValue = currentValue;
-                    updateRankingButtonState();
-                    updateFavoritesButtonState();
-
-                    const clearButton = searchContainer.querySelector('.danbooru-clear-search-button');
-                    if (clearButton) {
-                        clearButton.style.display = currentValue ? 'block' : 'none';
-                    }
-                };
-
-                searchInput.addEventListener("input", handleSearchInput);
-
-                // 收藏夹按钮点击事件
-                favoritesButton.addEventListener("click", async () => {
-                    if (!hasFavoriteAuth()) {
-                        showToast(t('authRequired'), 'warning');
-                        return;
-                    }
-
-
-                    const favTag = currentFavoriteTag();
-                    if (!favTag) {
-                        showToast(t('authRequired'), 'warning');
-                        return;
-                    }
-                    const currentValue = searchInput.value.trim();
-                    const hasFavs = currentValue.includes(favTag);
-
-                    if (hasFavs) {
-                        // 移除收藏夹标签，并清理残留的逗号
-                        let newValue = currentValue.replace(new RegExp(`\\s*${favTag}\\s*`), '');
-                        // 清理多余的逗号和空格
-                        newValue = newValue.replace(/,\s*,/g, ',').replace(/,\s*$/g, '').replace(/^\s*,/g, '').replace(/\s+/g, ' ').trim();
-                        searchInput.value = newValue;
-                    } else {
-                        let newValue;
-                        if (currentValue) {
-                            // 如果前面已经有内容，用逗号分隔，但检查末尾是否已有逗号（后面可能有空格）
-                            const hasTrailingComma = /\s*,\s*$/.test(currentValue);
-                            const separator = hasTrailingComma ? ' ' : ', ';
-                            newValue = `${currentValue}${separator}${favTag}`;
-                        } else {
-                            newValue = favTag;
-                        }
-                        searchInput.value = newValue;
-                        // 进入收藏夹模式时，不需要手动加载收藏列表，因为 fetchAndRender 会获取
-                    }
-                    updateFavoritesButtonState();
-                    saveToLocalStorage('searchValue', searchInput.value);
-                    fetchAndRender(true);
-                });
-
-                refreshButton.addEventListener("click", () => {
-                    fetchAndRender(true);
-                });
-
-                const searchContainer = $el("div.danbooru-search-container");
-                const clearButton = $el("button.danbooru-clear-search-button", {
-                    innerHTML: '×',
-                    title: t('clearSearch'),
-                    style: {
-                        display: 'none'
+import requests
+import json
+import folder_paths
+from server import PromptServer
+from aiohttp import web
+import time
+import threading
+import asyncio
+import torch
+import io
+import urllib.request
+import urllib.parse
+import numpy as np
+from PIL import Image
+import os
+import csv
+import re
+from requests.auth import HTTPBasicAuth
+import urllib3
+from pathlib import Path
+import sys
+from ..utils.logger import get_logger
+from .site_adapters import get_site_adapter
+from collections import defaultdict, deque
+
+logger = get_logger(__name__)
+
+# FIFO 选择队列（按 nodeId 分桶）：每次 Queue 时前端快照推入对应节点的队列，
+# 节点执行时只 pop 自己 nodeId 的条目，其他节点的条目不受影响。
+# 支持同一工作流中多个画廊节点互不干扰、主子工作流各自取自己的数据。
+_selection_queues = defaultdict(deque)
+_selection_queues_lock = threading.Lock()
+_selection_queue_gen = 0  # 每次 push 递增，IS_CHANGED 据此让所有节点都重新执行
+
+# 导入数据库管理器
+try:
+    from ..shared.db.db_manager import get_db_manager
+except ImportError as e:
+    logger.warning(f"[Autocomplete] 无法导入数据库管理器，将仅使用远程API模式: {e}")
+    get_db_manager = None
+
+# 禁用 SSL 警告（如果需要禁用证书验证）
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# Danbooru API文档链接 https://danbooru.donmai.us/wiki_pages/help:api
+
+# Danbooru API的基础URL
+BASE_URL = "https://danbooru.donmai.us"
+
+# 需要一个非 python-requests 的描述性 UA 才能过 Cloudflare（从 2026-04-23 起开启拦截）。
+# 实测 CF 对 UA 黑名单里包含 "ComfyUI" —— 推测 Danbooru 为抵制训练数据爬取主动加的规则。
+# 本节点只是图片浏览器（单图挑选，无批量导出），不参与训练数据收集，按 e621 式约定
+# 使用描述性项目 UA；避开 "ComfyUI" 字样以免被 CF 误伤。
+DANBOORU_HEADERS = {
+    "User-Agent": "Danbooru-Gallery/1.0"
+}
+
+# 官方文档限速为 10 req/s，保守取一半 = 5 req/s（200ms 间隔），避免触发 CF 或被站方拉黑。
+# 参考 deepghs/waifuc#22：Danbooru 管理员明确要求 "proper waits or backoffs"，否则会封项目。
+class _RateLimiter:
+    def __init__(self, min_interval_sec):
+        self.min_interval = min_interval_sec
+        self._last_ts = 0.0
+        self._lock = threading.Lock()
+
+    def wait(self):
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last_ts
+            if elapsed < self.min_interval:
+                time.sleep(self.min_interval - elapsed)
+            self._last_ts = time.monotonic()
+
+_donmai_throttle = _RateLimiter(min_interval_sec=0.2)
+
+# Gelbooru 公开 HTML 页列表固定每页 42 张，pid 为该页首张图片的偏移量
+GELBOORU_PUBLIC_PAGE_SIZE = 42
+
+# Gelbooru 公开页抓取限流器（0.75s = ~1.33 req/s，避开 429）
+_gelbooru_public_throttle = _RateLimiter(min_interval_sec=0.75)
+
+def _danbooru_request(method, url, **kwargs):
+    """统一的 donmai.us 请求入口：限流 + 默认 UA + 429/503 带 Retry-After 退避重试一次。"""
+    headers = dict(kwargs.pop("headers", None) or {})
+    for k, v in DANBOORU_HEADERS.items():
+        headers.setdefault(k, v)
+
+    resp = None
+    for attempt in range(2):
+        _donmai_throttle.wait()
+        resp = requests.request(method, url, headers=headers, **kwargs)
+        if resp.status_code not in (429, 503) or attempt == 1:
+            return resp
+        retry_after = resp.headers.get("Retry-After")
+        delay = 2.0
+        try:
+            if retry_after is not None:
+                delay = min(max(float(retry_after), 0.5), 10.0)
+        except ValueError:
+            pass
+        logger.warning(f"[Danbooru] {resp.status_code} 限流，{delay:.1f}s 后重试: {url}")
+        time.sleep(delay)
+    return resp
+
+# 获取插件目录路径
+# 获取当前文件所在目录
+PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+SETTINGS_FILE = os.path.join(PLUGIN_DIR, "settings.json")
+
+def load_settings():
+    """从本地文件加载所有设置"""
+    default_settings = {
+        "language": "zh",
+        "blacklist": [],
+        "filter_tags": [
+            "watermark", "sample_watermark", "weibo_username", "weibo", "weibo_logo",
+            "weibo_watermark", "censored", "mosaic_censoring", "artist_name", "twitter_username"
+        ],
+        "filter_enabled": True,
+        "danbooru_username": "",
+        "danbooru_api_key": "",
+        "gelbooru_user_id": "",
+        "gelbooru_api_key": "",
+        "gelbooru_display_all_site_content": False,
+        "favorites": [],
+        "debug_mode": False,
+        "cache_enabled": True,
+        "max_cache_age": 3600,
+        "default_page_size": 20,
+        "autocomplete_enabled": True,
+        "tooltip_enabled": True,
+        "autocomplete_max_results": 20,
+        "selected_categories": ["copyright", "character", "general"],
+        "source_site": "danbooru"
+    }
+
+    try:
+        if os.path.exists(SETTINGS_FILE):
+            with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                for key, value in default_settings.items():
+                    if key not in data:
+                        data[key] = value
+                return data
+    except Exception as e:
+        logger.error(f"加载设置失败: {e}")
+
+    return default_settings
+
+def load_autocomplete_config():
+    """加载自动补全配置（用于数据库优先+API fallback机制）"""
+    # 默认配置
+    default_config = {
+        "offline_mode": {
+            "enabled": True,
+            "fallback_to_remote": True,
+            "remote_timeout_ms": 2000  # 2秒超时
+        },
+        "cache": {
+            "use_database_query": True
+        }
+    }
+
+    # 尝试从多个位置加载配置
+    config_paths = [
+        Path(PLUGIN_DIR) / "config.json",
+        Path(PLUGIN_DIR).parent / "config.json",
+    ]
+
+    for config_path in config_paths:
+        if config_path.exists():
+            try:
+                with open(config_path, 'r', encoding='utf-8') as f:
+                    loaded = json.load(f)
+                    # 深度合并配置
+                    if "offline_mode" in loaded:
+                        default_config["offline_mode"].update(loaded["offline_mode"])
+                    if "cache" in loaded:
+                        default_config["cache"].update(loaded["cache"])
+                    logger.info(f"[Autocomplete] 加载配置: {config_path}")
+                    return default_config
+            except Exception as e:
+                logger.warning(f"[Autocomplete] 配置文件加载失败 {config_path}: {e}")
+
+    logger.info("[Autocomplete] 使用默认配置")
+    return default_config
+
+def save_settings(settings):
+    """保存所有设置到本地文件"""
+    try:
+        with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
+            json.dump(settings, f, ensure_ascii=False, indent=2)
+        return True
+    except Exception as e:
+        logger.error(f"保存设置失败: {e}")
+        return False
+
+def load_user_auth():
+    """从统一设置文件加载用户认证信息"""
+    settings = load_settings()
+    return settings.get("danbooru_username", ""), settings.get("danbooru_api_key", "")
+
+def save_user_auth(username, api_key):
+    """保存用户认证信息到统一设置文件"""
+    settings = load_settings()
+    settings["danbooru_username"] = username
+    settings["danbooru_api_key"] = api_key
+    return save_settings(settings)
+
+def load_gelbooru_auth():
+    """从统一设置文件加载Gelbooru API认证信息"""
+    settings = load_settings()
+    return settings.get("gelbooru_user_id", ""), settings.get("gelbooru_api_key", "")
+
+def save_gelbooru_auth(user_id, api_key):
+    """保存Gelbooru API认证信息到统一设置文件"""
+    settings = load_settings()
+    settings["gelbooru_user_id"] = user_id
+    settings["gelbooru_api_key"] = api_key
+    return save_settings(settings)
+
+def get_site_credentials(adapter):
+    """返回站点适配器需要的认证参数。Danbooru 使用 HTTP Basic Auth，Gelbooru 使用 query 参数。"""
+    if adapter.key == "gelbooru":
+        user_id, api_key = load_gelbooru_auth()
+        return {"user_id": user_id, "api_key": api_key}
+    return {}
+
+def has_required_site_credentials(adapter, credentials):
+    """检查当前站点适配器的必要凭据是否已配置。"""
+    if adapter.key == "gelbooru":
+        return bool(credentials.get("user_id") and credentials.get("api_key"))
+    return True
+
+def load_favorites():
+    """从统一设置文件加载收藏列表"""
+    settings = load_settings()
+    return settings.get("favorites", [])
+
+def save_favorites(favorites):
+    """保存收藏列表到统一设置文件"""
+    settings = load_settings()
+    settings["favorites"] = favorites
+    return save_settings(settings)
+
+def load_language():
+    """从统一设置文件加载语言设置"""
+    settings = load_settings()
+    return settings.get("language", "zh")
+
+def save_language(language):
+    """保存语言设置到统一设置文件"""
+    settings = load_settings()
+    settings["language"] = language
+    return save_settings(settings)
+
+def load_blacklist():
+    """从统一设置文件加载黑名单"""
+    settings = load_settings()
+    return settings.get("blacklist", [])
+
+def save_blacklist(blacklist_items):
+    """保存黑名单到统一设置文件"""
+    settings = load_settings()
+    settings["blacklist"] = blacklist_items
+    return save_settings(settings)
+
+def load_filter_tags():
+    """从统一设置文件加载提示词过滤设置"""
+    settings = load_settings()
+    return settings.get("filter_tags", []), settings.get("filter_enabled", True)
+
+def save_filter_tags(filter_tags, enabled):
+    """保存提示词过滤设置到统一设置文件"""
+    settings = load_settings()
+    settings["filter_tags"] = filter_tags
+    settings["filter_enabled"] = enabled
+    return save_settings(settings)
+
+def load_ui_settings():
+    """从统一设置文件加载UI设置"""
+    settings = load_settings()
+    return {
+        "autocomplete_enabled": settings.get("autocomplete_enabled", True),
+        "tooltip_enabled": settings.get("tooltip_enabled", True),
+        "autocomplete_max_results": settings.get("autocomplete_max_results", 20),
+        "selected_categories": settings.get("selected_categories", ["copyright", "character", "general"]),
+        "multi_select_enabled": settings.get("multi_select_enabled", False),
+        "source_site": settings.get("source_site", "danbooru"),
+        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False)
+    }
+
+def save_ui_settings(ui_settings):
+    """保存UI设置到统一设置文件"""
+    settings = load_settings()
+    settings["autocomplete_enabled"] = ui_settings.get("autocomplete_enabled", True)
+    settings["tooltip_enabled"] = ui_settings.get("tooltip_enabled", True)
+    settings["autocomplete_max_results"] = ui_settings.get("autocomplete_max_results", 20)
+    settings["selected_categories"] = ui_settings.get("selected_categories", ["copyright", "character", "general"])
+    settings["multi_select_enabled"] = ui_settings.get("multi_select_enabled", False)
+    settings["source_site"] = ui_settings.get("source_site", "danbooru")
+    settings["gelbooru_display_all_site_content"] = ui_settings.get("gelbooru_display_all_site_content", False)
+    return save_settings(settings)
+
+# ================================
+# Tag翻译系统
+# ================================
+
+class TagTranslationSystem:
+    """Tag翻译系统，负责加载、处理和查询汉化数据"""
+    
+    def __init__(self):
+        self.en_to_cn = {}  # 英文->中文映射
+        self.cn_to_en = {}  # 中文->英文映射
+        self.cn_search_index = {}  # 中文搜索索引
+        self.loaded = False
+        self._translation_cache = {}  # 翻译缓存
+        self._search_cache = {}  # 搜索缓存
+        self.max_cache_size = 1000  # 最大缓存条目数
+        
+    def load_translation_data(self):
+        """加载所有汉化数据文件"""
+        if self.loaded:
+            return True
+            
+        try:
+            zh_cn_dir = os.path.join(PLUGIN_DIR, "zh_cn")
+            
+            # 加载JSON格式数据
+            self._load_json_data(zh_cn_dir)
+            # 加载CSV格式数据
+            self._load_csv_data(zh_cn_dir)
+            # 加载角色CSV数据
+            self._load_character_csv_data(zh_cn_dir)
+            
+            # 构建下划线匹配映射
+            self._build_underscore_variants()
+            # 构建中文搜索索引
+            self._build_chinese_search_index()
+            
+            self.loaded = True
+            return True
+            
+        except Exception as e:
+            logger.error(f"[翻译系统] 加载失败: {e}")
+            return False
+    
+    def _load_json_data(self, zh_cn_dir):
+        """加载JSON格式的翻译数据"""
+        json_file = os.path.join(zh_cn_dir, "all_tags_cn.json")
+        if os.path.exists(json_file):
+            try:
+                with open(json_file, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                    for en_tag, cn_tag in data.items():
+                        if en_tag and cn_tag:
+                            self.en_to_cn[en_tag.strip()] = cn_tag.strip()
+                            self.cn_to_en[cn_tag.strip()] = en_tag.strip()
+            except Exception as e:
+                logger.error(f"[翻译系统] JSON加载失败: {e}")
+    
+    def _load_csv_data(self, zh_cn_dir):
+        """加载CSV格式的翻译数据"""
+        csv_file = os.path.join(zh_cn_dir, "danbooru.csv")
+        if os.path.exists(csv_file):
+            try:
+                with open(csv_file, 'r', encoding='utf-8') as f:
+                    reader = csv.reader(f)
+                    count = 0
+                    for row in reader:
+                        if len(row) >= 2 and row[0] and row[1]:
+                            en_tag = row[0].strip()
+                            cn_tag = row[1].strip()
+                            # 如果已存在翻译，跳过（保持第一个找到的）
+                            if en_tag not in self.en_to_cn:
+                                self.en_to_cn[en_tag] = cn_tag
+                            if cn_tag not in self.cn_to_en:
+                                self.cn_to_en[cn_tag] = en_tag
+                            count += 1
+            except Exception as e:
+                logger.error(f"[翻译系统] CSV加载失败: {e}")
+    
+    def _load_character_csv_data(self, zh_cn_dir):
+        """加载角色CSV格式的翻译数据（格式：中文名称,英文tag）"""
+        csv_file = os.path.join(zh_cn_dir, "wai_characters.csv")
+        if os.path.exists(csv_file):
+            try:
+                with open(csv_file, 'r', encoding='utf-8') as f:
+                    reader = csv.reader(f)
+                    count = 0
+                    for row in reader:
+                        if len(row) >= 2 and row[0] and row[1]:
+                            cn_tag = row[0].strip()
+                            en_tag = row[1].strip()
+                            # 如果已存在翻译，跳过（保持第一个找到的）
+                            if en_tag not in self.en_to_cn:
+                                self.en_to_cn[en_tag] = cn_tag
+                            if cn_tag not in self.cn_to_en:
+                                self.cn_to_en[cn_tag] = en_tag
+                            count += 1
+            except Exception as e:
+                logger.error(f"[翻译系统] 角色CSV加载失败: {e}")
+    
+    def _build_underscore_variants(self):
+        """构建下划线变体映射，处理有无下划线的匹配问题"""
+        variants_to_add = {}
+        
+        for en_tag, cn_tag in list(self.en_to_cn.items()):
+            # 为有下划线的tag生成无下划线版本
+            if '_' in en_tag:
+                no_underscore = en_tag.replace('_', '')
+                if no_underscore not in self.en_to_cn:
+                    variants_to_add[no_underscore] = cn_tag
+            
+            # 为无下划线的tag生成可能的下划线版本（基于常见模式）
+            else:
+                # 在数字和字母之间添加下划线 (如: 1girl -> 1_girl)
+                with_underscore = re.sub(r'(\d)([a-zA-Z])', r'\1_\2', en_tag)
+                if with_underscore != en_tag and with_underscore not in self.en_to_cn:
+                    variants_to_add[with_underscore] = cn_tag
+        
+        # 添加变体到主字典
+        self.en_to_cn.update(variants_to_add)
+    
+    def _build_chinese_search_index(self):
+        """构建中文搜索索引，支持部分匹配"""
+        for cn_tag in self.cn_to_en.keys():
+            # 为中文tag的每个字符建立索引
+            for i, char in enumerate(cn_tag):
+                if char not in self.cn_search_index:
+                    self.cn_search_index[char] = set()
+                self.cn_search_index[char].add(cn_tag)
+                
+                # 也为子字符串建立索引（2-3字符的组合）
+                for length in [2, 3]:
+                    if i + length <= len(cn_tag):
+                        substring = cn_tag[i:i + length]
+                        if substring not in self.cn_search_index:
+                            self.cn_search_index[substring] = set()
+                        self.cn_search_index[substring].add(cn_tag)
+        
+        # 转换set为list以便JSON序列化
+        for key in self.cn_search_index:
+            self.cn_search_index[key] = list(self.cn_search_index[key])
+            
+    
+    def translate_tag(self, en_tag):
+        """翻译单个英文tag到中文"""
+        if not self.loaded:
+            self.load_translation_data()
+        
+        tag_key = en_tag.strip()
+        
+        # 检查缓存
+        if tag_key in self._translation_cache:
+            return self._translation_cache[tag_key]
+        
+        # 查找翻译
+        translation = self.en_to_cn.get(tag_key)
+        
+        # 添加到缓存
+        if len(self._translation_cache) < self.max_cache_size:
+            self._translation_cache[tag_key] = translation
+        
+        return translation
+    
+    def translate_tags_batch(self, en_tags):
+        """批量翻译英文tags"""
+        if not self.loaded:
+            self.load_translation_data()
+        
+        result = {}
+        for tag in en_tags:
+            translation = self.en_to_cn.get(tag.strip())
+            if translation:
+                result[tag] = translation
+        return result
+    
+    def search_chinese_tags(self, query, limit=10):
+        """搜索中文tag，返回匹配的中文tag及对应英文tag，支持模糊搜索"""
+        if not self.loaded:
+            self.load_translation_data()
+        
+        query = query.strip()
+        if not query:
+            return []
+        
+        # 检查搜索缓存
+        cache_key = f"{query}:{limit}"
+        if cache_key in self._search_cache:
+            return self._search_cache[cache_key]
+        
+        matches = {}  # 使用字典存储匹配结果和权重
+        
+        # 1. 精确匹配（权重10）
+        if query in self.cn_to_en:
+            matches[query] = 10
+        
+        # 2. 前缀匹配（权重8）
+        for cn_tag in self.cn_to_en.keys():
+            if cn_tag.startswith(query) and cn_tag not in matches:
+                matches[cn_tag] = 8
+        
+        # 3. 索引匹配（权重6）
+        if query in self.cn_search_index:
+            for cn_tag in self.cn_search_index[query]:
+                if cn_tag not in matches:
+                    matches[cn_tag] = 6
+        
+        # 4. 包含匹配（权重4）
+        for cn_tag in self.cn_to_en.keys():
+            if query in cn_tag and cn_tag not in matches:
+                matches[cn_tag] = 4
+        
+        # 5. 模糊匹配（权重2）- 支持字符顺序模糊匹配
+        if len(query) >= 2:
+            query_chars = set(query)
+            for cn_tag in self.cn_to_en.keys():
+                if cn_tag not in matches:
+                    tag_chars = set(cn_tag)
+                    # 如果查询字符的50%以上都在tag中，认为是模糊匹配
+                    if len(query_chars & tag_chars) / len(query_chars) >= 0.5:
+                        matches[cn_tag] = 2
+        
+        # 6. 部分字符匹配（权重1）
+        for char in query:
+            if char in self.cn_search_index:
+                for cn_tag in self.cn_search_index[char]:
+                    if cn_tag not in matches:
+                        matches[cn_tag] = 1
+        
+        # 按权重和长度排序
+        sorted_matches = sorted(matches.items(), key=lambda x: (-x[1], len(x[0])))
+        
+        # 转换为结果格式并限制数量
+        results = []
+        for cn_tag, weight in sorted_matches[:limit]:
+            en_tag = self.cn_to_en.get(cn_tag)
+            if en_tag:
+                results.append({
+                    'chinese': cn_tag,
+                    'english': en_tag,
+                    'weight': weight
+                })
+        
+        # 添加到缓存
+        if len(self._search_cache) < self.max_cache_size:
+            self._search_cache[cache_key] = results
+        
+        return results
+
+# 全局翻译系统实例
+translation_system = TagTranslationSystem()
+
+# 预加载翻译数据
+def preload_translation_data():
+    """预加载翻译数据，在服务器启动时调用"""
+    try:
+        success = translation_system.load_translation_data()
+        if not success:
+            logger.warning("[翻译系统] 预加载失败")
+    except Exception as e:
+        logger.error(f"[翻译系统] 预加载异常: {e}")
+
+# 在模块加载时预加载翻译数据
+preload_translation_data()
+
+def check_network_connection(source="danbooru"):
+    """Check network connectivity for the selected gallery source."""
+    adapter = get_site_adapter(source)
+    try:
+        # 使用一个简单的公开API端点来检测连接
+        if adapter.key == "gelbooru":
+            ui_settings = load_ui_settings()
+            session = _get_gelbooru_session(ui_settings.get("gelbooru_display_all_site_content", False))
+            response = session.get(
+                adapter.posts_url,
+                params=adapter.build_public_posts_params("", 1, 1, None),
+                timeout=(8, 10),
+            )
+            return response.status_code == 200, False
+
+        test_url = f"{BASE_URL}/posts.json?limit=1"
+        response = _danbooru_request("GET", test_url, timeout=10)
+        return response.status_code == 200, False
+    except requests.exceptions.Timeout:
+        logger.error("网络连接超时")
+        return False, True
+    except requests.exceptions.RequestException as e:
+        logger.error(f"网络连接失败: {e}")
+        return False, True
+    except Exception as e:
+        logger.error(f"网络检测发生未知错误: {e}")
+        return False, True
+
+def verify_danbooru_auth(username, api_key):
+    """验证Danbooru用户认证"""
+    if not username or not api_key:
+        return False, False
+    try:
+        test_url = f"{BASE_URL}/profile.json?login={username}&api_key={api_key}"
+        response = _danbooru_request("GET", test_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
+        is_valid = response.status_code == 200
+        return is_valid, False
+    except Exception as e:
+        logger.error(f"验证用户认证失败: {e}")
+        return False, True
+
+def get_user_favorites(username, api_key):
+    """获取用户的收藏列表"""
+    try:
+        favorites_url = f"{BASE_URL}/favorites.json?login={username}&api_key={api_key}"
+        response = _danbooru_request("GET", favorites_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
+        if response.status_code == 200:
+            return response.json()
+        return []
+    except Exception as e:
+        logger.error(f"获取用户收藏列表失败: {e}")
+        return []
+
+# --- 省略其他不相关的路由和函数以保持简洁 ---
+
+def get_gelbooru_favorites(user_id, api_key, limit=1000):
+    """Fetch Gelbooru favorite post IDs for the configured user."""
+    if not user_id or not api_key:
+        return []
+    if not str(user_id).isdigit():
+        raise ValueError("Gelbooru User ID must be numeric")
+
+    adapter = get_site_adapter("gelbooru")
+    credentials = {"user_id": user_id, "api_key": api_key}
+
+    # Gelbooru's documented favorite DAPI may return an empty list for valid API
+    # credentials, while the site's own favorites link uses the fav:<user_id> tag.
+    favorite_posts = []
+    page = 1
+    per_page = min(max(int(limit), 1), 100)
+    while len(favorite_posts) < limit:
+        params = adapter.build_posts_params(f"fav:{user_id}", per_page, page, None)
+        params = adapter.apply_auth_params(params, credentials)
+        response = _danbooru_request("GET", adapter.posts_url, params=params, timeout=15)
+        response.raise_for_status()
+        posts = adapter.normalize_posts_response(response.json())
+        if not posts:
+            break
+        favorite_posts.extend(str(post.get("id")) for post in posts if post.get("id"))
+        if len(posts) < per_page:
+            break
+        page += 1
+
+    if favorite_posts:
+        return favorite_posts[:limit]
+
+    all_ids = []
+    page = 1
+
+    while len(all_ids) < limit:
+        params = adapter.build_favorites_params(user_id, per_page, page)
+        params = adapter.apply_auth_params(params, credentials)
+        response = _danbooru_request("GET", adapter.posts_url, params=params, timeout=15)
+        if response.status_code == 401:
+            raise requests.exceptions.HTTPError("Gelbooru favorite API authentication failed", response=response)
+        response.raise_for_status()
+        page_ids = adapter.normalize_favorites_response(response.json())
+        if not page_ids:
+            break
+        all_ids.extend(page_ids)
+        if len(page_ids) < per_page:
+            break
+        page += 1
+
+    return all_ids[:limit]
+
+def add_gelbooru_favorite(post_id, user_id, api_key):
+    """Add a Gelbooru favorite via the site's favorite endpoint."""
+    if not user_id or not api_key:
+        return False, "请先在设置中配置 Gelbooru User ID 和 API Key"
+
+    session = _get_gelbooru_session(load_ui_settings().get("gelbooru_display_all_site_content", False))
+    response = session.get(
+        "https://gelbooru.com/public/addfav.php",
+        params={"id": str(post_id), "user_id": user_id, "api_key": api_key},
+        headers=_gelbooru_browser_headers("*/*"),
+        timeout=(8, 15),
+    )
+    response.raise_for_status()
+    body = (response.text or "").strip()
+    if body == "1":
+        return True, "已收藏，无需重复操作"
+    if body == "2":
+        return False, "Gelbooru 返回未登录；该站点的添加收藏接口可能不接受 API-only 认证"
+    return True, "收藏成功"
+
+def remove_gelbooru_favorite(post_id, user_id, api_key):
+    """Remove a Gelbooru favorite via the site's favorite page endpoint."""
+    if not user_id or not api_key:
+        return False, "请先在设置中配置 Gelbooru User ID 和 API Key"
+
+    session = _get_gelbooru_session(load_ui_settings().get("gelbooru_display_all_site_content", False))
+    response = session.get(
+        "https://gelbooru.com/index.php",
+        params={
+            "page": "favorites",
+            "s": "delete",
+            "id": str(post_id),
+            "user_id": user_id,
+            "api_key": api_key,
+        },
+        headers=_gelbooru_browser_headers("text/html,*/*"),
+        allow_redirects=False,
+        timeout=(8, 15),
+    )
+    if response.status_code in (200, 302, 303):
+        location = response.headers.get("Location", "")
+        if "account" in location and "login" in location:
+            return False, "Gelbooru 返回登录页；该站点的取消收藏接口可能不接受 API-only 认证"
+        return True, "取消收藏成功"
+    response.raise_for_status()
+    return True, "取消收藏成功"
+
+@PromptServer.instance.routes.post("/danbooru_gallery/favorites/add")
+async def add_favorite(request):
+    """添加收藏"""
+    try:
+        data = await request.json()
+        post_id = data.get("post_id")
+        source = data.get("source", "danbooru")
+        adapter = get_site_adapter(source)
+
+        if not post_id:
+            return web.json_response({"success": False, "error": "缺少post_id"})
+
+        if adapter.key == "gelbooru":
+            user_id, gelbooru_api_key = load_gelbooru_auth()
+            try:
+                ok, message = add_gelbooru_favorite(post_id, user_id, gelbooru_api_key)
+                return web.json_response({"success": ok, "message": message, "error": None if ok else message})
+            except requests.exceptions.Timeout:
+                logger.error("[Gelbooru] 添加收藏请求超时")
+                return web.json_response({"success": False, "error": "Gelbooru 收藏请求超时，请稍后重试"})
+            except requests.exceptions.RequestException as e:
+                logger.error(f"[Gelbooru] 添加收藏请求失败: {type(e).__name__}")
+                return web.json_response({"success": False, "error": "Gelbooru 收藏请求失败，请检查网络或稍后重试"})
+
+        username, api_key = load_user_auth()
+        if not username or not api_key:
+            return web.json_response({"success": False, "error": "请先在设置中配置用户名和API Key"})
+
+        # 验证认证
+        is_valid, is_network_error = verify_danbooru_auth(username, api_key)
+        if is_network_error:
+            return web.json_response({"success": False, "error": "网络错误，无法连接到Danbooru服务器"})
+        if not is_valid:
+            return web.json_response({"success": False, "error": "认证无效，请检查用户名和API Key"})
+
+        try:
+            favorite_url = f"{BASE_URL}/favorites.json?login={username}&api_key={api_key}"
+            response = _danbooru_request(
+                "POST",
+                favorite_url,
+                auth=HTTPBasicAuth(username, api_key),
+                data={"post_id": post_id},
+                timeout=15,
+            )
+
+
+            if response.status_code in [200, 201]:
+                favorites = load_favorites()
+                if str(post_id) not in favorites:
+                    favorites.append(str(post_id))
+                    save_favorites(favorites)
+                return web.json_response({"success": True, "message": "收藏成功"})
+            
+            try:
+                error_data = response.json()
+                reason = error_data.get("reason", "未知")
+                message = error_data.get("message", "没有提供具体信息")
+            except (json.JSONDecodeError, ValueError):
+                error_data = {}
+                reason = "无法解析响应"
+                message = response.text
+
+            if response.status_code == 422 and "You have already favorited this post" in message:
+                favorites = load_favorites()
+                if str(post_id) not in favorites:
+                    favorites.append(str(post_id))
+                    save_favorites(favorites)
+                return web.json_response({"success": True, "message": "已收藏，无需重复操作"})
+                
+            error_map = {
+                401: "认证失败，请检查用户名和API Key",
+                403: "权限不足，可能需要Gold账户或更高权限",
+                404: "图片不存在",
+                429: "请求过于频繁，请稍后重试 (Rate Limited)",
+            }
+            
+            error_message = error_map.get(response.status_code, f"收藏失败，状态码: {response.status_code}, 原因: {message}")
+            logger.error(error_message)
+            return web.json_response({"success": False, "error": error_message})
+
+        except requests.exceptions.Timeout:
+            logger.error("添加收藏时网络请求超时")
+            return web.json_response({"success": False, "error": "网络请求超时"})
+        except requests.exceptions.RequestException as e:
+            logger.error(f"添加收藏时网络请求失败: {e}")
+            return web.json_response({"success": False, "error": f"网络请求失败: {e}"})
+        except Exception as e:
+            import traceback
+            logger.error(f"添加收藏时发生严重错误: {e}")
+            logger.error(traceback.format_exc())
+            return web.json_response({"success": False, "error": f"服务器内部错误: {e}"}, status=500)
+
+    except Exception as e:
+        logger.error(f"添加收藏接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)}, status=500)
+
+@PromptServer.instance.routes.post("/danbooru_gallery/favorites/remove")
+async def remove_favorite(request):
+    """移除收藏"""
+    try:
+        data = await request.json()
+        post_id = data.get("post_id")
+        source = data.get("source", "danbooru")
+        adapter = get_site_adapter(source)
+
+        if not post_id:
+            return web.json_response({"success": False, "error": "缺少post_id"})
+
+        if adapter.key == "gelbooru":
+            user_id, gelbooru_api_key = load_gelbooru_auth()
+            try:
+                ok, message = remove_gelbooru_favorite(post_id, user_id, gelbooru_api_key)
+                return web.json_response({"success": ok, "message": message, "error": None if ok else message})
+            except requests.exceptions.Timeout:
+                logger.error("[Gelbooru] 取消收藏请求超时")
+                return web.json_response({"success": False, "error": "Gelbooru 取消收藏请求超时，请稍后重试"})
+            except requests.exceptions.RequestException as e:
+                logger.error(f"[Gelbooru] 取消收藏请求失败: {type(e).__name__}")
+                return web.json_response({"success": False, "error": "Gelbooru 取消收藏请求失败，请检查网络或稍后重试"})
+        
+        username, api_key = load_user_auth()
+        if not username or not api_key:
+            return web.json_response({"success": False, "error": "请先在设置中配置用户名和API Key"})
+
+        # 验证认证
+        is_valid, is_network_error = verify_danbooru_auth(username, api_key)
+        if is_network_error:
+            return web.json_response({"success": False, "error": "网络错误，无法连接到Danbooru服务器"})
+        if not is_valid:
+            return web.json_response({"success": False, "error": "认证无效，请检查用户名和API Key"})
+        
+        try:
+            # 直接使用帖子ID删除收藏
+            delete_url = f"{BASE_URL}/favorites/{post_id}.json?login={username}&api_key={api_key}"
+            delete_response = _danbooru_request("DELETE", delete_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
+
+
+            if delete_response.status_code in [200, 204]:
+                favorites = load_favorites()
+                if str(post_id) in favorites:
+                    favorites.remove(str(post_id))
+                    save_favorites(favorites)
+                return web.json_response({"success": True, "message": "取消收藏成功"})
+            elif delete_response.status_code == 404:
+                # 如果收藏不存在，视为已删除
+                favorites = load_favorites()
+                if str(post_id) in favorites:
+                    favorites.remove(str(post_id))
+                    save_favorites(favorites)
+                return web.json_response({"success": True, "message": "该图片未在云端收藏，本地已同步"})
+
+            # 如果有收藏记录但删除失败，解析错误
+            try:
+                error_data = delete_response.json()
+                reason = error_data.get("reason", "未知")
+                message = error_data.get("message", "没有提供具体信息")
+            except (json.JSONDecodeError, ValueError):
+                error_data = {}
+                reason = "无法解析响应"
+                message = delete_response.text
+
+            error_map = {
+                401: "认证失败，请检查用户名和API Key",
+                403: "权限不足，可能需要Gold账户",
+                404: "收藏记录不存在",
+                429: "请求过于频繁，请稍后重试 (Rate Limited)",
+            }
+
+            error_message = error_map.get(delete_response.status_code, f"取消收藏失败，状态码: {delete_response.status_code}, 原因: {message}")
+            logger.error(error_message)
+            return web.json_response({"success": False, "error": error_message})
+
+        except requests.exceptions.Timeout:
+            logger.error("移除收藏时网络请求超时")
+            return web.json_response({"success": False, "error": "网络请求超时"})
+        except requests.exceptions.RequestException as e:
+            logger.error(f"移除收藏时网络请求失败: {e}")
+            return web.json_response({"success": False, "error": f"网络请求失败: {e}"})
+        except Exception as e:
+            import traceback
+            logger.error(f"移除收藏时发生严重错误: {e}")
+            logger.error(traceback.format_exc())
+            return web.json_response({"success": False, "error": f"服务器内部错误: {e}"}, status=500)
+
+    except Exception as e:
+        logger.error(f"移除收藏接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)}, status=500)
+
+@PromptServer.instance.routes.get("/danbooru_gallery/user_auth")
+async def get_user_auth_route(request):
+    """获取用户认证信息"""
+    try:
+        username, api_key = load_user_auth()
+        gelbooru_user_id, gelbooru_api_key = load_gelbooru_auth()
+        has_auth = bool(username and api_key)
+        return web.json_response({
+            "success": True,
+            "username": username,
+            "api_key": api_key,
+            "has_auth": has_auth,
+            "gelbooru_user_id": gelbooru_user_id,
+            "gelbooru_api_key": gelbooru_api_key,
+            "gelbooru_has_auth": bool(gelbooru_user_id and gelbooru_api_key)
+        })
+    except Exception as e:
+        logger.error(f"获取用户认证接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)}, status=500)
+
+@PromptServer.instance.routes.get("/danbooru_gallery/favorites")
+async def get_favorites_route(request):
+    """获取收藏列表"""
+    try:
+        source = request.query.get("source") or load_ui_settings().get("source_site", "danbooru")
+        adapter = get_site_adapter(source)
+        if adapter.key == "gelbooru":
+            user_id, gelbooru_api_key = load_gelbooru_auth()
+            if not user_id or not gelbooru_api_key:
+                return web.json_response({
+                    "success": False,
+                    "favorites": [],
+                    "source": adapter.key,
+                    "error": "请先在设置中配置 Gelbooru User ID 和 API Key"
+                })
+            try:
+                favorites = get_gelbooru_favorites(user_id, gelbooru_api_key)
+                return web.json_response({"success": True, "favorites": favorites, "source": adapter.key})
+            except requests.exceptions.Timeout:
+                logger.error("[Gelbooru] 获取收藏列表超时")
+                return web.json_response({
+                    "success": False,
+                    "favorites": [],
+                    "source": adapter.key,
+                    "error": "Gelbooru 收藏列表读取超时，请稍后重试"
+                })
+            except requests.exceptions.HTTPError as e:
+                status_code = e.response.status_code if e.response is not None else "unknown"
+                logger.error(f"[Gelbooru] 获取收藏列表失败: HTTP {status_code}")
+                return web.json_response({
+                    "success": False,
+                    "favorites": [],
+                    "source": adapter.key,
+                    "error": "Gelbooru 收藏列表读取失败，请检查 User ID/API Key 是否有效"
+                })
+            except ValueError as e:
+                logger.error(f"[Gelbooru] 收藏列表配置无效: {e}")
+                return web.json_response({
+                    "success": False,
+                    "favorites": [],
+                    "source": adapter.key,
+                    "error": "Gelbooru User ID 必须是数字 ID，不是用户名"
+                })
+            except requests.exceptions.RequestException as e:
+                logger.error(f"[Gelbooru] 获取收藏列表请求失败: {type(e).__name__}")
+                return web.json_response({
+                    "success": False,
+                    "favorites": [],
+                    "source": adapter.key,
+                    "error": "Gelbooru 收藏列表请求失败，请检查网络或稍后重试"
+                })
+
+        favorites = load_favorites()
+        return web.json_response({"success": True, "favorites": favorites, "source": adapter.key})
+    except Exception as e:
+        logger.error(f"获取收藏列表接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)}, status=500)
+
+@PromptServer.instance.routes.post("/danbooru_gallery/user_auth")
+async def save_user_auth_route(request):
+    """保存用户认证信息"""
+    try:
+        data = await request.json()
+        username = data.get("username", "")
+        api_key = data.get("api_key", "")
+        gelbooru_user_id = data.get("gelbooru_user_id", "")
+        gelbooru_api_key = data.get("gelbooru_api_key", "")
+        if save_user_auth(username, api_key) and save_gelbooru_auth(gelbooru_user_id, gelbooru_api_key):
+            return web.json_response({"success": True})
+        else:
+            return web.json_response({"success": False, "error": "无法保存用户认证信息"}, status=500)
+    except Exception as e:
+        logger.error(f"保存用户认证接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)}, status=500)
+
+@PromptServer.instance.routes.get("/danbooru_gallery/check_network")
+async def check_network(request):
+    """检测网络连接状态"""
+    try:
+        source = request.query.get("source") or load_ui_settings().get("source_site", "danbooru")
+        adapter = get_site_adapter(source)
+        is_connected, is_network_error = check_network_connection(adapter.key)
+        return web.json_response({
+            "success": True,
+            "connected": is_connected,
+            "network_error": is_network_error,
+            "source": adapter.key
+        })
+    except Exception as e:
+        logger.error(f"网络检测接口错误: {e}")
+        return web.json_response({"success": False, "error": "网络检测失败", "network_error": True}, status=500)
+
+@PromptServer.instance.routes.post("/danbooru_gallery/verify_auth")
+async def verify_auth(request):
+    """验证用户认证"""
+    try:
+        data = await request.json()
+        username = data.get("username", "")
+        api_key = data.get("api_key", "")
+
+        if not username or not api_key:
+            return web.json_response({"success": False, "error": "缺少用户名或API Key"})
+
+        is_valid, is_network_error = verify_danbooru_auth(username, api_key)
+        return web.json_response({"success": True, "valid": is_valid, "network_error": is_network_error})
+    except Exception as e:
+        logger.error(f"验证认证接口错误: {e}")
+        return web.json_response({"success": False, "error": "网络错误", "network_error": True}, status=500)
+
+# 图片代理并发上限：浏览器一次打开一页会 lazy-load 多张缩略图，没有上限会导致
+# 后端同时发出十几个 CDN 请求，配合全局限流会形成长队列；限到 3 并发即可让缩略图
+# 平滑流入，又避免瞬时流量把 CF 的 rate rule 触发。
+_image_proxy_semaphore = None
+_gelbooru_session = None
+_gelbooru_session_display_all = None
+_gelbooru_session_lock = threading.Lock()
+
+def _get_image_proxy_semaphore():
+    global _image_proxy_semaphore
+    if _image_proxy_semaphore is None:
+        _image_proxy_semaphore = asyncio.Semaphore(1)
+    return _image_proxy_semaphore
+
+def _gelbooru_browser_headers(accept="text/html,*/*"):
+    return {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36",
+        "Accept": accept,
+        "Referer": "https://gelbooru.com/",
+    }
+
+def _gelbooru_set_cookie(session, name, value):
+    for domain in ("gelbooru.com", ".gelbooru.com"):
+        session.cookies.set(name, value, domain=domain, path="/")
+
+def _gelbooru_public_page_requires_options(html_text):
+    """Detect Gelbooru's anonymous page that says results are hidden by site options."""
+    if not html_text:
+        return False
+    return (
+        "Check your blacklist" in html_text
+        and "Nobody here but us" in html_text
+    )
+
+def _configure_gelbooru_display_all_session(session):
+    """Apply Gelbooru anonymous options for fringe/gore searches."""
+    _gelbooru_set_cookie(session, "fringeBenefits", "yup")
+    _gelbooru_set_cookie(session, "post_threshold", "0")
+    _gelbooru_set_cookie(session, "comment_threshold", "0")
+
+    options_response = session.get(
+        "https://gelbooru.com/index.php",
+        params={"page": "account", "s": "options"},
+        timeout=(8, 15),
+    )
+    options_response.raise_for_status()
+
+    csrf_match = re.search(r'name=["\']csrf-token["\']\s+value=["\']([^"\']+)["\']', options_response.text, re.IGNORECASE)
+    csrf_token = csrf_match.group(1) if csrf_match else ""
+    if not csrf_token:
+        logger.warning("[Gelbooru] options CSRF token was not found; Display all site content may not persist")
+
+    response = session.post(
+        "https://gelbooru.com/index.php?page=account&s=options",
+        data={
+            "tags": "",
+            "fringeBenefits": "on",
+            "cthreshold": "0",
+            "pthreshold": "0",
+            "my_tags": "",
+            "ad_type[]": ["1", "2", "3"],
+            "show_comments": "on",
+            "searchPostView": "on",
+            "csrf-token": csrf_token,
+            "submit": "Save",
+        },
+        timeout=(8, 15),
+    )
+    response.raise_for_status()
+
+    _gelbooru_set_cookie(session, "fringeBenefits", "yup")
+    _gelbooru_set_cookie(session, "post_threshold", "0")
+    _gelbooru_set_cookie(session, "comment_threshold", "0")
+
+    fringe_enabled = bool(re.search(r'name=["\']fringeBenefits["\'][^>]*checked', response.text, re.IGNORECASE))
+    blacklist_empty = bool(re.search(r'<textarea\b[^>]*\bid=["\']tags["\'][^>]*>\s*</textarea>', response.text, re.IGNORECASE))
+    if fringe_enabled:
+        logger.info("[Gelbooru] Display all site content enabled for anonymous session")
+    else:
+        logger.warning("[Gelbooru] Display all site content submitted, but options page did not show it as checked")
+    if not blacklist_empty:
+        logger.warning("[Gelbooru] Tag blacklist may not be empty after options submit")
+
+def _get_gelbooru_session(display_all_site_content=False, force_refresh=False):
+    """Return a Gelbooru session, optionally enabling the public fringe content option."""
+    global _gelbooru_session, _gelbooru_session_display_all
+
+    display_all_site_content = bool(display_all_site_content)
+    with _gelbooru_session_lock:
+        if not force_refresh and _gelbooru_session is not None and _gelbooru_session_display_all == display_all_site_content:
+            return _gelbooru_session
+
+        session = requests.Session()
+        session.headers.update(_gelbooru_browser_headers())
+
+        if display_all_site_content:
+            try:
+                _configure_gelbooru_display_all_session(session)
+            except requests.exceptions.RequestException as e:
+                logger.warning(f"[Gelbooru] Failed to enable Display all site content; continuing with normal session: {e}")
+        if False and display_all_site_content:
+            session.cookies.set("fringeBenefits", "yup", domain="gelbooru.com", path="/")
+            try:
+                options_response = session.get(
+                    "https://gelbooru.com/index.php",
+                    params={"page": "account", "s": "options"},
+                    timeout=(8, 15),
+                )
+                csrf_match = re.search(r'name=["\']csrf-token["\']\s+value=["\']([^"\']+)["\']', options_response.text, re.IGNORECASE)
+                csrf_token = csrf_match.group(1) if csrf_match else ""
+                if not csrf_token:
+                    logger.warning("[Gelbooru] 未找到 options CSRF token，Display all site content 可能无法保存")
+
+                response = session.post(
+                    "https://gelbooru.com/index.php?page=account&s=options",
+                    data={
+                        "tags": "",
+                        "fringeBenefits": "on",
+                        "cthreshold": "0",
+                        "pthreshold": "0",
+                        "my_tags": "",
+                        "ad_type[]": ["1", "2", "3"],
+                        "show_comments": "on",
+                        "searchPostView": "on",
+                        "csrf-token": csrf_token,
+                        "submit": "Save",
                     },
-                    onclick: () => {
-                        searchInput.value = '';
-                        searchInput.dispatchEvent(new Event('input'));
-                        fetchAndRender(true);
-                    }
-                });
-                searchContainer.appendChild(searchInput);
-                searchContainer.appendChild(clearButton);
+                    timeout=(8, 15),
+                )
+                fringe_enabled = bool(re.search(r'name=["\']fringeBenefits["\'][^>]*checked', response.text, re.IGNORECASE))
+                if fringe_enabled:
+                    logger.info("[Gelbooru] 已启用 Display all site content 匿名会话")
+                else:
+                    logger.warning("[Gelbooru] 已提交 Display all site content，但返回页未显示 checked")
+            except requests.exceptions.RequestException as e:
+                logger.warning(f"[Gelbooru] 启用 Display all site content 失败，将继续普通会话: {e}")
 
-                // 选中计数徽章（多选模式时显示，移至底部状态栏）
-                const selectionCountBadge = $el("span.danbooru-selection-count", {
-                    style: {
-                        display: 'none',
-                        padding: '4px 8px',
-                        backgroundColor: 'rgba(0, 0, 0, 0.7)',
-                        color: 'white',
-                        fontSize: '12px',
-                        borderRadius: '4px',
-                        backdropFilter: 'blur(5px)',
-                        whiteSpace: 'nowrap'
-                    }
-                });
+        _gelbooru_session = session
+        _gelbooru_session_display_all = display_all_site_content
+        return _gelbooru_session
 
-                // 清除全选按钮（多选模式时显示）
-                const clearSelectionButton = $el("button.danbooru-clear-selection", {
-                    textContent: t('clearAllSelection'),
-                    title: t('clearAllSelection'),
-                    style: {
-                        display: uiSettings.multi_select_enabled ? 'inline-block' : 'none',
-                        padding: '5px 10px',
-                        borderRadius: '4px',
-                        backgroundColor: 'var(--comfy-input-bg)',
-                        border: '1px solid var(--input-border-color)',
-                        color: 'var(--comfy-input-text)',
-                        cursor: 'pointer',
-                        fontSize: '12px'
-                    },
-                    onclick: () => {
-                        clearAllSelections();
-                    }
-                });
+def _image_proxy_headers_for_host(host):
+    """Return browser-like headers for image CDNs that are sensitive to generic requests."""
+    if host == "gelbooru.com" or host.endswith(".gelbooru.com"):
+        return _gelbooru_browser_headers("image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+    return {}
 
-                // 将包含搜索框和建议面板的容器添加到总控件中
-                container.appendChild($el("div.danbooru-controls", [searchContainer, sourceSelect, displayAllSiteContentToggle, rankingButton, favoritesButton, ratingSelect, categoryDropdown, formattingDropdown, filterButton, clearSelectionButton, settingsButton, refreshButton]));
+def _fetch_supported_media(url):
+    """Fetch image/video bytes using the same site-aware request path as the preview proxy."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("invalid media url scheme")
 
-                // 🔧 重要：在 searchInput 被添加到 DOM 之后才创建智能补全实例
-                // 这样 AutocompleteUI 才能正确获取父元素并将建议容器添加到 DOM
-                const searchAutocomplete = new AutocompleteUI({
-                    inputElement: searchInput,
-                    language: globalMultiLanguageManager.getLanguage(),
-                    source: uiSettings.source_site || "danbooru",
-                    maxSuggestions: uiSettings.autocomplete_max_results || 20,
-                    customClass: 'danbooru-gallery-autocomplete',
-                    formatTag: (tag) => {
-                        // 应用格式化设置
-                        let processedTag = tag;
-                        if (uiSettings.formatting && uiSettings.formatting.replaceUnderscores) {
-                            processedTag = processedTag.replace(/_/g, ' ');
-                        }
-                        if (uiSettings.formatting && uiSettings.formatting.escapeBrackets) {
-                            processedTag = processedTag.replaceAll('(', '\\(').replaceAll(')', '\\)');
-                        }
-                        return processedTag;
-                    },
-                    onSelect: (tag) => {
-                        // 选择建议后保存
-                        saveToLocalStorage('searchValue', searchInput.value);
-                    }
-                });
-                container.appendChild(imageGrid);
+    host = (parsed.hostname or "").lower()
+    allowed_suffixes = ("donmai.us", "gelbooru.com")
+    if not any(host == suffix or host.endswith(f".{suffix}") for suffix in allowed_suffixes):
+        raise ValueError(f"unsupported media host: {host}")
 
-                // 创建底部状态栏容器
-                const bottomStatusBar = $el("div.danbooru-bottom-status", {
-                    style: {
-                        position: 'absolute',
-                        bottom: '10px',
-                        left: '10px',
-                        zIndex: '20',
-                        display: 'flex',
-                        gap: '8px',
-                        alignItems: 'center'
-                    }
-                });
+    if host == "gelbooru.com" or host.endswith(".gelbooru.com"):
+        display_all_site_content = load_ui_settings().get("gelbooru_display_all_site_content", False)
+        session = _get_gelbooru_session(display_all_site_content)
+        response = session.get(
+            url,
+            headers=_image_proxy_headers_for_host(host),
+            timeout=(8, 30),
+        )
+    else:
+        response = _danbooru_request(
+            "GET",
+            url,
+            headers=_image_proxy_headers_for_host(host),
+            timeout=30,
+        )
 
-                // 添加页码指示器
-                const pageIndicator = $el("div.danbooru-page-indicator", {
-                    style: {
-                        display: 'none', // Initially hidden
-                        padding: '4px 8px',
-                        backgroundColor: 'rgba(0, 0, 0, 0.7)',
-                        color: 'white',
-                        fontSize: '12px',
-                        borderRadius: '4px',
-                        backdropFilter: 'blur(5px)'
-                    }
-                });
+    response.raise_for_status()
+    content_type = response.headers.get("Content-Type", "application/octet-stream").lower()
+    if content_type and not content_type.startswith(("image/", "application/octet-stream")):
+        raise ValueError(f"upstream returned non-image content: {content_type}")
+    return response.content
 
-                // 将页码指示器和选择计数器添加到底部状态栏
-                bottomStatusBar.appendChild(pageIndicator);
-                bottomStatusBar.appendChild(selectionCountBadge);
-                container.appendChild(bottomStatusBar);
+def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, display_all_site_content=False):
+    """Fetch Gelbooru posts from public HTML pages when DAPI credentials are unavailable.
 
-                const insertNewPost = (post) => {
-                    const newElement = createPostElement(post);
-                    if (newElement) {
-                        imageGrid.prepend(newElement);
-                        newElement.classList.add('new-item');
-                        newElement.addEventListener('animationend', () => newElement.classList.remove('new-item'));
-                        resizeGrid();
-                    }
-                };
+    Uses fixed page size GELBOORU_PUBLIC_PAGE_SIZE (42) so pid is decoupled from
+    the frontend's requested limit; the frontend chains multiple page fetches via
+    maybeLoadMore to reach the user's preload_count.
 
-                const updateEditedStatus = (wrapperElement, postId) => {
-                    const originalPost = originalPostCache[postId]; // 从缓存中获取原始数据
-                    const editedPost = temporaryTagEdits[postId];
+    On transient failure (429/503) it retries once with Retry-After back-off.
+    If retry also fails or the response is non-recoverable, returns an error
+    placeholder object so the frontend can display a per-cell error rather than
+    crashing the whole gallery.
+    """
+    id_match = re.search(r"(?:^|\s)id:(\d+)(?:\s|$)", tags or "")
+    if id_match:
+        refs = [{"id": id_match.group(1)}]
+    else:
+        # 固定页大小，pid 与 frontend 的 limit 解耦
+        pid_value = max(page - 1, 0) * GELBOORU_PUBLIC_PAGE_SIZE
+        params = adapter.build_public_posts_params(tags, limit, page, rating_query)
+        # override pid with fixed page size
+        params["pid"] = pid_value
 
-                    let isTrulyEdited = false;
-                    if (editedPost && originalPost) {
-                        const categories = ["artist", "copyright", "character", "general", "meta"];
-                        const hasCategoryTags = categories.some(cat => originalPost.hasOwnProperty(`tag_string_${cat}`) || editedPost.hasOwnProperty(`tag_string_${cat}`));
+        session = _get_gelbooru_session(display_all_site_content)
 
-                        if (hasCategoryTags) {
-                            for (const category of categories) {
-                                if (!compareTagStrings(originalPost[`tag_string_${category}`], editedPost[`tag_string_${category}`])) {
-                                    isTrulyEdited = true;
-                                    break;
-                                }
-                            }
-                        } else {
-                            // 如果没有分类标签，检查tag_string是否被编辑
-                            if (!compareTagStrings(originalPost.tag_string, editedPost.tag_string)) {
-                                isTrulyEdited = true;
-                            }
-                        }
-                    }
+        def _get_list_page(sess):
+            """Inner closure: fetch list page with rate limiting + retry."""
+            for attempt in range(2):
+                _gelbooru_public_throttle.wait()
+                try:
+                    resp = sess.get(adapter.posts_url, params=params, timeout=(8, 15))
+                except requests.exceptions.RequestException as e:
+                    if attempt == 0:
+                        _log_gelbooru_retry_warning(f"网络异常: {e}", pid_value=pid_value)
+                        time.sleep(3)
+                    continue
 
-                    const indicator = wrapperElement.querySelector('.danbooru-edited-indicator');
+                if resp.status_code not in (429, 503):
+                    return resp  # 正常（含 200/500/403），交调用方判断
 
-                    if (isTrulyEdited) {
-                        if (!indicator) {
-                            const newIndicator = $el("div.danbooru-edited-indicator", { textContent: t('edited') });
-                            wrapperElement.appendChild(newIndicator);
-                        }
-                    } else {
-                        if (indicator) {
-                            indicator.remove();
-                        }
-                    }
-                    return isTrulyEdited;
-                };
-                // 初始化功能
-                const initializeApp = async () => {
-                    try {
-                        // Try to load filter state from the widget right before we need it
-                        try {
-                            if (filterWidget.value) {
-                                filterState = JSON.parse(filterWidget.value);
-                            }
-                        } catch (e) {
-                            logger.warn("Danbooru Gallery: Could not parse filter state, using default.", e);
-                            filterState = { startTime: null, endTime: null, startPage: null };
-                        }
+                # 429/503 限流: 读 Retry-After 退避一次
+                retry_after = resp.headers.get("Retry-After")
+                delay = 2.0
+                try:
+                    if retry_after is not None:
+                        delay = min(max(float(retry_after), 0.5), 10.0)
+                except ValueError:
+                    pass
+                if attempt == 0:
+                    _log_gelbooru_retry_warning(f"HTTP {resp.status_code} 限流，{delay:.1f}s 后重试", pid_value=pid_value)
+                    time.sleep(delay)
+                else:
+                    _log_gelbooru_retry_warning(f"重试仍限流({resp.status_code})，跳过本页", pid_value=pid_value)
+                    return None  # 重试仍限流 → 跳过本页
+
+            return None
+
+        list_response = _get_list_page(session)
+        if list_response is None:
+            # 返回 error 占位格（不含 list_response.text 细节）
+            driver_pid = params.get("pid", pid_value)
+            return [{"error": "Gelbooru 服务暂不可用", "pid": driver_pid, "page": page}]
+
+        if display_all_site_content and _gelbooru_public_page_requires_options(list_response.text):
+            logger.warning("[GelbooruPublic] Result page still requested Display all site content; rebuilding session and retrying")
+            session = _get_gelbooru_session(display_all_site_content, force_refresh=True)
+            list_response = _get_list_page(session)
+            if list_response is None:
+                driver_pid = params.get("pid", pid_value)
+                return [{"error": "Gelbooru 服务暂不可用", "pid": driver_pid, "page": page}]
+
+        refs = adapter.extract_public_post_refs(list_response.text, limit)
+        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} refs={len(refs)}")
+
+    if not id_match:
+        return refs
+
+    posts = []
+    for ref in refs:
+        post_id = ref.get("id")
+        if not post_id:
+            continue
+
+        # 0 引用重试：HTML 结构有可能解析失败
+        for attempt in range(2):
+            try:
+                post_response = _get_gelbooru_session(display_all_site_content).get(
+                    adapter.posts_url,
+                    params=adapter.build_public_post_params(post_id),
+                    timeout=(8, 15),
+                )
+                post_response.raise_for_status()
+                post = adapter.normalize_public_post_page(post_id, post_response.text, ref)
+                if post.get("preview_file_url") or post.get("file_url"):
+                    posts.append(post)
+                    break
+            except requests.exceptions.RequestException as e:
+                if attempt == 0:
+                    logger.warning(f"[GelbooruPublic] 帖子页面解析失败/id={post_id} 尝试重试: {e}")
+                    time.sleep(1)
+                else:
+                    logger.warning(f"[GelbooruPublic] 帖子页面解析失败/id={post_id} 放弃: {e}")
+
+    return posts
 
 
-                        let networkConnected = true;
+def _log_gelbooru_retry_warning(message, pid_value=None):
+    """Short helper for logging gelbooru public fetch retry messages."""
+    if pid_value is not None:
+        logger.warning(f"[GelbooruPublic] {message} (pid={pid_value})")
+    else:
+        logger.warning(f"[GelbooruPublic] {message}")
 
-                        await loadUiSettings();
+@PromptServer.instance.routes.get("/danbooru_gallery/image_proxy")
+async def image_proxy(request):
+    # 浏览器直连 cdn.donmai.us 会被 Cloudflare 按 cross-site <img> 请求挑战并返回 403，
+    # 而后端用描述性 UA (DANBOORU_HEADERS) 能过 CF。转发一次即可让前端拿到缩略图。
+    url = request.query.get("url", "")
+    if not url:
+        return web.Response(status=400, text="missing url")
 
-                        // 优先检测网络连接状态
-                        try {
-                            const sourceForNetworkCheck = loadFromLocalStorage('sourceSite', uiSettings.source_site || "danbooru");
-                            const networkResponse = await fetch(`/danbooru_gallery/check_network?source=${encodeURIComponent(sourceForNetworkCheck)}`);
-                            const networkData = await networkResponse.json();
-                            if (!networkData.success || !networkData.connected) {
-                                networkConnected = false;
-                                // 注释掉网络错误toast提示 - 本小姐才不想看到这些烦人的提示呢！
-                                // showError('网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接', true);
-                                console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");  // 仅在控制台记录
-                            }
-                        } catch (e) {
-                            logger.error('网络检测失败:', e);
-                            networkConnected = false;
-                            // 注释掉网络错误toast提示 - 本小姐才不想看到这些烦人的提示呢！
-                            // showError('网络检测失败 - 请检查网络连接', true);
-                            console.log("网络错误已隐藏: 网络检测失败 - 请检查网络连接");  // 仅在控制台记录
-                        }
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception:
+        return web.Response(status=400, text="invalid url")
 
-                        // 加载语言设置
-                        await loadLanguage();
+    if parsed.scheme not in ("http", "https"):
+        return web.Response(status=400, text="invalid scheme")
 
-                        // 加载用户认证信息
-                        await loadUserAuth();
+    # SSRF 防护：只允许当前支持图站的图片域名
+    host = (parsed.hostname or "").lower()
+    allowed_suffixes = ("donmai.us", "gelbooru.com")
+    if not any(host == suffix or host.endswith(f".{suffix}") for suffix in allowed_suffixes):
+        return web.Response(status=403, text="host not allowed")
 
+    async with _get_image_proxy_semaphore():
+        try:
+            if host == "gelbooru.com" or host.endswith(".gelbooru.com"):
+                display_all_site_content = load_ui_settings().get("gelbooru_display_all_site_content", False)
+                session = _get_gelbooru_session(display_all_site_content)
+                resp = await asyncio.to_thread(
+                    session.get,
+                    url,
+                    headers=_image_proxy_headers_for_host(host),
+                    timeout=(8, 15),
+                )
+            else:
+                resp = await asyncio.to_thread(
+                    _danbooru_request,
+                    "GET",
+                    url,
+                    headers=_image_proxy_headers_for_host(host),
+                    timeout=15,
+                )
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"[ImageProxy] 上游请求失败 {url}: {e}")
+            return web.Response(status=502, text="upstream error")
 
-                        if (networkConnected && hasFavoriteAuth()) {
-                            await loadFavorites();
-                        }
+    if resp.status_code != 200:
+        logger.debug(f"[ImageProxy] 上游返回 {resp.status_code}: {url}")
+        return web.Response(status=resp.status_code)
 
-                        // 更新界面文本
-                        updateInterfaceTexts();
+    content_type = resp.headers.get("Content-Type", "application/octet-stream")
+    if not content_type.lower().startswith(("image/", "video/")):
+        logger.warning(f"[ImageProxy] 上游返回非媒体内容 {content_type}: {url}")
+        return web.Response(status=502, text="upstream returned non-media content")
 
-                        // 更新收藏夹按钮状态
-                        updateFavoritesButtonState();
+    return web.Response(
+        body=resp.content,
+        headers={
+            "Content-Type": content_type,
+            "Cache-Control": "public, max-age=86400",
+        },
+    )
 
-                        // 加载黑名单
-                        await loadBlacklist();
+# --- 保留文件中剩余的其他部分 ---
+@PromptServer.instance.routes.get("/danbooru_gallery/posts")
+async def get_posts_for_front(request):
+    query = request.query
+    tags = query.get("search[tags]", "")
+    page = query.get("page", "1")
+    limit = query.get("limit", "100")
+    rating = query.get("search[rating]", "")
+    source = query.get("source", "danbooru")
+    gelbooru_display_all_site_content = query.get("gelbooru_display_all_site_content", "").lower() in ("1", "true", "yes", "on")
+    force_public_detail = query.get("force_public_detail", "").lower() in ("1", "true", "yes", "on")
+    before_id_raw = query.get("before_id", "")
+    gelbooru_dedup_mode = query.get("gelbooru_dedup_mode", "off").strip().lower()
+    if gelbooru_dedup_mode not in ("off", "on", "on_auth"):
+        gelbooru_dedup_mode = "off"
 
-                        // 加载提示词过滤设置
-                        await loadFilterTags();
-
-                        // 加载UI设置
-                        const savedSourceSite = loadFromLocalStorage('sourceSite', null);
-                        if (savedSourceSite && SOURCE_SITES.some(site => site.value === savedSourceSite)) {
-                            uiSettings.source_site = savedSourceSite;
-                        }
-                        const savedDisplayAllSiteContent = loadFromLocalStorage('gelbooruDisplayAllSiteContent', null);
-                        if (typeof savedDisplayAllSiteContent === "boolean") {
-                            uiSettings.gelbooru_display_all_site_content = savedDisplayAllSiteContent;
-                        }
-                        updateSourceState();
-                        searchAutocomplete.source = uiSettings.source_site || "danbooru";
-
-                        // 从 localStorage 加载并覆盖筛选状态
-                        const savedSearch = loadFromLocalStorage('searchValue', null);
-                        if (savedSearch !== null) {
-                            searchInput.value = savedSearch;
-                        }
-
-                        const savedRatingValues = loadFromLocalStorage('ratingValues', null);
-                        if (Array.isArray(savedRatingValues) && savedRatingValues.length > 0) {
-                            applySelectedRatings(savedRatingValues);
-                        } else {
-                            const savedRating = loadFromLocalStorage('ratingValue', null);
-                            if (savedRating && RATING_VALUES.includes(savedRating)) {
-                                applySelectedRatings([savedRating]);
-                                saveToLocalStorage('ratingValues', [savedRating]);
-                            } else {
-                                applySelectedRatings(RATING_VALUES);
-                            }
-                        }
-
-                        const savedCategories = loadFromLocalStorage('selectedCategories', null);
-                        if (savedCategories) {
-                            uiSettings.selected_categories = savedCategories;
-                        }
-                        const categoryCheckboxes = categoryDropdown.querySelectorAll('.danbooru-category-checkbox');
-                        categoryCheckboxes.forEach(checkbox => {
-                            checkbox.checked = uiSettings.selected_categories.includes(checkbox.name);
-                        });
-
-                        const savedFormatting = loadFromLocalStorage('formatting', null);
-                        if (savedFormatting) {
-                            uiSettings.formatting = savedFormatting;
-                        }
-                        const escapeBracketsCheckbox = formattingDropdown.querySelector('[name="escapeBrackets"]');
-                        const replaceUnderscoresCheckbox = formattingDropdown.querySelector('[name="replaceUnderscores"]');
-                        if (escapeBracketsCheckbox && uiSettings.formatting) {
-                            escapeBracketsCheckbox.checked = uiSettings.formatting.escapeBrackets;
-                        }
-                        if (replaceUnderscoresCheckbox && uiSettings.formatting) {
-                            replaceUnderscoresCheckbox.checked = uiSettings.formatting.replaceUnderscores;
-                        }
-
-                        const savedFilterData = loadFromLocalStorage('filterData', null);
-                        if (savedFilterData) {
-                            filterState = savedFilterData;
-                            filterWidget.value = JSON.stringify(filterState);
-                        }
-
-                        // 恢复已存储的 preload/dedup/globalLogging（在 loadUiSettings 之后）
-                        const savedPreloadCount = loadFromLocalStorage('preload_count', null);
-                        if (savedPreloadCount !== null) {
-                            const clamped = Math.min(Math.max(parseInt(savedPreloadCount, 10) || 40, 20), 200);
-                            uiSettings.preload_count = clamped;
-                        } else {
-                            uiSettings.preload_count = 40;
-                        }
-                        const savedGelbooruDedupMode = loadFromLocalStorage('gelbooru_dedup_mode', null);
-                        if (savedGelbooruDedupMode && ["off", "on", "on_auth"].includes(savedGelbooruDedupMode)) {
-                            uiSettings.gelbooru_dedup_mode = savedGelbooruDedupMode;
-                        } else {
-                            uiSettings.gelbooru_dedup_mode = "off";
-                        }
-                        const savedGlobalLogging = loadFromLocalStorage('global_logging', null);
-                        if (typeof savedGlobalLogging === "boolean") {
-                            uiSettings.global_logging = savedGlobalLogging;
-                            loggerClient.setConsoleOutput(savedGlobalLogging);
-                        } else {
-                            uiSettings.global_logging = false;
-                            loggerClient.setConsoleOutput(false);
-                        }
-
-                        // 恢复保存的滚动锚点（刷新后用其 id 做游标往下接）
-                        const savedScrollAnchor = loadFromLocalStorage('scrollAnchorPostId', null);
-                        if (savedScrollAnchor) {
-                            scrollAnchorPostId = savedScrollAnchor;
-                        }
-
-                        // 初始化排行榜按钮状态
-                        updateRankingButtonState();
-
-                        // 根据加载的 filterState 更新筛选按钮状态
-                        if (filterState.startTime || filterState.endTime || filterState.startPage) {
-                            filterButton.classList.add('active');
-                        } else {
-                            filterButton.classList.remove('active');
-                        }
-
-                        // 页面加载时直接获取第一页的帖子（先同步 currentTags，否则重置块会因 '' !== 搜索值而清空锚点）
-                        currentTags = searchInput.value.trim();
-                        fetchAndRender(true);
-
-                    } catch (error) {
-                        logger.error("Danbooru Gallery initialization failed:", error);
-                        showError("图库初始化失败，请检查控制台日志。", true);
-                    }
-                };
-
-                const updateCurrentPageIndicator = () => {
-                    if (posts.length === 0) {
-                        pageIndicator.style.display = 'none';
-                        return;
-                    }
-
-                    const itemsPerPage = 100;
-
-                    // Find the first visible element in the grid
-                    const firstVisibleChild = Array.from(imageGrid.children).find(child => {
-                        const rect = child.getBoundingClientRect();
-                        const gridRect = imageGrid.getBoundingClientRect();
-                        return rect.bottom > gridRect.top && rect.top < gridRect.bottom;
-                    });
-
-                    if (firstVisibleChild) {
-                        const postId = firstVisibleChild.dataset.postId;
-                        const postIndex = posts.findIndex(p => String(p.id) === postId);
-
-                        if (postIndex !== -1) {
-                            const currentPageInView = Math.floor(postIndex / itemsPerPage) + (filterState.startPage || 1);
-                            pageIndicator.textContent = `${t('currentPage')}: ${currentPageInView}`;
-                            pageIndicator.style.display = 'block';
-                        } else {
-                            pageIndicator.style.display = 'none';
-                        }
-                    } else {
-                        pageIndicator.style.display = 'none';
-                    }
-                };
-
-                // 启动应用
-                initializeApp();
-
-                this.onResize = (size) => {
-                    const [width, height] = size;
-                    const contentWidth = Math.max(150, width - 24);
-                    container.style.width = `${contentWidth}px`;
-                    imageGrid.style.width = "100%";
-                    imageGrid.style.boxSizing = "border-box";
-
-                    const controlsHeight = container.querySelector('.danbooru-controls')?.offsetHeight || 0;
-                    if (controlsHeight > 0) {
-                        imageGrid.style.height = `${Math.max(120, height - controlsHeight - 10)}px`;
-                    }
-
-                    cachedColumnWidth = 0;
-                    scheduleResizeGrid();
-                }
-            };
-
-            const onRemoved = nodeType.prototype.onRemoved;
-            nodeType.prototype.onRemoved = function () {
-                // 移除所有可能由该节点创建的全局UI元素
-                const elementsToRemove = document.querySelectorAll(
-                    ".danbooru-settings-dialog, .danbooru-edit-panel, .danbooru-tag-tooltip, .danbooru-tag-context-menu, .danbooru-toast"
-                );
-                elementsToRemove.forEach(el => el.remove());
-
-                // 调用原始的 onRemoved 方法
-                onRemoved?.apply(this, arguments);
-            };
-        }
-    },
-});
-
-$el("style", {
-    textContent: `
-    /* 搜索容器，用于定位建议面板 */
-    .danbooru-search-container {
-        position: relative;
-        flex-grow: 1;
-        display: flex;
-        align-items: center;
-    }
-
-    .danbooru-search-input {
-        /* padding-right: 28px !important; */ /* 为清空按钮留出空间, 已被新的flex布局取代 */
-    }
-
-    .danbooru-clear-search-button {
-        position: absolute;
-        right: 5px;
-        top: 50%;
-        transform: translateY(-50%);
-        background: transparent;
-        border: none;
-        color: #999;
-        cursor: pointer;
-        font-size: 20px;
-        line-height: 1;
-        padding: 0 5px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 22px;
-        height: 22px;
-        border-radius: 50%;
-        transition: all 0.2s;
-    }
-    .danbooru-clear-search-button:hover {
-        background-color: rgba(255, 255, 255, 0.1);
-        color: white;
-    }
-
-    /* 自动补全建议面板 */
-    .danbooru-suggestions-panel {
-        display: none;
-        position: absolute;
-        top: 100%;
-        left: 0;
-        min-width: 100%;
-        max-width: 600px;
-        width: auto;
-        background-color: var(--comfy-menu-bg);
-        border: 1px solid var(--input-border-color);
-        border-top: none;
-        border-radius: 0 0 6px 6px;
-        z-index: 1002;
-        max-height: 400px;
-        overflow-y: auto;
-        overflow-x: hidden;
-        box-shadow: 0 8px 16px rgba(0,0,0,0.3);
-        white-space: nowrap;
-    }
-
-    .danbooru-suggestion-item {
-        padding: 8px 12px;
-        cursor: pointer;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        transition: background-color 0.2s;
-        min-width: fit-content;
-    }
-
-    .danbooru-suggestion-item:hover,
-    .danbooru-suggestion-item.selected {
-        background-color: rgba(123, 104, 238, 0.3);
-    }
-
-    .danbooru-suggestion-name {
-        color: var(--comfy-input-text);
-        font-weight: 500;
-        flex: 1;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        margin-right: 8px;
-    }
-
-    .danbooru-suggestion-count {
-        color: #888;
-        font-size: 0.9em;
-        flex-shrink: 0;
-    }
-
-    /* 中文搜索建议面板 */
-    .danbooru-chinese-suggestions-panel {
-        display: none;
-        position: absolute;
-        top: 100%;
-        left: 0;
-        min-width: 100%;
-        max-width: 500px;
-        width: auto;
-        background-color: var(--comfy-menu-bg);
-        border: 1px solid var(--input-border-color);
-        border-top: none;
-        border-radius: 0 0 6px 6px;
-        z-index: 1003;
-        max-height: 300px;
-        overflow-y: auto;
-        overflow-x: hidden;
-        box-shadow: 0 8px 16px rgba(0,0,0,0.3);
-        white-space: nowrap;
-    }
-
-    .danbooru-chinese-suggestion-item {
-        padding: 8px 12px;
-        cursor: pointer;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        transition: background-color 0.2s;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-        min-width: fit-content;
-    }
-
-    .danbooru-chinese-suggestion-item:last-child {
-        border-bottom: none;
-    }
-
-    .danbooru-chinese-suggestion-item:hover,
-    .danbooru-chinese-suggestion-item.selected {
-        background-color: rgba(123, 104, 238, 0.3);
-    }
-
-    .danbooru-suggestion-chinese {
-        color: var(--comfy-input-text);
-        font-weight: 600;
-        font-size: 0.95em;
-        margin-right: 8px;
-        flex-shrink: 0;
-    }
-
-    .danbooru-suggestion-english {
-        color: #888;
-        font-size: 0.85em;
-        font-style: italic;
-        flex-shrink: 0;
-    }
-
-    /* Category Dropdown Styles */
-    .danbooru-category-dropdown { position: relative; display: inline-block; }
+    posts_json_str, = DanbooruGalleryNode.get_posts_internal(
+        tags=tags,
+        limit=int(limit),
+        page=int(page),
+        rating=rating,
+        source=source,
+        gelbooru_display_all_site_content=gelbooru_display_all_site_content,
+        force_public_detail=force_public_detail,
+        before_id=before_id_raw,
+        gelbooru_dedup_mode=gelbooru_dedup_mode,
+    )
     
-    /* Spinner for buttons */
-    .spinner {
-        width: 10px;
-        height: 10px;
-        border: 1px solid currentColor;
-        border-top: 1px solid transparent;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-    }
-   
-   .danbooru-category-button {
-       background-color: var(--comfy-input-bg);
-       color: var(--comfy-input-text);
-       padding: 5px 10px;
-       border: 1px solid var(--input-border-color);
-       border-radius: 4px;
-       cursor: pointer;
-       height: 100%;
-       display: flex;
-       align-items: center;
-       gap: 5px;
-       transition: background-color 0.2s;
-   }
-   .danbooru-category-button:hover { background-color: var(--comfy-menu-bg); }
-   .danbooru-category-button .arrow-down { transition: transform 0.2s ease-in-out; }
-   .danbooru-category-button.open .arrow-down { transform: rotate(180deg); }
+    try:
+        posts_list = json.loads(posts_json_str)
+    except json.JSONDecodeError:
+        posts_list = []
 
-   .danbooru-category-list {
-       visibility: hidden;
-       opacity: 0;
-       transform: translateY(-10px);
-       transition: visibility 0.2s, opacity 0.2s, transform 0.2s ease-out;
-       position: absolute;
-       background-color: var(--comfy-menu-bg);
-       border: 1px solid var(--input-border-color);
-       border-radius: 6px;
-       z-index: 1001;
-       min-width: 160px;
-       box-shadow: 0 5px 15px rgba(0,0,0,0.3);
-       padding: 6px;
-       backdrop-filter: blur(5px);
-   }
-   .danbooru-category-list.show {
-       visibility: visible;
-       opacity: 1;
-       transform: translateY(0);
-   }
+    return web.json_response(posts_list, headers={
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0"
+    })
 
-   .danbooru-category-item {
-       display: flex;
-       align-items: center;
-       padding: 6px 10px;
-       color: var(--comfy-input-text);
-       border-radius: 4px;
-       transition: background-color 0.2s;
-   }
-   .danbooru-category-item:hover { background-color: rgba(255, 255, 255, 0.1); }
-   .danbooru-rating-dropdown .danbooru-category-item { cursor: pointer; }
-   .danbooru-category-item label { margin-left: 10px; cursor: pointer; user-select: none; }
-   
-   .danbooru-category-checkbox {
-       appearance: none;
-       -webkit-appearance: none;
-       width: 16px;
-       height: 16px;
-       border-radius: 4px;
-       border: 2px solid #555;
-       cursor: pointer;
-       position: relative;
-       transition: background-color 0.2s, border-color 0.2s;
-   }
-   .danbooru-category-checkbox:checked {
-       background-color: #7B68EE;
-       border-color: #7B68EE;
-   }
-   .danbooru-category-checkbox:checked::before {
-       content: '✔';
-       font-size: 12px;
-       color: white;
-       position: absolute;
-       top: 50%;
-       left: 50%;
-       transform: translate(-50%, -50%);
-   }
+@PromptServer.instance.routes.get("/danbooru_gallery/autocomplete")
+async def get_autocomplete(request):
+    """三层查询机制：数据库 → API → 空结果"""
+    try:
+        query = request.query.get("query", "")
+        limit = int(request.query.get("limit", "20"))
+        source = request.query.get("source", "danbooru")
+        adapter = get_site_adapter(source)
 
-    .danbooru-gallery { width: 100%; display: flex; flex-direction: column; min-height: 200px; }
-    .danbooru-controls { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 5px; align-items: stretch; }
-    .danbooru-auth-controls { display: flex; gap: 5px; }
-    .danbooru-controls > button, .danbooru-controls > div { padding: 5px; border-radius: 4px; border: 1px solid var(--input-border-color); background-color: var(--comfy-input-bg); color: var(--comfy-input-text); }
-    .danbooru-controls > .danbooru-search-container > .danbooru-search-input { background: var(--comfy-input-bg); border: 1px solid var(--input-border-color); padding: 5px 10px; border-radius: 4px; }
-    .danbooru-controls .danbooru-search-input { flex-grow: 1; min-width: 150px; }
-    .danbooru-controls > select { min-width: 100px; }
-    .danbooru-source-select { height: 32px; padding: 5px 8px; border-radius: 4px; border: 1px solid var(--input-border-color); background-color: var(--comfy-input-bg); color: var(--comfy-input-text); }
-    .danbooru-gelbooru-display-all-toggle { height: 32px; align-items: center; gap: 6px; padding: 5px 8px; border-radius: 4px; border: 1px solid var(--input-border-color); background-color: var(--comfy-input-bg); color: var(--comfy-input-text); font-size: 12px; white-space: nowrap; cursor: pointer; }
-    .danbooru-gelbooru-display-all-toggle input { margin: 0; }
-    .danbooru-image-wrapper.new-item { animation: fadeInUp 0.5s ease-out; }
-    @keyframes fadeInUp { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
-    .danbooru-settings-button {
-        flex-grow: 0;
-        width: 40px;
-        height: 40px;
-        aspect-ratio: 1;
-        padding: 8px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        cursor: pointer;
-        transition: background-color 0.2s, transform 0.2s;
-        background-color: var(--comfy-input-bg);
-        color: var(--comfy-input-text);
-        border: 1px solid var(--input-border-color);
-        border-radius: 6px;
-    }
-    .danbooru-settings-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.1); }
-    .danbooru-settings-button .icon { width: 24px; height: 24px; }
-    .danbooru-refresh-button { flex-grow: 0; width: 40px; height: 40px; aspect-ratio: 1; padding: 8px; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: background-color 0.2s, transform 0.2s; border-radius: 6px; }
-    .danbooru-refresh-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.1); }
-    .danbooru-refresh-button.loading { cursor: not-allowed; }
-    .danbooru-filter-button { flex-grow: 0; width: 40px; height: 40px; aspect-ratio: 1; padding: 8px; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: background-color 0.2s, transform 0.2s, color 0.2s, border-color 0.2s; border-radius: 6px; }
-    .danbooru-filter-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.1); }
-    .danbooru-filter-button.active { background-color: #7B68EE; color: white; border-color: #7B68EE; }
-    .danbooru-refresh-button.loading .icon { animation: spin 1s linear infinite; }
-    @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-    .danbooru-ranking-button {
-        flex-grow: 0;
-        width: auto;
-        padding: 5px 8px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 5px;
-        cursor: pointer;
-        transition: background-color 0.2s, transform 0.2s;
-        font-size: 12px;
-        white-space: nowrap;
-    }
-    .danbooru-ranking-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.05); }
-    .danbooru-ranking-button.active {
-        background-color: #7B68EE;
-        color: white;
-        border-color: #7B68EE;
-    }
-    .danbooru-ranking-button .icon { width: 16px; height: 16px; }
+        if not query:
+            return web.json_response([])
+
+        # 加载配置
+        config = load_autocomplete_config()
+
+        # ✅ 第1层：查询本地SQLite数据库
+        if adapter.key == "danbooru" and get_db_manager and config['cache'].get('use_database_query', True):
+            try:
+                db = get_db_manager()
+                db_results = await db.search_tags_by_prefix(query, limit)
+
+                if db_results:
+                    # 数据库有结果，转换格式并返回
+                    formatted_results = [
+                        {
+                            'name': tag['tag'],
+                            'category': tag['category'],
+                            'post_count': tag['post_count'],
+                            'translation': tag.get('translation_cn'),
+                            'aliases': tag.get('aliases', [])
+                        }
+                        for tag in db_results
+                    ]
+                    logger.debug(f"[Autocomplete] 数据库查询成功: '{query}' -> {len(formatted_results)}条结果")
+                    return web.json_response(formatted_results)
+                else:
+                    logger.debug(f"[Autocomplete] 数据库无结果: '{query}'")
+            except Exception as e:
+                logger.warning(f"[Autocomplete] 数据库查询失败: {e}，尝试API fallback")
+
+        # ✅ 第2层：Fallback到Danbooru API
+        if config['offline_mode'].get('fallback_to_remote', True):
+            try:
+                timeout = config['offline_mode'].get('remote_timeout_ms', 2000) / 1000.0
+
+                tags_url = adapter.tags_url
+                params = adapter.build_autocomplete_params(query, limit)
+                credentials = get_site_credentials(adapter)
+                if not has_required_site_credentials(adapter, credentials):
+                    if adapter.key == "gelbooru":
+                        logger.info("[Gelbooru] 未配置 User ID/API Key，改用公开 autocomplete2")
+                        params = adapter.build_public_autocomplete_params(query, limit)
+                        response = _danbooru_request("GET", tags_url, params=params, timeout=timeout)
+                        response.raise_for_status()
+                        return web.json_response(adapter.normalize_public_autocomplete_response(response.json()))
+                    logger.warning(f"[{adapter.key}] 缺少必要认证信息，已跳过自动补全请求")
+                    return web.json_response([])
+                params = adapter.apply_auth_params(params, credentials)
+
+                username, api_key = load_user_auth()
+                auth = HTTPBasicAuth(username, api_key) if adapter.requires_auth and username and api_key else None
+
+                logger.debug(f"[Autocomplete] 调用远程API({adapter.key}): '{query}' (超时: {timeout}s)")
+                response = _danbooru_request("GET", tags_url, params=params, auth=auth, timeout=timeout)
+                response.raise_for_status()
+
+                result = adapter.normalize_autocomplete_response(response.json())
+
+                # 排序确保按热度排列
+                if isinstance(result, list):
+                    result.sort(key=lambda x: x.get('post_count', 0), reverse=True)
+                    logger.info(f"[Autocomplete] API查询成功({adapter.key}): '{query}' -> {len(result)}条结果")
+
+                return web.json_response(result)
+
+            except requests.Timeout:
+                logger.warning(f"[Autocomplete] 远程API超时 (>{timeout}s): '{query}'")
+            except requests.exceptions.RequestException as e:
+                logger.warning(f"[Autocomplete] 远程API失败: {e}")
+            except Exception as e:
+                logger.error(f"[Autocomplete] API调用错误: {e}")
+
+        # ✅ 第3层：返回空结果
+        logger.debug(f"[Autocomplete] 所有查询方式均无结果: '{query}'")
+        return web.json_response([])
+
+    except Exception as e:
+        logger.error(f"[Autocomplete] 处理请求时发生错误: {e}")
+        return web.json_response([])
+
+@PromptServer.instance.routes.get("/danbooru_gallery/blacklist")
+async def get_blacklist(request):
+    blacklist = load_blacklist()
+    return web.json_response({"blacklist": blacklist})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/blacklist")
+async def save_blacklist_route(request):
+    try:
+        data = await request.json()
+        blacklist_items = data.get("blacklist", [])
+        success = save_blacklist(blacklist_items)
+        return web.json_response({"success": success})
+    except Exception as e:
+        logger.error(f"保存黑名单接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.get("/danbooru_gallery/language")
+async def get_language(request):
+    language = load_language()
+    return web.json_response({"language": language})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/language")
+async def save_language_route(request):
+    try:
+        data = await request.json()
+        language = data.get("language", "zh")
+        success = save_language(language)
+        return web.json_response({"success": success})
+    except Exception as e:
+        logger.error(f"保存语言设置接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.get("/danbooru_gallery/filter_tags")
+async def get_filter_tags(request):
+    filter_tags, filter_enabled = load_filter_tags()
+    return web.json_response({"filter_tags": filter_tags, "filter_enabled": filter_enabled})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/filter_tags")
+async def save_filter_tags_route(request):
+    try:
+        data = await request.json()
+        filter_tags = data.get("filter_tags", [])
+        filter_enabled = data.get("filter_enabled", False)
+        success = save_filter_tags(filter_tags, filter_enabled)
+        return web.json_response({"success": success})
+    except Exception as e:
+        logger.error(f"保存提示词过滤设置接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.get("/danbooru_gallery/ui_settings")
+async def get_ui_settings(request):
+    try:
+        ui_settings = load_ui_settings()
+        return web.json_response({
+            "success": True,
+            "settings": ui_settings
+        })
+    except Exception as e:
+        logger.error(f"[UI_SETTINGS] 获取UI设置接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/ui_settings")
+async def save_ui_settings_route(request):
+    try:
+        data = await request.json()
+        ui_settings = {
+            "autocomplete_enabled": data.get("autocomplete_enabled", True),
+            "tooltip_enabled": data.get("tooltip_enabled", True),
+            "autocomplete_max_results": data.get("autocomplete_max_results", 20),
+            "selected_categories": data.get("selected_categories", ["copyright", "character", "general"]),
+            "multi_select_enabled": data.get("multi_select_enabled", False),
+            "source_site": data.get("source_site", "danbooru"),
+            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False)
+        }
+        success = save_ui_settings(ui_settings)
+        return web.json_response({"success": success})
+    except Exception as e:
+        logger.error(f"保存UI设置接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/selection_queue_push")
+async def selection_queue_push(request):
+    """前端在每次 Queue 前把当前选中的条目推入对应 nodeId 的 FIFO 桶"""
+    try:
+        data = await request.json()
+        item = data.get("item")
+        node_id = data.get("nodeId", "")
+        if item:
+            global _selection_queue_gen
+            with _selection_queues_lock:
+                _selection_queues[node_id].append(item)
+                _selection_queue_gen += 1
+            logger.debug(f"[SelectionQueue] push node={node_id} → 队列长度 {len(_selection_queues[node_id])}")
+        return web.json_response({"success": True})
+    except Exception as e:
+        logger.error(f"[SelectionQueue] push error: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/selection_queue_pop")
+async def selection_queue_pop(request):
+    """节点执行时从队列头部 pop 一个条目（不移除则 peek）"""
+    try:
+        data = await request.json() if request.can_read_body else {}
+        remove = data.get("remove", True)
+        with _selection_queue_lock:
+            if _selection_queue:
+                item = _selection_queue.popleft() if remove else _selection_queue[0]
+                logger.debug(f"[SelectionQueue] pop → 剩余 {len(_selection_queue)}")
+                return web.json_response({"success": True, "item": item})
+        return web.json_response({"success": True, "item": None})
+    except Exception as e:
+        logger.error(f"[SelectionQueue] pop error: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+# ================================
+# Tag翻译API接口
+# ================================
+
+@PromptServer.instance.routes.get("/danbooru_gallery/translate_tag")
+async def translate_tag_route(request):
+    """翻译单个tag"""
+    try:
+        tag = request.query.get("tag", "").strip()
+        if not tag:
+            return web.json_response({"success": False, "error": "缺少tag参数"})
+        
+        translation = translation_system.translate_tag(tag)
+        return web.json_response({
+            "success": True,
+            "tag": tag,
+            "translation": translation
+        })
+    except Exception as e:
+        logger.error(f"翻译tag接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/translate_tags_batch")
+async def translate_tags_batch_route(request):
+    """批量翻译tags"""
+    try:
+        data = await request.json()
+        tags = data.get("tags", [])
+        
+        if not isinstance(tags, list):
+            return web.json_response({"success": False, "error": "tags必须是数组"})
+        
+        translations = translation_system.translate_tags_batch(tags)
+        return web.json_response({
+            "success": True,
+            "translations": translations
+        })
+    except Exception as e:
+        logger.error(f"批量翻译tags接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.get("/danbooru_gallery/search_chinese")
+async def search_chinese_route(request):
+    """中文搜索匹配 - 优先使用FTS5数据库搜索"""
+    try:
+        query = request.query.get("query", "").strip()
+        limit = int(request.query.get("limit", "10"))
+        source = request.query.get("source", "danbooru")
+        adapter = get_site_adapter(source)
+
+        if not query:
+            return web.json_response({"success": True, "results": []})
+
+        # 加载配置
+        config = load_autocomplete_config()
+
+        # ✅ 优先使用FTS5数据库搜索（速度更快，10-50ms → 2-5ms）
+        if adapter.key == "danbooru" and get_db_manager and config['cache'].get('use_database_query', True):
+            try:
+                db = get_db_manager()
+                db_results = await db.search_tags_optimized(query, limit, search_type="chinese")
+
+                if db_results:
+                    # 转换为前端期望的格式
+                    formatted_results = [
+                        {
+                            'tag': tag['tag'],
+                            'translation_cn': tag.get('translation_cn'),
+                            'category': tag['category'],
+                            'post_count': tag['post_count'],
+                            'match_score': tag.get('match_score', 5)
+                        }
+                        for tag in db_results
+                    ]
+                    logger.debug(f"[SearchChinese] FTS5数据库查询: '{query}' -> {len(formatted_results)}条结果")
+                    return web.json_response({
+                        "success": True,
+                        "query": query,
+                        "results": formatted_results
+                    })
+            except Exception as e:
+                logger.warning(f"[SearchChinese] FTS5查询失败: {e}，回退到translation_system")
+
+        # ⚠️ Fallback: 使用旧的translation_system（线性搜索，较慢）
+        try:
+            results = translation_system.search_chinese_tags(query, limit)
+            logger.debug(f"[SearchChinese] translation_system查询: '{query}' -> {len(results)}条结果")
+            return web.json_response({
+                "success": True,
+                "query": query,
+                "results": results
+            })
+        except Exception as e:
+            logger.error(f"[SearchChinese] translation_system查询失败: {e}")
+            return web.json_response({
+                "success": False,
+                "error": str(e)
+            })
+
+    except Exception as e:
+        logger.error(f"中文搜索接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.get("/danbooru_gallery/autocomplete_with_translation")
+async def get_autocomplete_with_translation(request):
+    """带翻译的自动补全API - 三层查询机制：数据库 → API → 空结果"""
+    try:
+        query = request.query.get("query", "")
+        limit = int(request.query.get("limit", "20"))
+        source = request.query.get("source", "danbooru")
+        adapter = get_site_adapter(source)
+
+        if not query:
+            return web.json_response([])
+
+        # 加载配置
+        config = load_autocomplete_config()
+
+        # ✅ 第1层：查询本地SQLite数据库（已包含翻译）
+        if adapter.key == "danbooru" and get_db_manager and config['cache'].get('use_database_query', True):
+            try:
+                db = get_db_manager()
+                db_results = await db.search_tags_by_prefix(query, limit)
+
+                if db_results:
+                    # 数据库有结果，转换格式（已包含translation_cn）
+                    formatted_results = [
+                        {
+                            'name': tag['tag'],
+                            'category': tag['category'],
+                            'post_count': tag['post_count'],
+                            'translation': tag.get('translation_cn'),
+                            'aliases': tag.get('aliases', [])
+                        }
+                        for tag in db_results
+                    ]
+                    logger.debug(f"[AutocompleteTranslation] 数据库查询成功: '{query}' -> {len(formatted_results)}条结果")
+                    return web.json_response(formatted_results)
+                else:
+                    logger.debug(f"[AutocompleteTranslation] 数据库无结果: '{query}'")
+            except Exception as e:
+                logger.warning(f"[AutocompleteTranslation] 数据库查询失败: {e}，尝试API fallback")
+
+        # ✅ 第2层：Fallback到Danbooru API（需要手动添加翻译）
+        if config['offline_mode'].get('fallback_to_remote', True):
+            try:
+                timeout = config['offline_mode'].get('remote_timeout_ms', 2000) / 1000.0
+
+                tags_url = adapter.tags_url
+                params = adapter.build_autocomplete_params(query, limit)
+                credentials = get_site_credentials(adapter)
+                if not has_required_site_credentials(adapter, credentials):
+                    if adapter.key == "gelbooru":
+                        logger.info("[Gelbooru] 未配置 User ID/API Key，改用公开 autocomplete2")
+                        params = adapter.build_public_autocomplete_params(query, limit)
+                        response = _danbooru_request("GET", tags_url, params=params, timeout=timeout)
+                        response.raise_for_status()
+                        result = adapter.normalize_public_autocomplete_response(response.json())
+                        for tag_data in result:
+                            tag_name = tag_data.get('name', '')
+                            tag_data['translation'] = translation_system.translate_tag(tag_name)
+                        return web.json_response(result)
+                    logger.warning(f"[{adapter.key}] 缺少必要认证信息，已跳过带翻译自动补全请求")
+                    return web.json_response([])
+                params = adapter.apply_auth_params(params, credentials)
+
+                username, api_key = load_user_auth()
+                auth = HTTPBasicAuth(username, api_key) if adapter.requires_auth and username and api_key else None
+
+                logger.debug(f"[AutocompleteTranslation] 调用远程API({adapter.key}): '{query}' (超时: {timeout}s)")
+                response = _danbooru_request("GET", tags_url, params=params, auth=auth, timeout=timeout)
+                response.raise_for_status()
+
+                result = adapter.normalize_autocomplete_response(response.json())
+
+                # 为每个tag添加翻译
+                if isinstance(result, list):
+                    for tag_data in result:
+                        tag_name = tag_data.get('name', '')
+                        translation = translation_system.translate_tag(tag_name)
+                        tag_data['translation'] = translation
+
+                    logger.info(f"[AutocompleteTranslation] API查询成功: '{query}' -> {len(result)}条结果")
+
+                return web.json_response(result)
+
+            except requests.Timeout:
+                logger.warning(f"[AutocompleteTranslation] 远程API超时 (>{timeout}s): '{query}'")
+            except requests.exceptions.RequestException as e:
+                logger.warning(f"[AutocompleteTranslation] 远程API失败: {e}")
+            except Exception as e:
+                logger.error(f"[AutocompleteTranslation] API调用错误: {e}")
+
+        # ✅ 第3层：返回空结果
+        logger.debug(f"[AutocompleteTranslation] 所有查询方式均无结果: '{query}'")
+        return web.json_response([])
+
+    except Exception as e:
+        logger.error(f"[AutocompleteTranslation] 处理请求时发生错误: {e}")
+        return web.json_response([])
+
+class DanbooruGalleryNode:
+    _post_cache = {}
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {},
+            "optional": {
+                # 兼容前端 bypass 解析：
+                # 该节点原本只有 hidden 输入，某些前端 bypass 路径会在无可见输入时抛出
+                # "No input found for flattened id ... slot [0]"。
+                # 增加可选透传槽位后，bypass 时不会因缺少输入槽而直接报错。
+                "bypass_image": ("IMAGE", {"forceInput": True}),
+                "bypass_prompts": ("STRING", {"forceInput": True}),
+            },
+            "hidden": {
+                "selection_data": ("STRING", {"default": "{}", "multiline": True, "forceInput": True}),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE", "STRING")
+    RETURN_NAMES = ("images", "prompts")
+    OUTPUT_IS_LIST = (True, True)
+    FUNCTION = "get_selected_data"
+    CATEGORY = "danbooru"
+    OUTPUT_NODE = True
+
+    @classmethod
+    def IS_CHANGED(cls, selection_data="{}", **kwargs):
+        """返回队首条目的 _queue_id（唯一），队列空时返回 ""（缓存命中不再重复执行）。
+        彻底解决快速选图 1→Queue→2→Queue→... 导致的提示词覆盖竞态。
+        注意：此方法不感知 nodeId，但只要每个节点都有自己的 selection_data widget，
+        每次 Queue 序列化时都会 snapshot 各节点当前值，配合后端 FIFO 分桶即可逐节点隔离。"""
+        if not selection_data or selection_data == "{}":
+            return ""
+        try:
+            data = json.loads(selection_data)
+            node_id = data.get("nodeId", "")
+            with _selection_queues_lock:
+                q = _selection_queues.get(node_id)
+                if q and len(q) > 0:
+                    return str(q[0].get("_queue_id", ""))
+        except (json.JSONDecodeError, TypeError):
+            pass
+        if not selection_data or selection_data == "{}":
+            return ""
+        return selection_data
+
+    def get_selected_data(self, selection_data="{}", **kwargs):
+        """处理选中的图片数据，从 FIFO 队列（按 nodeId 分桶）中 pop，否则回退。"""
+        images = []
+        prompts = []
+        my_node_id = ""
+
+        try:
+            # 解析自己的 selection_data 获取 nodeId
+            if selection_data and selection_data != "{}":
+                data = json.loads(selection_data)
+                my_node_id = data.get("nodeId", "")
+
+            # 从 FIFO 按 nodeId 分桶 pop
+            item = None
+            if my_node_id:
+                with _selection_queues_lock:
+                    q = _selection_queues.get(my_node_id)
+                    if q and len(q) > 0:
+                        item = q.popleft()
+                        logger.debug(f"[SelectionQueue] get_selected_data pop node={my_node_id} → 剩余 {len(q)}")
+
+            if item:
+                selections = item.get("selections", [])
+            else:
+                # 回退：从自己的 widget 读取
+                if not selection_data or selection_data == "{}":
+                    return ([torch.zeros(1, 1, 1, 3)], [""])
+                data = json.loads(selection_data)
+                selections = data.get("selections", [])
+
+            if not selections:
+                return ([torch.zeros(1, 1, 1, 3)], [""])
+
+            for sel in selections:
+                prompt = sel.get("prompt", "")
+                image_url = sel.get("image_url")
+                prompts.append(prompt)
+                if image_url:
+                    try:
+                        img_data = _fetch_supported_media(image_url)
+                        img = Image.open(io.BytesIO(img_data)).convert("RGB")
+                        img_array = np.array(img).astype(np.float32) / 255.0
+                        tensor = torch.from_numpy(img_array)[None,]
+                        images.append(tensor)
+                    except Exception as e:
+                        logger.error(f"加载图片失败 {image_url}: {e}")
+                        images.append(torch.zeros(1, 1, 1, 3))
+                else:
+                    images.append(torch.zeros(1, 1, 1, 3))
+
+            if not images:
+                return ([torch.zeros(1, 1, 1, 3)], [""])
+
+        except Exception as e:
+            logger.error(f"Error processing selection in DanbooruGalleryNode: {e}")
+            return ([torch.zeros(1, 1, 1, 3)], [""])
+
+        return (images, prompts)
     
-    /* 收藏夹按钮样式 */
-    .danbooru-favorites-button {
-        flex-grow: 0;
-        width: auto;
-        padding: 5px 8px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 5px;
-        cursor: pointer;
-        transition: background-color 0.2s, transform 0.2s;
-        font-size: 12px;
-        white-space: nowrap;
-    }
-    .danbooru-favorites-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.05); }
-    .danbooru-favorites-button.active {
-        background-color: #DC3545; /* Bootstrap's danger color */
-        color: white;
-        border-color: #DC3545;
-    }
-    .danbooru-favorites-button .icon { width: 16px; height: 16px; }
-    .danbooru-image-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); grid-gap: 5px; grid-auto-rows: 1px; overflow-y: auto; background-color: var(--comfy-input-bg); padding: 5px; border-radius: 4px; flex-grow: 1; height: 0; }
-    .danbooru-image-wrapper {
-        grid-row-start: auto;
-        border: 2px solid transparent;
-        transition: border-color 0.2s, transform 0.2s ease-out, box-shadow 0.2s ease-out;
-        border-radius: 6px;
-        overflow: visible !important;
-        position: relative !important; /* Add relative positioning */
-        display: block !important;
-    }
-    .danbooru-image-wrapper:hover {
-        transform: scale(1.05);
-        box-shadow: 0 0 15px rgba(88, 101, 242, 0.7); /* 泛光效果 */
-        z-index: 10;
-        position: relative;
-    }
-    .danbooru-image-wrapper.selected {
-        border-color: #7B68EE; /* A more vibrant purple */
-        box-shadow: 0 0 20px rgba(123, 104, 238, 0.8); /* Stronger glow */
-        transform: scale(1.05);
-        z-index: 11;
-    }
+    @staticmethod
+    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False, before_id=None, gelbooru_dedup_mode: str = "off"):
+        settings = load_settings()
+        cache_enabled = settings.get("cache_enabled", True)
+        max_cache_age = settings.get("max_cache_age", 3600)
+        adapter = get_site_adapter(source)
+        if gelbooru_display_all_site_content is None:
+            gelbooru_display_all_site_content = settings.get("gelbooru_display_all_site_content", False)
 
-    .danbooru-image-wrapper.selected::after {
-        content: "✓";
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        color: white;
-        font-size: 50px;
-        font-weight: bold;
-        text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
-        z-index: 12;
-        pointer-events: none;
-    }
-    
-    .danbooru-image-wrapper.selected::before {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: rgba(123, 104, 238, 0.3); /* Semi-transparent overlay */
-        z-index: 11;
-        pointer-events: none;
-    }
-    
-    /* 按钮容器，位于右上角 */
-    .danbooru-image-buttons {
-        position: absolute;
-        top: 3px;
-        right: 3px;
-        display: flex;
-        gap: 2px;
-        opacity: 0;
-        transform: scale(0.9);
-        transition: all 0.2s ease !important;
-        z-index: 15;
-    }
-    
-    .danbooru-image-wrapper:hover .danbooru-image-buttons {
-        opacity: 1;
-        transform: scale(1);
-    }
+        if gelbooru_dedup_mode not in ("off", "on", "on_auth"):
+            gelbooru_dedup_mode = "off"
 
-    /* 通用按钮样式 */
-    .danbooru-image-buttons button {
-        background-color: rgba(0, 0, 0, 0.8) !important;
-        color: white !important;
-        border: none !important;
-        border-radius: 50% !important;
-        width: 20px !important;
-        height: 20px !important;
-        display: flex !important;
-        align-items: center !important;
-        justify-content: center !important;
-        cursor: pointer !important;
-        transition: all 0.2s ease !important;
-        backdrop-filter: blur(5px) !important;
-        -webkit-backdrop-filter: blur(5px) !important;
-        padding: 0 !important;
-        margin: 0 !important;
-    }
+        # before_id分页：化 + 数字校验，防止 page=b; DROP TABLE 类拼接注入
+        before_id = str(before_id).strip() if before_id else ""
+        if before_id and not before_id.isdigit():
+            before_id = ""
+        # order/ordfav/sort变结果顺序，游标会漏图，禁用
+        if before_id and re.search(r'(?:^|\s)(?:order|ordfav|sort):', tags or ''):
+            before_id = ""
+        #仅在 Danbooru（官方 page=b<id>）或 Gelbooru + dedup 开启时生效
+        if before_id and not (
+            adapter.key == "danbooru"
+            or (adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"))
+        ):
+            before_id = ""
 
-    .danbooru-image-buttons button:hover {
-        transform: scale(1.1) !important;
-        background-color: rgba(123, 104, 238, 0.9) !important; /* 统一使用紫色悬浮效果 */
-    }
+        credentials = get_site_credentials(adapter)
+        has_gelbooru_creds = has_required_site_credentials(adapter, credentials)
 
-    /* 收藏按钮特定样式 */
-    .danbooru-favorite-button.favorited {
-        background-color: rgba(220, 53, 69, 0.9) !important; /* DC3545 in rgba */
-        color: white !important;
-    }
+        # 创建缓存键（rating 归一化排序，避免 "e,q" 与 "q,e" 命中两条缓存）
+        rating_key = ','.join(sorted(r.strip().lower() for r in (rating or '').split(',') if r.strip()))
+        site_options_key = ""
+        if adapter.key == "gelbooru":
+            site_options_key = "display_all" if gelbooru_display_all_site_content else "default"
+            # dedup位影响 tag断数量，须区分，否则 on/off/on_auth 在 before_id 同为空时互相污染
+            site_options_key += f"_dedup_{gelbooru_dedup_mode}"
+        # before_id 入键避免不同游标页相互污染
+        cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}:{before_id}"
 
-    .danbooru-favorite-button.favorited:hover {
-        background-color: rgba(123, 104, 238, 0.9) !important; /* 统一使用紫色悬浮效果 */
-    }
+        # 判断是否获取收藏列表，如果是清除缓存以避免相同的请求前端列表不更新
+        match = re.search(r'\bordfav:([^\s]+)', tags)
 
-    /* 统一所有按钮的悬浮样式 */
-    .danbooru-download-button:hover,
-    .danbooru-edit-button:hover,
-    .danbooru-view-image-button:hover {
-        background-color: rgba(123, 104, 238, 0.9) !important; /* 统一使用紫色悬浮效果 */
-    }
+        # 如果启用了缓存，则检查缓存
+        if cache_enabled and not match:
+            if cache_key in DanbooruGalleryNode._post_cache:
+                cached_data, timestamp = DanbooruGalleryNode._post_cache[cache_key]
+                if time.time() - timestamp < max_cache_age:
+                    return (cached_data,)
 
-    /* 可点击的tag样式 */
-    .danbooru-clickable-tag {
-        cursor: pointer !important;
-        transition: transform 0.1s, filter 0.1s !important;
-    }
-    .danbooru-clickable-tag:hover {
-        transform: scale(1.05) !important;
-        filter: brightness(1.2) !important;
-    }
+        # 分离 date: 标签和其他标签
+        date_tag = ''
+        other_tags = []
+        for tag in tags.split(' '):
+            if tag.strip().startswith('date:'):
+                date_tag = tag.strip()
+            elif tag.strip():
+                other_tags.append(tag.strip())
 
-    /* 旧的、独立的按钮样式将被上面的新规则取代或覆盖，为了清晰起见，我将删除它们 */
-    /* 收藏按钮样式 - 位于右上角最右侧 (旧) */
-    .danbooru-gallery .danbooru-image-grid .danbooru-image-wrapper .danbooru-favorite-button-old {
-        position: absolute !important;
-        top: 3px !important;
-        right: 3px !important;
-        bottom: auto !important;
-        left: auto !important;
-        border: none !important;
-        /* Keep this empty or remove it. The styles are now in .danbooru-image-buttons button */
-    }
-    
-    /* All button styles are now handled by .danbooru-image-buttons and its children. */
-    /* The individual hover/visibility rules are replaced by the container's hover effect. */
-    
-    .danbooru-image-grid img {
-        width: 100%;
-        height: auto;
-        cursor: pointer;
-        display: block;
-    }
-    .danbooru-status { text-align: center; width: 100%; margin: 10px 0; color: #ccc; }
-    .danbooru-status.error { color: #f55; }
-    
-        /* New Tooltip Styles */
-        @keyframes danbooru-tooltip-fade-in {
-            from { opacity: 0; transform: scale(0.95); }
-            to { opacity: 1; transform: scale(1); }
-        }
-    
-        .danbooru-tag-tooltip {
-            background-color: rgba(28, 29, 31, 0.9);
-            border: 1px solid rgba(255, 255, 255, 0.1);
-            border-radius: 6px;
-            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.6);
-            padding: 8px;
-            max-width: 600px;
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            animation: danbooru-tooltip-fade-in 0.15s ease-out;
-            transition: opacity 0.15s, transform 0.15s;
-            pointer-events: none; /* Disable mouse interaction */
-        }
-
-        .danbooru-tooltip-tags {
-            display: flex;
-            flex-direction: column;
-            gap: 8px; /* Space between sections */
-        }
-
-        .danbooru-tooltip-section {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .danbooru-tooltip-upload-date {
-            color: #a0a3a8;
-            font-size: 0.8em;
-            margin-top: 2px;
-        }
-
-        .danbooru-tooltip-category-header {
-            font-size: 0.85em;
-            font-weight: 600;
-            color: #b0b3b8;
-            margin-bottom: 4px;
-        }
-
-        .danbooru-tooltip-tags-wrapper {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 4px;
-        }
-    
-        .danbooru-tooltip-tag {
-            font-size: 0.8em;
-            font-weight: 500;
-            color: white;
-            padding: 2px 6px;
-            border-radius: 4px;
-            cursor: default; /* Change cursor to default */
-            transition: none; /* Remove transitions */
-        }
-    
-        .danbooru-tooltip-tag:hover {
-            transform: none; /* Remove hover effect */
-            filter: none; /* Remove hover effect */
-        }
-    
-        .danbooru-tooltip-tag.copied {
-            animation: danbooru-tag-copied-animation 0.6s ease-out;
-        }
-    
-        @keyframes danbooru-tag-copied-animation {
-            0% { transform: scale(1); }
-            50% { transform: scale(1.1); background-color: #ffffff; color: #000000; }
-            100% { transform: scale(1); }
-        }
+        # 限制其他标签的数量。Gelbooru标模式下 id:<X 占用一个 tag 名额（公开页/2-tag 限制），
+        # on_auth + 已配密钥走 DAPI 时可放宽到更多 tag。
+        if adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"):
+            if gelbooru_dedup_mode == "on_auth" and has_gelbooru_creds:
+                max_tags = 10
+            else:
+                max_tags = 1
+        else:
+            max_tags = 2
+        if len(other_tags) > max_tags:
+            other_tags = other_tags[:max_tags]
         
-        /* Tag Colors */
-        /* Tag Colors based on new categories */
-        .danbooru-tooltip-tag.tag-category-artist { background-color: #FFF3CD; color: #664D03; } /* Artist: Light Yellow */
-        .danbooru-tooltip-tag.tag-category-copyright { background-color: #F8D7DA; color: #58151D; } /* Copyright: Light Pink */
-        .danbooru-tooltip-tag.tag-category-character { background-color: #D4EDDA; color: #155724; } /* Character: Light Green */
-        .danbooru-tooltip-tag.tag-category-general { background-color: #D1ECF1; color: #0C5460; } /* General: Light Blue */
-        .danbooru-tooltip-tag.tag-category-meta { background-color: #F8F9FA; color: #383D41; border: 1px solid #DFE2E5; } /* Meta: Light Grey */
+        # 重新组合标签
+        final_tags = ' '.join(other_tags)
+        if date_tag:
+            final_tags = f"{final_tags} {date_tag}".strip()
+
+        rating_query = ""
+        if adapter.key == "danbooru" and rating and rating.lower() != 'all':
+            allowed = {'general', 'sensitive', 'questionable', 'explicit', 'g', 's', 'q', 'e'}
+            rating_values = [r.strip().lower() for r in rating.split(',') if r.strip()]
+            rating_values = [r for r in rating_values if r in allowed]
+            if len(rating_values) == 1:
+                rating_query = f"rating:{rating_values[0]}"
+            elif len(rating_values) > 1:
+                rating_query = ' '.join(f"~rating:{r}" for r in rating_values)
+        elif adapter.key != "danbooru":
+            rating_query = rating
         
-        /* 黑名单对话框样式 */
-        .danbooru-blacklist-dialog * { box-sizing: border-box; }
-        .danbooru-blacklist-dialog textarea:focus { outline: 2px solid #7B68EE; }
-        .danbooru-blacklist-dialog button:hover { opacity: 0.9; }
-        
-        /* 语言切换按钮样式 */
-        .danbooru-language-button {
-            flex-grow: 0;
-            width: auto;
-            aspect-ratio: 1;
-            padding: 5px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            cursor: pointer;
-            transition: background-color 0.2s, transform 0.2s;
-        }
-        .danbooru-language-button:hover {
-            background-color: var(--comfy-menu-bg);
-            transform: scale(1.1);
-        }
-        .danbooru-language-button .icon {
-            width: 16px;
-            height: 16px;
-        }
-        .danbooru-language-select-button {
-            padding: 8px 16px;
-            border: 2px solid var(--input-border-color);
-            border-radius: 6px;
-            background-color: var(--comfy-input-bg);
-            color: var(--comfy-input-text);
-            cursor: pointer;
-            font-size: 14px;
-            font-weight: normal;
-            transition: all 0.2s ease;
-        }
-        .danbooru-language-select-button.active {
-            border-color: #7B68EE;
-            background-color: #7B68EE;
-            color: white;
-            font-weight: 600;
-        }
-        .danbooru-language-select-button:hover:not(.active) {
-            border-color: #9a8ee8;
-            background-color: rgba(123, 104, 238, 0.1);
-        }
-        /* 设置对话框样式 */
-        .danbooru-settings-dialog * {
-            box-sizing: border-box;
-        }
-        
-        .danbooru-settings-dialog {
-            /* backdrop-filter: blur(3px); */
-            /* -webkit-backdrop-filter: blur(3px); */
-        }
-        
-        .danbooru-settings-dialog-content {
-            animation: fadeInScale 0.3s ease-out;
-        }
-        
-        @keyframes fadeInScale {
-            from {
-                opacity: 0;
-                transform: scale(0.9);
-            }
-            to {
-                opacity: 1;
-                transform: scale(1);
-            }
-        }
-        
-        .danbooru-settings-dialog-content h2 {
-            padding: 0 10px 12px 10px !important;
-        }
+        tags = final_tags
+        # Gelbooru：拼进 tags（公开页 / DAPI用 tags 参数，见 build_public_posts_params / build_posts_params）
+        if before_id and adapter.key == "gelbooru":
+            tags = f"{tags} id:<{before_id}".strip()
 
-        .danbooru-settings-section {
-            transition: all 0.2s ease;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-            margin-bottom: 24px !important;
-        }
-        
-        .danbooru-settings-section:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-        }
-        
-        .danbooru-settings-dialog button:hover {
-            opacity: 0.9;
-            transform: translateY(-1px);
-        }
-        
-        .danbooru-settings-dialog button:focus {
-            outline: 2px solid #7B68EE;
-            outline-offset: 2px;
-        }
-        
-        .danbooru-settings-dialog textarea:focus {
-            outline: 2px solid #7B68EE;
-            outline-offset: 1px;
-        }
-        
-        .danbooru-settings-sidebar {
-            display: flex;
-            flex-direction: column;
-            gap: 5px;
-            padding-right: 15px;
-            border-right: 1px solid var(--input-border-color);
-            flex-shrink: 0;
-            width: 180px;
-            box-sizing: border-box;
-            overflow: visible;
-        }
+        username, api_key = load_user_auth()
+        auth = HTTPBasicAuth(username, api_key) if adapter.requires_auth and username and api_key else None
+        credentials = get_site_credentials(adapter)
+        if adapter.key == "gelbooru" and force_public_detail:
+            posts = _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, gelbooru_display_all_site_content)
+            result_text = json.dumps(posts, ensure_ascii=False)
+            return (result_text,)
 
-        .sidebar-button {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            padding: 12px 15px;
-            border-radius: 8px;
-            cursor: pointer;
-            background-color: transparent;
-            color: var(--comfy-input-text);
-            text-align: left;
-            font-size: 14px;
-            font-weight: 500;
-            transition: background-color 0.2s, color 0.2s;
-            width: 100%;
-            border: none;
-            box-sizing: border-box;
-            justify-content: flex-start;
-        }
+        if not has_required_site_credentials(adapter, credentials):
+            if adapter.key == "gelbooru":
+                logger.info("[Gelbooru] 未配置 User ID/API Key，改用公开网页解析模式")
+                posts = _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, gelbooru_display_all_site_content)
+                result_text = json.dumps(posts, ensure_ascii=False)
 
-        .sidebar-button.active {
-            background-color: rgba(123, 104, 238, 0.2) !important;
-            color: #E0E0E0 !important;
-            font-weight: 600 !important;
-            border: none !important;
-            outline: none !important;
-        }
+                if cache_enabled and not (adapter.key == "gelbooru" and gelbooru_display_all_site_content and not posts):
+                    # 跳过 error 占位格缓存（否则一次限流会让接下来 TTL 内都看不到新图）
+                    has_error_placeholder = posts and any(isinstance(p, dict) and p.get("error") for p in posts)
+                    if not has_error_placeholder:
+                        DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
 
-        .sidebar-button:hover {
-            background-color: rgba(255, 255, 255, 0.1);
-        }
+                return (result_text,)
+            logger.warning(f"[{adapter.key}] 缺少必要认证信息，已跳过帖子请求")
+            return ("[]",)
+            
+        params = adapter.build_posts_params(tags, limit, page, rating_query)
+        params = adapter.apply_auth_params(params, credentials)
+        # Danbooru：走官方 page=b<id>
+        if before_id and adapter.key == "danbooru":
+            params["page"] = f"b{before_id}"
 
-        .sidebar-button-icon {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
+        try:
+            response = _danbooru_request("GET", adapter.posts_url, params=params, auth=auth, timeout=15)
+            if response.status_code == 401 and adapter.key == "gelbooru":
+                logger.warning("[Gelbooru] DAPI 返回 401，改用公开网页解析模式")
+                posts = _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, gelbooru_display_all_site_content)
+            else:
+                response.raise_for_status()
+                posts = adapter.normalize_posts_response(response.json())
 
-        .sidebar-button svg {
-            stroke-width: 2;
-        }
+            result_text = json.dumps(posts, ensure_ascii=False)
+            
+            # 如果启用了缓存，则存储结果（跳过 error 占位格）
+            if cache_enabled and not (adapter.key == "gelbooru" and gelbooru_display_all_site_content and not posts):
+                has_error_placeholder = posts and any(isinstance(p, dict) and p.get("error") for p in posts)
+                if not has_error_placeholder:
+                    DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
+                # 清理旧缓存（可选，防止内存无限增长）
+                if len(DanbooruGalleryNode._post_cache) > 200: # 假设最多缓存200个请求
+                    oldest_key = min(DanbooruGalleryNode._post_cache.keys(), key=lambda k: DanbooruGalleryNode._post_cache[k][1])
+                    del DanbooruGalleryNode._post_cache[oldest_key]
+            
+            return (result_text,)
+        except requests.exceptions.RequestException as e:
+            logger.error(f"网络请求时发生错误: {e}")
+            return ("[]",)
+        except Exception as e:
+            logger.error(f"发生未知错误: {e}")
+            return ("[]",)
 
-        .sidebar-button:focus {
-            outline: none;
-        }
-
-        /* 设置对话框滚动容器样式 */
-        .danbooru-settings-scroll-container {
-            scrollbar-width: thin;
-            scrollbar-color: rgba(123, 104, 238, 0.6) transparent;
-        }
-        
-        .danbooru-settings-scroll-container::-webkit-scrollbar {
-            width: 8px;
-        }
-        
-        .danbooru-settings-scroll-container::-webkit-scrollbar-track {
-            background: transparent;
-            border-radius: 4px;
-        }
-        
-        .danbooru-settings-scroll-container::-webkit-scrollbar-thumb {
-            background: rgba(123, 104, 238, 0.6);
-            border-radius: 4px;
-            transition: background 0.2s ease;
-        }
-        
-        .danbooru-settings-scroll-container::-webkit-scrollbar-thumb:hover {
-            background: rgba(123, 104, 238, 0.8);
-        }
-        
-        /* 社交链接按钮样式 */
-        .danbooru-settings-dialog button[title*="GitHub"]:hover {
-            background-color: #1c2128 !important;
-            border-color: #1c2128 !important;
-            transform: translateY(-1px);
-        }
-
-        .danbooru-settings-dialog button[title*="Discord"]:hover {
-            background-color: #4752c4 !important;
-            border-color: #4752c4 !important;
-            transform: translateY(-1px);
-        }
-
-        .danbooru-settings-dialog button[title*="GitHub"]:hover svg,
-        .danbooru-settings-dialog button[title*="Discord"]:hover svg {
-            transform: scale(1.1);
-        }
-
-        /* 移除社交链接按钮的focus效果 */
-        .danbooru-settings-dialog button[title*="GitHub"]:focus,
-        .danbooru-settings-dialog button[title*="Discord"]:focus {
-            outline: none !important;
-        }
-
-        .danbooru-settings-dialog button svg {
-            flex-shrink: 0;
-            transition: transform 0.2s ease;
-        }
-
-        /* Toast提示样式 */
-        #danbooru-gallery-toast-container {
-            position: fixed;
-            top: 20px;
-            right: 20px;
-            z-index: 999999;
-            display: flex;
-            flex-direction: column;
-            gap: 8px;
-            align-items: flex-end;
-        }
-        .danbooru-toast {
-            padding: 12px 20px;
-            border-radius: 6px;
-            color: white;
-            font-size: 14px;
-            font-weight: 500;
-            max-width: 300px;
-            word-wrap: break-word;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-            opacity: 0;
-            transform: translateX(100%);
-            transition: opacity 0.3s ease-out, transform 0.3s ease-out;
-        }
-        .danbooru-toast.show {
-            opacity: 1;
-            transform: translateX(0);
-        }
-
-        .danbooru-toast-success {
-            background-color: #28a745;
-            border-left: 4px solid #1e7e34;
-        }
-
-        .danbooru-toast-error {
-            background-color: #dc3545;
-            border-left: 4px solid #bd2130;
-        }
-
-        .danbooru-toast-info {
-            background-color: #17a2b8;
-            border-left: 4px solid #117a8b;
-        }
-
-        @keyframes toastSlideIn {
-            from {
-                transform: translateX(100%);
-                opacity: 0;
-            }
-            to {
-                transform: translateX(0);
-                opacity: 1;
-            }
-        }
-
-        .danbooru-toast.fade-out {
-            animation: toastFadeOut 0.3s ease-out forwards;
-        }
-
-        @keyframes toastFadeOut {
-            from {
-                transform: translateX(0);
-                opacity: 1;
-            }
-            to {
-                transform: translateX(100%);
-                opacity: 0;
-            }
-        }
-        `,
-    parent: document.head,
-});
-
-$el("style", {
-    textContent: `
-    /* 编辑面板样式 */
-    .danbooru-edit-panel-content {
-        position: relative;
-    }
-    .danbooru-edit-panel-close-button {
-        background: transparent;
-        border: none;
-        color: var(--comfy-input-text);
-        cursor: pointer;
-        padding: 5px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: background-color 0.2s, transform 0.2s;
-    }
-    .danbooru-edit-panel-close-button:hover {
-        background-color: rgba(255, 255, 255, 0.15);
-        transform: rotate(90deg);
-    }
-    /* Styles for the new copy and reset buttons */
-    .danbooru-edit-panel-content button {
-        transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
-    }
-    .danbooru-edit-panel-content button:hover {
-        background-color: rgba(123, 104, 238, 0.2); /* 统一紫色悬浮效果，增强视觉强度 */
-        border-color: #7B68EE;
-        color: white; /* 悬浮时文字改为白色，提高对比度 */
-        transform: translateY(-2px);
-    }
-    .danbooru-edit-panel-content button:active {
-        background-color: rgba(123, 104, 238, 0.3); /* 点击时进一步加深 */
-        transform: translateY(0);
-    }
-    .danbooru-edit-tags-container {
-        scrollbar-width: thin;
-        scrollbar-color: #555 #333;
-    }
-    .danbooru-edit-tags-container::-webkit-scrollbar {
-        width: 6px;
-    }
-    .danbooru-edit-tags-container::-webkit-scrollbar-track {
-        background: #333;
-        border-radius: 3px;
-    }
-    .danbooru-edit-tags-container::-webkit-scrollbar-thumb {
-        background: #555;
-        border-radius: 3px;
-    }
-    .danbooru-edit-tags-container::-webkit-scrollbar-thumb:hover {
-        background: #777;
-    }
-    .danbooru-view-image-button:hover {
-        background-color: rgba(23, 162, 184, 0.9) !important;
-    }
-    `,
-    parent: document.head
-});
-
-$el("style", {
-    textContent: `
-    .danbooru-tag-context-menu {
-        /* Styles are set in JS, but we can add basics here */
-    }
-    .danbooru-context-menu-item {
-        padding: 8px 12px;
-        cursor: pointer;
-        font-size: 14px;
-        border-radius: 4px;
-        transition: background-color 0.2s;
-    }
-    .danbooru-context-menu-item:hover {
-        background-color: rgba(123, 104, 238, 0.3);
-    }
-    .danbooru-add-tag-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 22px;
-        height: 22px;
-        border-radius: 50%;
-        border: 1px dashed #888;
-        color: #888;
-        background-color: transparent;
-        cursor: pointer;
-        font-size: 16px;
-        margin-left: 5px;
-        transition: all 0.2s;
-    }
-    .danbooru-add-tag-button:hover {
-        background-color: rgba(123, 104, 238, 0.3);
-        color: white;
-        border-style: solid;
-        border-color: #7B68EE;
-    }
-    .danbooru-add-tag-input {
-        background-color: var(--comfy-input-bg);
-        border: 1px solid #7B68EE;
-        color: var(--comfy-input-text);
-        border-radius: 4px;
-        padding: 2px 6px;
-        font-size: 0.8em;
-        margin-left: 5px;
-        outline: none;
-    }
-    .danbooru-reset-tags-button {
-        padding: 8px 15px;
-        border: 1px solid #7B68EE;
-        border-radius: 6px;
-        background-color: transparent;
-        color: #7B68EE;
-        cursor: pointer;
-        font-size: 14px;
-        font-weight: 500;
-        transition: all 0.2s ease;
-        display: flex;
-        align-items: center;
-        gap: 8px;
-    }
-    .danbooru-reset-tags-button:hover {
-        background-color: rgba(123, 104, 238, 0.2);
-        border-color: #7B68EE;
-        color: white;
-        transform: translateY(-2px);
-    }
-    .danbooru-add-tag-container {
-        position: relative;
-        display: inline-block;
-    }
-    .danbooru-add-tag-input {
-        background-color: var(--comfy-input-bg);
-        border: 1px solid #7B68EE;
-        color: var(--comfy-input-text);
-        border-radius: 4px;
-        padding: 2px 6px;
-        font-size: 0.8em;
-        outline: none;
-        width: 120px;
-    }
-    /* These panels are now attached to body, so they need absolute positioning relative to viewport */
-    .danbooru-add-tag-container .danbooru-suggestions-panel,
-    .danbooru-add-tag-container .danbooru-chinese-suggestions-panel,
-    .danbooru-suggestions-panel, /* Add rule for when it's a direct child of body */
-    .danbooru-chinese-suggestions-panel {
-        position: absolute; /* Changed from relative to absolute */
-        z-index: 10003; /* Ensure it's on top of the edit panel */
-        width: auto;
-        min-width: 150px; /* Set a minimum width */
-        max-width: 450px; /* Allow it to be wider */
-        max-height: 300px;
-        overflow-y: auto;
-    }
-    `,
-    parent: document.head
-});
-
-$el("style", {
-    textContent: `
-    .danbooru-settings-section {
-        padding: 16px;
-        border: 1px solid var(--input-border-color);
-        border-radius: 8px;
-        background-color: var(--comfy-input-bg);
-    }
-    .danbooru-settings-dialog input[type="datetime-local"],
-    .danbooru-settings-dialog input[type="number"] {
-        background-color: var(--comfy-menu-bg);
-        color: var(--comfy-input-text);
-        border: 1px solid var(--input-border-color);
-        border-radius: 4px;
-        padding: 8px;
-        user-select: none;
-    }
-    .danbooru-primary-button {
-        padding: 10px 20px;
-        border: 2px solid #7B68EE;
-        border-radius: 6px;
-        background-color: #7B68EE;
-        color: white;
-        cursor: pointer;
-        font-size: 14px;
-        font-weight: 600;
-        transition: all 0.2s ease;
-    }
-    .danbooru-radio-group {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        gap: 20px;
-        margin: 10px 0;
-    }
-    .danbooru-radio-button-wrapper {
-        flex: 0 0 auto;
-        min-width: 140px;
-    }
-    .danbooru-radio-label {
-        padding: 12px 20px;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        background-color: var(--comfy-input-bg);
-        color: var(--comfy-input-text);
-        border: 2px solid var(--input-border-color);
-        border-radius: 8px;
-        text-align: center;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        font-weight: 500;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        transform: translateY(0);
-        position: relative;
-        overflow: hidden;
-    }
-    .danbooru-radio-label:hover {
-        background-color: rgba(123, 104, 238, 0.1);
-        border-color: #7B68EE;
-        color: #7B68EE;
-        transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(123, 104, 238, 0.3);
-    }
-    .danbooru-settings-dialog .danbooru-radio-label.checked {
-        background-color: transparent;
-        color: white;
-        border-color: #7B68EE;
-        box-shadow: 0 4px 12px rgba(123, 104, 238, 0.4);
-        transform: translateY(-1px);
-        font-weight: 600;
-    }
-    .danbooru-settings-dialog .danbooru-radio-label.checked::before {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: #7B68EE;
-        z-index: 0;
-        transition: transform 0.4s ease;
-        transform: scaleX(1);
-        transform-origin: left;
-    }
-    .danbooru-radio-label::before {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: #7B68EE;
-        z-index: 0;
-        transition: transform 0.4s ease;
-        transform: scaleX(0);
-        transform-origin: right;
-    }
-    .danbooru-radio-label:hover::before {
-        transform: scaleX(1);
-        transform-origin: left;
-    }
-    .danbooru-settings-dialog .danbooru-radio-label.checked:hover::before {
-        transform: scaleX(1);
-    }
-    .danbooru-settings-dialog .danbooru-radio-label.checked:hover {
-        background-color: transparent;
-        color: white;
-        border-color: #9a8ee8;
-        transform: translateY(-3px);
-        box-shadow: 0 6px 16px rgba(123, 104, 238, 0.5);
-    }
-    .danbooru-settings-dialog .danbooru-radio-label.checked:hover::before {
-        background-color: #9a8ee8;
-    }
-    .danbooru-radio-indicator {
-        display: inline-block;
-        width: 14px;
-        height: 14px;
-        border-radius: 50%;
-        border: 2px solid #888;
-        margin-right: 10px;
-        transition: all 0.2s;
-        flex-shrink: 0;
-        z-index: 1;
-        position: relative;
-    }
-    .danbooru-radio-label:hover .danbooru-radio-indicator {
-        border-color: #7B68EE;
-    }
-    .danbooru-settings-dialog .danbooru-radio-label.checked .danbooru-radio-indicator {
-        background-color: #7B68EE;
-        border-color: #7B68EE;
-        position: relative;
-    }
-    .danbooru-settings-dialog .danbooru-radio-label.checked .danbooru-radio-indicator::before {
-        content: "";
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        width: 8px;
-        height: 8px;
-        background-color: white;
-        border-radius: 50%;
-        transform: translate(-50%, -50%);
-        z-index: 1;
-    }
-   .danbooru-input-row {
-       display: flex;
-       justify-content: space-between;
-       align-items: center;
-       width: 100%;
-       padding: 8px;
-       border-radius: 6px;
-       transition: background-color 0.2s ease;
-       cursor: pointer;
-       user-select: none;
-   }
-   .danbooru-input-row:hover {
-       background-color: rgba(255, 255, 255, 0.1);
-   }
-   .danbooru-input-row input {
-       cursor: pointer;
-   }
-    .danbooru-dialog-button--secondary {
-       padding: 8px 16px;
-       border: 1px solid var(--input-border-color);
-       border-radius: 6px;
-       background-color: var(--comfy-input-bg);
-       color: var(--comfy-input-text);
-       cursor: pointer;
-       transition: all 0.2s ease;
-   }
-   .danbooru-dialog-button--secondary:hover {
-       background-color: var(--comfy-menu-bg);
-       border-color: #999;
-       transform: translateY(-2px);
-       box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-   }
-
-   .danbooru-dialog-button--primary {
-       padding: 8px 16px;
-       border: 1px solid #7B68EE;
-       border-radius: 6px;
-       background-color: #7B68EE;
-       color: white;
-       cursor: pointer;
-       font-weight: 600;
-       transition: all 0.2s ease;
-   }
-   .danbooru-dialog-button--primary:hover {
-       background-color: #9a8ee8;
-       border-color: #9a8ee8;
-       transform: translateY(-2px);
-       box-shadow: 0 4px 8px rgba(123, 104, 238, 0.3);
-   }
-    `,
-    parent: document.head,
-});
-
-
-$el("style", {
-    textContent: `
-    /* "已编辑" 提示样式 */
-    .danbooru-edited-indicator {
-        position: absolute;
-        top: 5px;
-        left: 5px;
-        background-color: rgba(123, 104, 238, 0.9); /* 紫色背景 */
-        color: white;
-        padding: 3px 8px;
-        font-size: 10px;
-        font-weight: bold;
-        border-radius: 8px;
-        z-index: 15;
-        pointer-events: none;
-        box-shadow: 0 1px 3px rgba(0,0,0,0.3);
-        animation: fadeInDown 0.3s ease-out;
-        border: 1px solid rgba(255, 255, 255, 0.2);
+# ComfyUI 必须的字典
+def get_node_class_mappings():
+    return {
+        "DanbooruGalleryNode": DanbooruGalleryNode
     }
 
-    @keyframes fadeInDown {
-        from {
-            opacity: 0;
-            transform: translateY(-10px);
-        }
-        to {
-            opacity: 1;
-            transform: translateY(0);
-        }
+def get_node_display_name_mappings():
+    return {
+        "DanbooruGalleryNode": "D站画廊 (Danbooru Gallery)"
     }
-    `,
-    parent: document.head
-});
 
+NODE_CLASS_MAPPINGS = get_node_class_mappings()
+NODE_DISPLAY_NAME_MAPPINGS = get_node_display_name_mappings()
 

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -5,7 +5,7 @@ import { AutocompleteUI } from "../global/autocomplete_ui.js";
 import { toastManagerProxy } from "../global/toast_manager.js";
 import { globalMultiLanguageManager } from "../global/multi_language.js";
 
-import { createLogger } from '../global/logger_client.js';
+import { createLogger, loggerClient } from '../global/logger_client.js';
 
 // 创建logger实例
 const logger = createLogger('danbooru_gallery');
@@ -64,7 +64,7 @@ app.registerExtension({
                 // 存储每张图片的原始标签数据，用于重置和编辑状态判断
                 const originalPostCache = {};
 
-                // 创建隐藏的 selection_data widget
+                // 创建隐藏的 selection_data widget（仍保留用于兼容/回退）
                 const selectionWidget = this.addWidget("text", "selection_data", JSON.stringify({}), () => { }, {
                     serialize: true // 确保序列化
                 });
@@ -152,11 +152,9 @@ app.registerExtension({
                     tagHintDisplay.style.display = "none";
                 };
 
-                // 检查网络连接状态
+                // 检查网络连接状态（30s TTL：上次成功且 30s 内则跳过完整网络往返）
+                const NETWORK_CHECK_TTL = 30000;
                 const checkNetworkStatus = async () => {
-                    // 节流：上次检查成功且在 30 秒内，直接复用，避免每次滚动加载都做一次完整网络往返
-                    // （G 站的检查是抓公开 HTML 页、8 秒超时，频繁触发会卡顿并误报"网络连接失败"）。
-                    const NETWORK_CHECK_TTL = 30000;
                     if (networkStatus.connected && networkStatus.lastChecked &&
                         (Date.now() - networkStatus.lastChecked) < NETWORK_CHECK_TTL) {
                         return true;
@@ -194,8 +192,10 @@ app.registerExtension({
                 let globalTooltip, globalTooltipTimeout;
                 let currentTooltipId = 0; // 用于追踪当前活动的tooltip请求
                 let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
-                let lastPostId = null;            // D 站游标分页：上一批最后一张的 id
-                const seenPostIds = new Set();    // 渲染前 id 去重兜底
+                let lastPostId = null;
+                let scrollAnchorPostId = null;
+                const seenPostIds = new Set();
+                let selectionQueueId = 0; // FIFO 队列唯一 ID 计数器
                 let filterState = { startTime: null, endTime: null, startPage: null };
                 let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
                 let userFavorites = []; // 用户收藏列表，确保字符串
@@ -727,7 +727,7 @@ app.registerExtension({
                         uiSettings.selected_categories = newSelectedCategories;
                         saveToLocalStorage('selectedCategories', newSelectedCategories);
                         await saveUiSettings(uiSettings);
-                        await updateSelectionData();
+                        updateSelectionData();
                     });
                     return $el("div.danbooru-category-item", [
                         checkbox,
@@ -760,7 +760,7 @@ app.registerExtension({
                         uiSettings.formatting = newFormattingOptions;
                         saveToLocalStorage('formatting', newFormattingOptions);
                         await saveUiSettings(uiSettings);
-                        await updateSelectionData();
+                        updateSelectionData();
                     });
                     return $el("div.danbooru-category-item", [
                         checkbox,
@@ -1436,43 +1436,45 @@ app.registerExtension({
                     selectionModeSection.appendChild(selectionModeDesc);
                     selectionModeSection.appendChild(multiSelectDiv);
 
-                    // 预加载设置（每次加载的图片数量，越大一次拉取越多但首屏越慢）
+                    // 预加载设置
                     const preloadSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
-                    const preloadTitle = $el("h3", { textContent: "预加载设置", style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
-                    const preloadDesc = $el("p", { textContent: "每次加载的图片数量。数值越大一次拉取越多，但首屏等待时间也越长（建议 40-100）", style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
-                    const preloadCountLabel = $el("label", { htmlFor: "preloadCountInput", textContent: "每次加载数量", style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
+                    const preloadTitle = $el("h3", { textContent: "预加载 / 去重", style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
+                    preloadSection.appendChild(preloadTitle);
+
+                    // 每次增加张数
+                    const preloadCountLabel = $el("label", { htmlFor: "preloadCountInput", textContent: "每次增加缓冲张数：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
                     const preloadCountInput = $el("input", {
-                        type: "number",
-                        id: "preloadCountInput",
-                        title: "设置每次加载数量（20-200）",
-                        value: (initialState.preloadCount ?? uiSettings.preload_count) || 40,
-                        min: "20",
-                        max: "200",
+                        type: "number", id: "preloadCountInput", min: "20", max: "200",
+                        value: (initialState.preloadCount !== undefined ? initialState.preloadCount : uiSettings.preload_count) || 40,
                         style: { width: "60px", padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
                     });
-                    const preloadCountDiv = $el("div", { style: { display: "flex", alignItems: "center" } }, [preloadCountLabel, preloadCountInput]);
-                    preloadSection.appendChild(preloadTitle);
-                    preloadSection.appendChild(preloadDesc);
-                    preloadSection.appendChild(preloadCountDiv);
+                    const preloadCountDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [preloadCountLabel, preloadCountInput]);
 
-                    // G 站防重复设置（按 id 游标分页，解决翻页时新上传挤入导致的重复图）
-                    // 三段式：off / on（未配密钥时仅1个tag留名额给游标）/ on_auth（已配密钥，多tag可用）
-                    const gelbooruDedupLabel = $el("label", { htmlFor: "gelbooruDedupSelect", textContent: "G 站防重复", style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
+                    // G站防重复模式
+                    const gelbooruDedupLabel = $el("label", { htmlFor: "gelbooruDedupSelect", textContent: "G站防重复：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
                     const gelbooruDedupSelect = $el("select", {
                         id: "gelbooruDedupSelect",
-                        title: "G 站游标防重复档位（按id推进分页，避免新上传图导致翻页重复）",
                         style: { padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
                     }, [
                         $el("option", { value: "off", textContent: "关闭（可使用2个tag）" }),
                         $el("option", { value: "on", textContent: "开启（限1个tag）" }),
                         $el("option", { value: "on_auth", textContent: "开启·已配密钥（多tag可用）" }),
                     ]);
-                    const dedupInitial = (initialState.gelbooruDedupMode ?? uiSettings.gelbooru_dedup_mode) || "off";
-                    if (["off", "on", "on_auth"].includes(dedupInitial)) gelbooruDedupSelect.value = dedupInitial;
-                    const gelbooruDedupDiv = $el("div", { style: { display: "flex", alignItems: "center", marginTop: "12px" } }, [gelbooruDedupLabel, gelbooruDedupSelect]);
-                    const gelbooruDedupDesc = $el("p", { textContent: "关闭时 G 站保持原样；开启时按 id 游标推进翻页。未配密钥的开启档会限 1 个 tag 留给游标；已配密钥多 tag 可用", style: { margin: "8px 0 0 0", color: "#888", fontSize: "0.85em" } });
+                    gelbooruDedupSelect.value = initialState.gelbooruDedupMode !== undefined ? initialState.gelbooruDedupMode : (uiSettings.gelbooru_dedup_mode || "off");
+                    const gelbooruDedupDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [gelbooruDedupLabel, gelbooruDedupSelect]);
+
+                    // 全局日志
+                    const globalLogLabel = $el("label", { htmlFor: "globalLogCheck", textContent: "启用全局日志：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
+                    const globalLogCheck = $el("input", {
+                        type: "checkbox", id: "globalLogCheck",
+                        checked: initialState.globalLogging !== undefined ? initialState.globalLogging : (uiSettings.global_logging || false),
+                        style: { width: "16px", height: "16px" }
+                    });
+                    const globalLogDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "8px" } }, [globalLogCheck, globalLogLabel]);
+
+                    preloadSection.appendChild(preloadCountDiv);
                     preloadSection.appendChild(gelbooruDedupDiv);
-                    preloadSection.appendChild(gelbooruDedupDesc);
+                    preloadSection.appendChild(globalLogDiv);
 
                     // 创建侧边栏按钮和内容区域的映射
                     const sections = {
@@ -1481,7 +1483,6 @@ app.registerExtension({
                         'content': { title: t('contentSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18l-1.5 14H4.5L3 6z"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>', elements: [blacklistSection] },
                         'prompt': { title: t('promptSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>', elements: [filterSection] },
                         'ui': { title: t('uiSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>', elements: [autocompleteSection, tooltipSection, selectionModeSection] },
-                        'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
                         'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
                     };
 
@@ -1693,10 +1694,6 @@ app.registerExtension({
                             const newAutocompleteMaxResults = parseInt(autocompleteMaxResultsInput.value, 10);
                             const newSelectedCategories = Array.from(categoryDropdown.querySelectorAll("input:checked")).map(i => i.name);
                             const newMultiSelectEnabled = multiSelectCheckbox.checked;
-                            let newPreloadCount = parseInt(preloadCountInput.value, 10);
-                            if (isNaN(newPreloadCount)) newPreloadCount = 40;
-                            newPreloadCount = Math.min(Math.max(newPreloadCount, 20), 200); // 夹到 20-200
-                            const newGelbooruDedupMode = ["off", "on", "on_auth"].includes(gelbooruDedupSelect.value) ? gelbooruDedupSelect.value : "off";
 
                             // 保存所有设置
                             const [blacklistSuccess, filterSuccess, uiSettingsSuccess] = await Promise.all([
@@ -1708,8 +1705,6 @@ app.registerExtension({
                                     autocomplete_max_results: newAutocompleteMaxResults,
                                     selected_categories: newSelectedCategories,
                                     multi_select_enabled: newMultiSelectEnabled,
-                                    preload_count: newPreloadCount,
-                                    gelbooru_dedup_mode: newGelbooruDedupMode,
                                     source_site: uiSettings.source_site || "danbooru",
                                     gelbooru_display_all_site_content: uiSettings.gelbooru_display_all_site_content || false
                                 })
@@ -1725,10 +1720,24 @@ app.registerExtension({
                                 uiSettings.autocomplete_max_results = newAutocompleteMaxResults;
                                 uiSettings.selected_categories = newSelectedCategories;
                                 uiSettings.multi_select_enabled = newMultiSelectEnabled;
-                                uiSettings.preload_count = newPreloadCount;
-                                uiSettings.gelbooru_dedup_mode = newGelbooruDedupMode;
                                 uiSettings.source_site = sourceSelect.value || uiSettings.source_site || "danbooru";
-                                await updateSelectionData();
+
+                                // 保存 preload/dedup/global_logging
+                                let newPreloadCount = parseInt(preloadCountInput.value, 10);
+                                if (isNaN(newPreloadCount)) newPreloadCount = 40;
+                                newPreloadCount = Math.min(Math.max(newPreloadCount, 20), 200);
+                                uiSettings.preload_count = newPreloadCount;
+                                saveToLocalStorage('preload_count', newPreloadCount);
+
+                                const newGelbooruDedupMode = ["off", "on", "on_auth"].includes(gelbooruDedupSelect.value) ? gelbooruDedupSelect.value : "off";
+                                uiSettings.gelbooru_dedup_mode = newGelbooruDedupMode;
+                                saveToLocalStorage('gelbooru_dedup_mode', newGelbooruDedupMode);
+
+                                const newGlobalLogging = globalLogCheck.checked;
+                                uiSettings.global_logging = newGlobalLogging;
+                                saveToLocalStorage('global_logging', newGlobalLogging);
+                                loggerClient.setConsoleOutput(newGlobalLogging);
+                                updateSelectionData();
 
                                 dialog.remove();
                                 showToast(t('saveSuccess'), 'success');
@@ -2111,8 +2120,6 @@ app.registerExtension({
                     multi_select_enabled: false,
                     source_site: "danbooru",
                     gelbooru_display_all_site_content: false,
-                    preload_count: 40,
-                    gelbooru_dedup_mode: "off",
                     formatting: {
                         escapeBrackets: true,
                         replaceUnderscores: true,
@@ -2132,8 +2139,6 @@ app.registerExtension({
                                 multi_select_enabled: data.settings.multi_select_enabled || false,
                                 source_site: data.settings.source_site || "danbooru",
                                 gelbooru_display_all_site_content: data.settings.gelbooru_display_all_site_content || false,
-                                preload_count: data.settings.preload_count || 40,
-                                gelbooru_dedup_mode: data.settings.gelbooru_dedup_mode || "off",
                                 formatting: data.settings.formatting || { escapeBrackets: true, replaceUnderscores: true }
                             };
                         }
@@ -2295,21 +2300,13 @@ app.registerExtension({
                             params.set("force_public_detail", "1");
                         }
                         const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        // 防御性解析：避免非 JSON 响应抛裸 JSON.parse 异常刷屏
-                        const rawText = await response.text();
-                        let data;
-                        try {
-                            data = JSON.parse(rawText);
-                        } catch (parseErr) {
-                            logger.warn(`[fetchOriginalPost] id=${postId} 响应非 JSON(status=${response.status})，跳过`);
-                            return null;
-                        }
-                        if (Array.isArray(data) && data.length > 0) {
+                        const data = await response.json();
+                        if (data && data.length > 0) {
                             return data[0];
                         }
                         return null;
                     } catch (error) {
-                        logger.warn(`[fetchOriginalPost] id=${postId} 详情抓取失败:`, error?.message || error);
+                        logger.error("Failed to fetch original post data:", error);
                         return null;
                     }
                 };
@@ -2365,9 +2362,10 @@ app.registerExtension({
                     return allowPreviewFallback ? (postData.preview_file_url || "") : "";
                 };
 
-                const getPostWithOriginalMedia = async (postData) => {
+                const getPostWithOriginalMedia = (postData) => {
                     const basePost = temporaryTagEdits[postData.id] || postData;
-                    return await hydrateGelbooruPost(basePost);
+                    // 同步：帖子在加载时已完成 hydrate，选图时无需再 await 网络请求
+                    return basePost;
                 };
 
                 const proxiedMediaUrl = (url) => `/danbooru_gallery/image_proxy?url=${encodeURIComponent(url)}`;
@@ -2462,17 +2460,11 @@ app.registerExtension({
                     }).join(' ');
                 };
 
+                let currentTags = ""; // 追踪当前搜索条件，用于决定是否重置游标（搜索条件变化时清空 lastPostId）
+
                 const fetchAndRender = async (reset = false) => {
-                    if (isLoading) {
-                        return;
-                    }
-                    if (endOfResults && !reset) {
-                        return;
-                    }
-                    const src = uiSettings.source_site || "danbooru";
-                    // G 站游标模式（防重复开启）：分页靠 id:<X 推进，pid 必须恒为 0，
-                    // 否则 page 偏移与游标双重推进会跳图。此时翻批不递增 currentPage。
-                    const gelbooruCursorMode = (src === "gelbooru" && (uiSettings.gelbooru_dedup_mode || "off") !== "off");
+                    if (isLoading) return;
+                    if (endOfResults && !reset) return;
                     isLoading = true;
                     refreshButton.classList.add("loading");
                     refreshButton.disabled = true;
@@ -2484,52 +2476,50 @@ app.registerExtension({
 
                     if (reset) {
                         currentPage = filterState.startPage || 1;
-                        lastPostId = null;        // 重置游标
-                        seenPostIds.clear();      // 重置去重集合
+                        const newTags = searchInput.value.trim();
+                        if (newTags !== currentTags) {
+                            lastPostId = null;
+                            scrollAnchorPostId = null;
+                            seenPostIds.clear();
+                        } else if (scrollAnchorPostId) {
+                            // 搜索条件没变 + 有锚点 → 用锚点做游标，往下接
+                            lastPostId = scrollAnchorPostId;
+                        }
+                        currentTags = newTags;
+
                         posts = [];
                         endOfResults = false;
                         imageGrid.innerHTML = "";
                         imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
                     }
 
-                    // 检查网络连接状态
+                    // 网络检查
                     const isNetworkConnected = await checkNetworkStatus();
-
                     if (!isNetworkConnected) {
-                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到服务器");  // 仅在控制台记录
-                        // 仅在首次加载(reset)时用整屏错误提示；滚动加载(reset=false)失败时
-                        // 不清空已加载内容，静默返回，下次滚动再试，避免"频繁报错+整屏重载"。
-                        if (reset) {
-                            imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
-                        }
+                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");
+                        imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
                         isLoading = false;
                         refreshButton.classList.remove("loading");
                         refreshButton.disabled = false;
                         const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) {
-                            indicator.remove();
-                        }
+                        if (indicator) indicator.remove();
                         return;
                     } else {
-                        // 网络连接恢复，清除之前的错误提示
                         clearError();
                     }
 
+                    let parseFailed = false;
                     try {
-                        // 检测tag数量
                         const searchValue = searchInput.value.trim();
                         const tags = searchValue.split(',').filter(tag => tag.trim() !== '');
                         const tagCount = tags.length;
 
-                        // 如果超过2个tag，给用户提示
                         if (tagCount > 2) {
                             showTagHint('搜索只考虑前两个tag，第三个及后续tag将被忽略', false);
                         } else {
-                            // 清除之前的提示
                             clearTagHint();
                         }
 
-                        // 将搜索框中的标签转换为API格式
                         let apiFormattedTags = convertTagsToApiFormat(searchValue);
 
                         // 添加日期筛选
@@ -2539,58 +2529,75 @@ app.registerExtension({
                             apiFormattedTags += ` date:${start}..${end}`;
                         }
 
+                        const src = uiSettings.source_site || "danbooru";
+                        const dedup = uiSettings.gelbooru_dedup_mode || "off";
                         const selectedRatings = getSelectedRatings();
                         const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
                         const ratingForServer = sendAll ? "" : selectedRatings.join(",");
                         const params = new URLSearchParams({
-                            "source": uiSettings.source_site || "danbooru",
+                            "source": src,
                             "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
+                            "gelbooru_dedup_mode": dedup,
                             "search[tags]": apiFormattedTags.trim(),
                             "search[rating]": ratingForServer,
-                            limit: String(uiSettings.preload_count || 40),
+                            limit: "40",
                             page: currentPage,
                         });
 
-                        // 游标防重复：reset 后第一次不带（从最新开始）。
-                        // D 站默认排序始终用；G 站仅当 dedup 开关非 off 时用（后端会再校验密钥/排序）。
-                        if (lastPostId && !reset) {
-                            const src = uiSettings.source_site || "danbooru";
-                            const dedup = uiSettings.gelbooru_dedup_mode || "off";
-                            if (src === "danbooru" || (src === "gelbooru" && dedup !== "off")) {
-                                params.set("before_id", lastPostId);
-                            }
+                        // 游标分页：D站始终用游标；G站仅当 dedup 非 off 时
+                        const useCursor = src === "danbooru" || (src === "gelbooru" && dedup !== "off");
+                        if (useCursor && lastPostId) {
+                            params.set("before_id", lastPostId);
                         }
 
+                        // G站游标模式下 pid 恒为 0，不允许当前页推进
+                        const gelbooruCursorMode = (src === "gelbooru" && dedup !== "off");
+
                         const response = await fetch(`/danbooru_gallery/posts?${params}`);
-                        // 防御性解析：后端偶发返回非 JSON（错误页/半截响应）时，
-                        // 不让裸 JSON.parse 异常冒泡导致整屏清空。
+                        const rawText = await response.text();
+
+                        // 防御性 JSON 解析：后端偶发返回非 JSON（错误页/半截响应），此时不销毁已有内容
                         let newPosts;
-                        let parseFailed = false;
                         try {
-                            const rawText = await response.text();
                             newPosts = JSON.parse(rawText);
                         } catch (parseErr) {
                             logger.warn(`[fetchAndRender] 响应解析失败(status=${response.status})，本次跳过:`, parseErr?.message || parseErr);
                             parseFailed = true;
                             newPosts = [];
                         }
-
                         if (!Array.isArray(newPosts)) newPosts = [];
 
-                        // 解析失败：不标记到底（可能只是偶发），保留已有内容，静默返回等下次触发
                         if (parseFailed) {
+                            if (reset) {
+                                imageGrid.innerHTML = `<p class="danbooru-status error">响应解析失败(status=${response.status})</p>`;
+                                return;
+                            }
+                            renderPost({ error: `响应解析失败(status=${response.status})` });
                             return;
                         }
 
-                        // 评分过滤已交给服务端，本地只做文件类型/黑名单过滤
-                        const filteredPosts = newPosts.filter(post => !isPostFiltered(post));
+                        // 先分离 error 占位格与正常 post
+                        const errorPosts = newPosts.filter(p => p && p.error);
+                        const normalRaw = newPosts.filter(p => !p || !p.error);
 
-                        const filteredCount = newPosts.length - filteredPosts.length;
+                        // 去重：seenPostIds 中已存在的跳过（防止 G站 pid 失效产生的重复被加入 posts 数组）
+                        const freshRaw = normalRaw.filter(p => !seenPostIds.has(String(p.id)));
+                        freshRaw.forEach(p => seenPostIds.add(String(p.id)));
 
-                        // API returned nothing → no more pages. Flag it so scroll events stop
-                        // triggering fetches; otherwise the bottom-proximity check would keep
-                        // firing and walk off the end of the result set indefinitely.
-                        if (newPosts.length === 0) {
+                        // 对正常格做过滤
+                        const filteredPosts = freshRaw.filter(post => !isPostFiltered(post));
+
+                        if (errorPosts.length > 0) {
+                            if (reset && filteredPosts.length === 0 && freshRaw.length === 0) {
+                                // 首次加载全是 error 格：整屏错误
+                                imageGrid.innerHTML = `<p class="danbooru-status error">${errorPosts[0].error}</p>`;
+                                return;
+                            }
+                            // 续加载/混合正常格：追加 error 格
+                            errorPosts.forEach(renderPost);
+                        }
+
+                        if (newPosts.length === 0 && errorPosts.length === 0) {
                             endOfResults = true;
                             if (reset) {
                                 imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
@@ -2598,97 +2605,134 @@ app.registerExtension({
                             return;
                         }
 
-                        if (filteredPosts.length === 0 && reset) {
+                        if (filteredPosts.length === 0 && freshRaw.length === 0 && reset && errorPosts.length === 0) {
                             imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
                             return;
                         }
 
-                        // 游标模式靠 id:<X 推进，pid 须恒为 0，不递增 page；其余模式正常翻页
+                        // 确保即使在 cursor 模式下过滤掉了所有正常图片也能推进游标
+                        if (normalRaw.length > 0) {
+                            lastPostId = normalRaw[normalRaw.length - 1].id;
+                        }
+
+                        // G站游标模式下 pid 恒定不推进；D站正常推进 page
                         if (!gelbooruCursorMode) {
                             currentPage++;
                         }
-                        // 渲染前 id 去重兜底（防游标边界残留重复）
-                        const fresh = filteredPosts.filter(p => {
-                            if (seenPostIds.has(p.id)) return false;
-                            seenPostIds.add(p.id);
-                            return true;
-                        });
-                        // 游标用原始返回最后一张推进（即使本批被过滤光也连续）
-                        lastPostId = newPosts[newPosts.length - 1].id;
-                        posts.push(...fresh);
-                        fresh.forEach(renderPost);
 
-                        // 防无限补货：本页返回了数据，但去重后 0 张新增（全是已见过的）。
-                        // 说明分页失效或到底（如 Gelbooru 空标签浏览时 pid 偏移无效，每页返回同样内容）。
-                        // 标记到底，停止后续补货，避免无限翻页空转。
-                        if (fresh.length === 0 && newPosts.length > 0 && !reset) {
+                        posts.push(...filteredPosts);
+                        filteredPosts.forEach(renderPost);
+
+                        // 去重陷阱检测：本页有返回值但全部是已见过的 → 判定到底
+                        if (freshRaw.length === 0 && normalRaw.length > 0 && !reset) {
                             endOfResults = true;
                             logger.warn(`[fetchAndRender] 本页 ${newPosts.length} 张全是重复，判定到底/分页失效，停止加载`);
+                            return;
                         }
 
-                        // Filter-cascade guard: if the blacklist/rating filter dropped every
-                        // post on this page, the grid didn't grow — the user's scroll is still
-                        // within the 400px bottom threshold, so the scroll listener would
-                        // re-fire immediately. Hold isLoading for ~1.5s (still inside the try
-                        // block, before the finally clears it) to space out these "auto-skip"
-                        // fetches.
+                        // Filter-cascade guard
                         if (filteredPosts.length === 0 && !reset) {
                             await new Promise(r => setTimeout(r, 1500));
                         }
 
                     } catch (e) {
-                        // 仅首次加载(reset)时用整屏错误提示；滚动/续拉失败时保留已加载内容，
-                        // 不清屏（单次请求失败不该抹掉已经看到的图）。
+                        // 首次加载→整屏错误；滚动续拉→保留内容+加错误格
                         if (reset) {
                             imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
                         } else {
                             logger.warn('[fetchAndRender] 加载失败，保留已有内容:', e?.message || e);
+                            renderPost({ error: `请求失败: ${e.message}` });
                         }
                     } finally {
                         isLoading = false;
                         refreshButton.classList.remove("loading");
                         refreshButton.disabled = false;
                         const indicator = imageGrid.querySelector('.danbooru-loading');
-                        if (indicator) {
-                            indicator.remove();
+                        if (indicator) indicator.remove();
+                        // 刷新后还原滚动位置
+                        if (reset && scrollAnchorPostId) {
+                            // 等 maybeLoadMore 链走完（多个 setTimeout(…,0)）后尝试还原
+                            const attemptScroll = (retries = 8) => {
+                                const target = imageGrid.querySelector(`[data-post-id="${scrollAnchorPostId}"]`);
+                                if (target) {
+                                    target.scrollIntoView({ block: "start", behavior: "instant" });
+                                    return;
+                                }
+                                if (retries > 0) {
+                                    setTimeout(() => attemptScroll(retries - 1), 150);
+                                }
+                            };
+                            setTimeout(() => attemptScroll(), 300);
+                        }
+                        // 每次加载完成后检查是否需要补充更多（maybeLoadMore）
+                        if (!endOfResults && !parseFailed) {
+                            maybeLoadMore();
                         }
                     }
-
-                    // 加载完一页后，检查缓冲是否仍不足（前方未看的图 < preload_count），
-                    // 不足则继续补——渐进式补货，每次补一页，直到缓冲满或到底。
-                    maybeLoadMore();
                 };
 
-                // 统一的缓冲补货：估算"前方未看过的图片数"，不足 preload_count 就再加载一页。
-                // 两站、两档共用。reset 后首屏、滚动、每次加载完成都会调它。
                 const maybeLoadMore = () => {
                     if (isLoading || endOfResults) return;
                     const bufferTarget = parseInt(uiSettings.preload_count, 10) || 40;
-                    // 估算已浏览到的张数：按滚动位置比例 * 总数。grid 高度为 0（首屏未铺开）时按已看 0 处理。
                     const scrollH = imageGrid.scrollHeight;
                     let viewedCount = 0;
                     if (scrollH > 0) {
                         const viewedRatio = Math.min(1, (imageGrid.scrollTop + imageGrid.clientHeight) / scrollH);
                         viewedCount = Math.floor(posts.length * viewedRatio);
                     }
-                    const aheadBuffer = posts.length - viewedCount;  // 前方未看过的张数
+                    const aheadBuffer = posts.length - viewedCount;
                     if (aheadBuffer < bufferTarget) {
-                        // 异步触发，让出调用栈避免深递归；isLoading 已释放
+                        // 异步触发避免递归撑爆调用栈
                         setTimeout(() => fetchAndRender(false), 0);
                     }
                 };
 
-                const resizeGrid = () => {
-                    const rowGap = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-row-gap'));
-                    const rowHeight = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-auto-rows'));
-
-                    Array.from(imageGrid.children).forEach((wrapper) => {
-                        const img = wrapper.querySelector('img');
-                        if (img && img.clientHeight > 0) {
-                            const spans = Math.ceil((img.clientHeight + rowGap) / (rowHeight + rowGap));
-                            wrapper.style.gridRowEnd = `span ${spans}`;
+                // Queue 按钮拦截：每次点击时将当前选中快照推入后端 FIFO 队列
+                const _hookQueueButton = () => {
+                    // 兼容不同 ComfyUI 前端版本：data-testid（新版）/ #comfy-queue-btn（旧版）
+                    const queueBtn = document.querySelector('[data-testid="queue-button"]') || document.getElementById("comfy-queue-btn");
+                    if (!queueBtn) { setTimeout(_hookQueueButton, 500); return; }
+                    queueBtn.addEventListener("click", async () => {
+                        const selectedWrappers = imageGrid.querySelectorAll('.danbooru-image-wrapper.selected');
+                        if (selectedWrappers.length === 0) return;
+                        const selections = [];
+                        for (const wrapper of selectedWrappers) {
+                            const postId = wrapper.dataset.postId;
+                            const postData = posts.find(p => p.id == postId) || temporaryTagEdits[postId];
+                            if (postData) {
+                                const prompt = buildPromptForPost(postData);
+                                const mediaPost = getPostWithOriginalMedia(postData);
+                                const imageUrl = getBestImageUrl(mediaPost, false);
+                                selections.push({ post_id: postId, prompt, image_url: imageUrl });
+                            }
                         }
-                    });
+                        if (selections.length === 0) return;
+                        selectionQueueId++;
+                        await fetch("/danbooru_gallery/selection_queue_push", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ item: { selections, _queue_id: selectionQueueId } })
+                        });
+                    }, true); // useCapture = true：在原始 onclick 之前触发
+                };
+                setTimeout(_hookQueueButton, 1000);
+
+                const resizeGrid = () => {
+                    try {
+                        const cs = window.getComputedStyle(imageGrid);
+                        const rowGap = parseInt(cs.getPropertyValue('grid-row-gap')) || parseInt(cs.rowGap) || 5;
+                        const rowHeight = parseInt(cs.getPropertyValue('grid-auto-rows')) || 1;
+
+                        Array.from(imageGrid.children).forEach((wrapper) => {
+                            const img = wrapper.querySelector('img');
+                            if (img && img.clientHeight > 0) {
+                                const spans = Math.ceil((img.clientHeight + rowGap) / (rowHeight + rowGap));
+                                wrapper.style.gridRowEnd = `span ${spans}`;
+                            }
+                        });
+                    } catch (e) {
+                        // 计算失败不影响主体流程
+                    }
                 }
 
                 // Pre-reserve grid space from post dimensions so rate-limited async loads
@@ -2696,10 +2740,16 @@ app.registerExtension({
                 let cachedColumnWidth = 0;
                 const getColumnWidth = () => {
                     if (cachedColumnWidth > 0) return cachedColumnWidth;
-                    const cols = window.getComputedStyle(imageGrid).gridTemplateColumns.split(' ');
-                    const px = parseFloat(cols[0]);
-                    if (px > 0) cachedColumnWidth = px;
-                    return cachedColumnWidth;
+                    try {
+                        const cs = window.getComputedStyle(imageGrid);
+                        const template = cs.gridTemplateColumns;
+                        if (template && template !== 'none') {
+                            const cols = template.split(' ');
+                            const px = parseFloat(cols[0]);
+                            if (px > 0) cachedColumnWidth = px;
+                        }
+                    } catch (e) {}
+                    return cachedColumnWidth || 150; // grid 未 layout 时保底 150px
                 };
                 const computeSpanFromDims = (imgW, imgH) => {
                     const colW = getColumnWidth();
@@ -2844,7 +2894,7 @@ app.registerExtension({
                                 newPostElement.classList.add('selected');
 
                             }
-                            await updateSelectionData();
+                            updateSelectionData();
                         } else { // 如果打开面板时未选中，则清除所有选中的图像和提示词
 
                             imageGrid.querySelectorAll('.danbooru-image-wrapper.selected').forEach(w => {
@@ -2907,7 +2957,7 @@ app.registerExtension({
                             const selectedCategoriesToCopy = Array.from(selectedCategoriesCheckboxes).map(cb => cb.name);
 
                             const postToCopy = temporaryTagEdits[post.id] || post;
-                            const formattedTags = await buildPromptForPost(postToCopy, selectedCategoriesToCopy);
+                            const formattedTags = buildPromptForPost(postToCopy, selectedCategoriesToCopy);
 
                             if (formattedTags) {
                                 try {
@@ -2953,7 +3003,7 @@ app.registerExtension({
 
                                 // 6. Update selectionWidget if the post is currently selected
                                 if (isPostCurrentlySelected) {
-                                    await updateSelectionData();
+                                    updateSelectionData();
                                 }
                                 showToast(t('resetTags') + '成功', 'success', resetTagsButton);
                             } else {
@@ -3235,9 +3285,9 @@ app.registerExtension({
                 };
 
                 // 辅助函数：为单个帖子构建提示词
-                const buildPromptForPost = async (postData, selectedCategoriesOverride = null) => {
-                    let promptPost = temporaryTagEdits[postData.id] || postData;
-                    promptPost = await hydrateGelbooruPost(promptPost);
+                const buildPromptForPost = (postData, selectedCategoriesOverride = null) => {
+                    // 同步：G站在加载时已完成 hydrate，选图时 tag_xxx 已就绪，无需再 await 网络请求
+                    const promptPost = temporaryTagEdits[postData.id] || postData;
 
                     const promptCategories = Array.isArray(selectedCategoriesOverride)
                         ? selectedCategoriesOverride.filter(name => TAG_CATEGORY_ORDER.includes(name))
@@ -3253,7 +3303,7 @@ app.registerExtension({
                 };
 
                 // 辅助函数：收集所有选中图片的数据并更新 widget
-                const updateSelectionData = async () => {
+                const updateSelectionData = () => {
                     const selectedWrappers = imageGrid.querySelectorAll('.danbooru-image-wrapper.selected');
                     const selections = [];
 
@@ -3261,9 +3311,9 @@ app.registerExtension({
                         const postId = wrapper.dataset.postId;
                         const postData = posts.find(p => p.id == postId) || temporaryTagEdits[postId];
                         if (postData) {
-                            const prompt = await buildPromptForPost(postData);
+                            const prompt = buildPromptForPost(postData);
                             const updatedPostData = posts.find(p => p.id == postId) || temporaryTagEdits[postId] || postData;
-                            const mediaPost = await getPostWithOriginalMedia(updatedPostData);
+                            const mediaPost = getPostWithOriginalMedia(updatedPostData);
                             const imageUrl = getBestImageUrl(mediaPost, false);
                             selections.push({
                                 post_id: postId,
@@ -3275,7 +3325,7 @@ app.registerExtension({
 
                     const selectionData = { selections: selections };
 
-                    // 更新 widget
+                    // 更新 widget（仍保留用于兼容回退）
                     if (nodeInstance && nodeInstance.widgets) {
                         const selectionWidget = nodeInstance.widgets.find(w => w.name === "selection_data");
                         if (selectionWidget) {
@@ -3310,6 +3360,16 @@ app.registerExtension({
                 };
 
                 const createPostElement = (post) => {
+                    // error 占位格：红色边框，直接显示错误文本
+                    if (post && post.error) {
+                        const wrapper = $el("div.danbooru-image-wrapper", {
+                            style: { border: '1px solid #ff4444', minHeight: '80px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#ff4444', fontSize: '0.85em', padding: '8px', textAlign: 'center' }
+                        });
+                        wrapper.dataset.postId = `err_${post.pid || post.page || '?'}`;
+                        wrapper.textContent = post.error;
+                        return wrapper;
+                    }
+
                     if (!post.id || !post.preview_file_url) return null;
 
                     const wrapper = $el("div.danbooru-image-wrapper");
@@ -3317,19 +3377,15 @@ app.registerExtension({
 
                     // Reserve grid space up-front from the post's real dimensions so the
                     // waterfall is stable before thumbnails finish loading.
-                    // G 站公开抓取返回 image_width/height=0，算不出 span；此时给一个保底高度，
-                    // 否则 wrapper 只占 grid-auto-rows(1px)，整个网格塌成一条线 →
-                    // 永远到不了"距底部 400px" → 滚动加载再也不触发。
+                    // G公开页返回的 post 经常 image_width/height=0，按列宽的估算方形保底高度
                     let reservedSpans = 0;
                     if (post.image_width && post.image_height) {
                         reservedSpans = computeSpanFromDims(post.image_width, post.image_height);
                     }
                     if (reservedSpans <= 0) {
-                        // 保底：按列宽估一个近似正方形高度（图片 onload 后 resizeGrid 会修正为真实高度）
                         const colW = getColumnWidth();
-                        const cs = window.getComputedStyle(imageGrid);
-                        const rowGap = parseInt(cs.gridRowGap) || parseInt(cs.rowGap) || 5;
-                        const rowHeight = parseInt(cs.gridAutoRows) || 1;
+                        const rowGap = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-row-gap')) || parseInt(window.getComputedStyle(imageGrid).rowGap) || 5;
+                        const rowHeight = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-auto-rows')) || 1;
                         reservedSpans = colW > 0 ? Math.ceil((colW + rowGap) / (rowHeight + rowGap)) : 200;
                     }
                     if (reservedSpans > 0) wrapper.style.gridRowEnd = `span ${reservedSpans}`;
@@ -3348,7 +3404,6 @@ app.registerExtension({
 
                     const img = $el("img", {
                         src: `/danbooru_gallery/image_proxy?url=${encodeURIComponent(previewUrl)}`,
-                        loading: "eager",
                         onload: scheduleResizeGrid,
                         onerror: () => { wrapper.style.display = 'none'; },
                         onclick: async (e) => {
@@ -3389,7 +3444,7 @@ app.registerExtension({
                             e.stopPropagation(); // 阻止事件冒泡，避免触发图片选择
 
                             try {
-                                const mediaPost = await getPostWithOriginalMedia(post);
+                                const mediaPost = getPostWithOriginalMedia(post);
                                 const imageUrl = getBestImageUrl(mediaPost, false);
                                 if (!imageUrl) {
                                     return;
@@ -3648,7 +3703,7 @@ app.registerExtension({
                         title: t('viewImage'),
                         onclick: async (e) => {
                             e.stopPropagation();
-                            const mediaPost = await getPostWithOriginalMedia(post);
+                            const mediaPost = getPostWithOriginalMedia(post);
                             const imageUrl = getBestImageUrl(mediaPost, false);
                             if (imageUrl) {
                                 window.open(proxiedMediaUrl(imageUrl), '_blank', 'noreferrer');
@@ -3681,10 +3736,8 @@ app.registerExtension({
                 observer.observe(imageGrid);
 
                 let scrollTimeout;
+                let scrollAnchorTimeout; // 锚点记录的防抖
                 imageGrid.addEventListener("scroll", () => {
-                    // 滚动消耗了前方缓冲 → 检查是否需要补货（维持前方 preload_count 张未看）。
-                    // 同时保留"接近底部"作为兜底触发（缓冲估算在 0 尺寸图下可能偏差）。
-                    maybeLoadMore();
                     if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
                         fetchAndRender(false);
                     }
@@ -3692,6 +3745,27 @@ app.registerExtension({
                     // Debounced scroll logic for page indicator
                     clearTimeout(scrollTimeout);
                     scrollTimeout = setTimeout(updateCurrentPageIndicator, 150);
+
+                    // 记录滚动锚点（每秒；取视野最上方的图往前 8 张，刷新时用其 id 做游标往下接）
+                    clearTimeout(scrollAnchorTimeout);
+                    scrollAnchorTimeout = setTimeout(() => {
+                        const scrollRect = imageGrid.getBoundingClientRect();
+                        let closestIdx = -1, closestDist = Infinity;
+                        const children = Array.from(imageGrid.children);
+                        children.forEach((w, i) => {
+                            const rect = w.getBoundingClientRect();
+                            const dist = Math.abs(rect.top - scrollRect.top);
+                            if (dist < closestDist) { closestDist = dist; closestIdx = i; }
+                        });
+                        if (closestIdx >= 0) {
+                            const anchorIdx = Math.max(0, closestIdx - 8);
+                            const anchorEl = children[anchorIdx];
+                            if (anchorEl && anchorEl.dataset.postId) {
+                                scrollAnchorPostId = anchorEl.dataset.postId;
+                                saveToLocalStorage('scrollAnchorPostId', scrollAnchorPostId);
+                            }
+                        }
+                    }, 1000);
                 });
 
                 searchInput.addEventListener("keydown", (e) => {
@@ -4110,6 +4184,35 @@ app.registerExtension({
                             filterWidget.value = JSON.stringify(filterState);
                         }
 
+                        // 恢复已存储的 preload/dedup/globalLogging（在 loadUiSettings 之后）
+                        const savedPreloadCount = loadFromLocalStorage('preload_count', null);
+                        if (savedPreloadCount !== null) {
+                            const clamped = Math.min(Math.max(parseInt(savedPreloadCount, 10) || 40, 20), 200);
+                            uiSettings.preload_count = clamped;
+                        } else {
+                            uiSettings.preload_count = 40;
+                        }
+                        const savedGelbooruDedupMode = loadFromLocalStorage('gelbooru_dedup_mode', null);
+                        if (savedGelbooruDedupMode && ["off", "on", "on_auth"].includes(savedGelbooruDedupMode)) {
+                            uiSettings.gelbooru_dedup_mode = savedGelbooruDedupMode;
+                        } else {
+                            uiSettings.gelbooru_dedup_mode = "off";
+                        }
+                        const savedGlobalLogging = loadFromLocalStorage('global_logging', null);
+                        if (typeof savedGlobalLogging === "boolean") {
+                            uiSettings.global_logging = savedGlobalLogging;
+                            loggerClient.setConsoleOutput(savedGlobalLogging);
+                        } else {
+                            uiSettings.global_logging = false;
+                            loggerClient.setConsoleOutput(false);
+                        }
+
+                        // 恢复保存的滚动锚点（刷新后用其 id 做游标往下接）
+                        const savedScrollAnchor = loadFromLocalStorage('scrollAnchorPostId', null);
+                        if (savedScrollAnchor) {
+                            scrollAnchorPostId = savedScrollAnchor;
+                        }
+
                         // 初始化排行榜按钮状态
                         updateRankingButtonState();
 
@@ -4120,7 +4223,8 @@ app.registerExtension({
                             filterButton.classList.remove('active');
                         }
 
-                        // 页面加载时直接获取第一页的帖子
+                        // 页面加载时直接获取第一页的帖子（先同步 currentTags，否则重置块会因 '' !== 搜索值而清空锚点）
+                        currentTags = searchInput.value.trim();
                         fetchAndRender(true);
 
                     } catch (error) {

--- a/js/danbooru_gallery/danbooru_gallery.js
+++ b/js/danbooru_gallery/danbooru_gallery.js
@@ -1,2107 +1,5530 @@
-import requests
-import json
-import folder_paths
-from server import PromptServer
-from aiohttp import web
-import time
-import threading
-import asyncio
-import torch
-import io
-import urllib.request
-import urllib.parse
-import numpy as np
-from PIL import Image
-import os
-import csv
-import re
-from requests.auth import HTTPBasicAuth
-import urllib3
-from pathlib import Path
-import sys
-from ..utils.logger import get_logger
-from .site_adapters import get_site_adapter
-from collections import defaultdict, deque
-
-logger = get_logger(__name__)
-
-# FIFO 选择队列（按 nodeId 分桶）：每次 Queue 时前端快照推入对应节点的队列，
-# 节点执行时只 pop 自己 nodeId 的条目，其他节点的条目不受影响。
-# 支持同一工作流中多个画廊节点互不干扰、主子工作流各自取自己的数据。
-_selection_queues = defaultdict(deque)
-_selection_queues_lock = threading.Lock()
-_selection_queue_gen = 0  # 每次 push 递增，IS_CHANGED 据此让所有节点都重新执行
-
-# 导入数据库管理器
-try:
-    from ..shared.db.db_manager import get_db_manager
-except ImportError as e:
-    logger.warning(f"[Autocomplete] 无法导入数据库管理器，将仅使用远程API模式: {e}")
-    get_db_manager = None
-
-# 禁用 SSL 警告（如果需要禁用证书验证）
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
-# Danbooru API文档链接 https://danbooru.donmai.us/wiki_pages/help:api
-
-# Danbooru API的基础URL
-BASE_URL = "https://danbooru.donmai.us"
-
-# 需要一个非 python-requests 的描述性 UA 才能过 Cloudflare（从 2026-04-23 起开启拦截）。
-# 实测 CF 对 UA 黑名单里包含 "ComfyUI" —— 推测 Danbooru 为抵制训练数据爬取主动加的规则。
-# 本节点只是图片浏览器（单图挑选，无批量导出），不参与训练数据收集，按 e621 式约定
-# 使用描述性项目 UA；避开 "ComfyUI" 字样以免被 CF 误伤。
-DANBOORU_HEADERS = {
-    "User-Agent": "Danbooru-Gallery/1.0"
-}
-
-# 官方文档限速为 10 req/s，保守取一半 = 5 req/s（200ms 间隔），避免触发 CF 或被站方拉黑。
-# 参考 deepghs/waifuc#22：Danbooru 管理员明确要求 "proper waits or backoffs"，否则会封项目。
-class _RateLimiter:
-    def __init__(self, min_interval_sec):
-        self.min_interval = min_interval_sec
-        self._last_ts = 0.0
-        self._lock = threading.Lock()
-
-    def wait(self):
-        with self._lock:
-            now = time.monotonic()
-            elapsed = now - self._last_ts
-            if elapsed < self.min_interval:
-                time.sleep(self.min_interval - elapsed)
-            self._last_ts = time.monotonic()
-
-_donmai_throttle = _RateLimiter(min_interval_sec=0.2)
-
-# Gelbooru 公开 HTML 页列表固定每页 42 张，pid 为该页首张图片的偏移量
-GELBOORU_PUBLIC_PAGE_SIZE = 42
-
-# Gelbooru 公开页抓取限流器（0.75s = ~1.33 req/s，避开 429）
-_gelbooru_public_throttle = _RateLimiter(min_interval_sec=0.75)
-
-def _danbooru_request(method, url, **kwargs):
-    """统一的 donmai.us 请求入口：限流 + 默认 UA + 429/503 带 Retry-After 退避重试一次。"""
-    headers = dict(kwargs.pop("headers", None) or {})
-    for k, v in DANBOORU_HEADERS.items():
-        headers.setdefault(k, v)
-
-    resp = None
-    for attempt in range(2):
-        _donmai_throttle.wait()
-        resp = requests.request(method, url, headers=headers, **kwargs)
-        if resp.status_code not in (429, 503) or attempt == 1:
-            return resp
-        retry_after = resp.headers.get("Retry-After")
-        delay = 2.0
-        try:
-            if retry_after is not None:
-                delay = min(max(float(retry_after), 0.5), 10.0)
-        except ValueError:
-            pass
-        logger.warning(f"[Danbooru] {resp.status_code} 限流，{delay:.1f}s 后重试: {url}")
-        time.sleep(delay)
-    return resp
-
-# 获取插件目录路径
-# 获取当前文件所在目录
-PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
-SETTINGS_FILE = os.path.join(PLUGIN_DIR, "settings.json")
-
-def load_settings():
-    """从本地文件加载所有设置"""
-    default_settings = {
-        "language": "zh",
-        "blacklist": [],
-        "filter_tags": [
-            "watermark", "sample_watermark", "weibo_username", "weibo", "weibo_logo",
-            "weibo_watermark", "censored", "mosaic_censoring", "artist_name", "twitter_username"
-        ],
-        "filter_enabled": True,
-        "danbooru_username": "",
-        "danbooru_api_key": "",
-        "gelbooru_user_id": "",
-        "gelbooru_api_key": "",
-        "gelbooru_display_all_site_content": False,
-        "favorites": [],
-        "debug_mode": False,
-        "cache_enabled": True,
-        "max_cache_age": 3600,
-        "default_page_size": 20,
-        "autocomplete_enabled": True,
-        "tooltip_enabled": True,
-        "autocomplete_max_results": 20,
-        "selected_categories": ["copyright", "character", "general"],
-        "source_site": "danbooru"
-    }
-
-    try:
-        if os.path.exists(SETTINGS_FILE):
-            with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-                for key, value in default_settings.items():
-                    if key not in data:
-                        data[key] = value
-                return data
-    except Exception as e:
-        logger.error(f"加载设置失败: {e}")
-
-    return default_settings
-
-def load_autocomplete_config():
-    """加载自动补全配置（用于数据库优先+API fallback机制）"""
-    # 默认配置
-    default_config = {
-        "offline_mode": {
-            "enabled": True,
-            "fallback_to_remote": True,
-            "remote_timeout_ms": 2000  # 2秒超时
-        },
-        "cache": {
-            "use_database_query": True
-        }
-    }
-
-    # 尝试从多个位置加载配置
-    config_paths = [
-        Path(PLUGIN_DIR) / "config.json",
-        Path(PLUGIN_DIR).parent / "config.json",
-    ]
-
-    for config_path in config_paths:
-        if config_path.exists():
-            try:
-                with open(config_path, 'r', encoding='utf-8') as f:
-                    loaded = json.load(f)
-                    # 深度合并配置
-                    if "offline_mode" in loaded:
-                        default_config["offline_mode"].update(loaded["offline_mode"])
-                    if "cache" in loaded:
-                        default_config["cache"].update(loaded["cache"])
-                    logger.info(f"[Autocomplete] 加载配置: {config_path}")
-                    return default_config
-            except Exception as e:
-                logger.warning(f"[Autocomplete] 配置文件加载失败 {config_path}: {e}")
-
-    logger.info("[Autocomplete] 使用默认配置")
-    return default_config
-
-def save_settings(settings):
-    """保存所有设置到本地文件"""
-    try:
-        with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
-            json.dump(settings, f, ensure_ascii=False, indent=2)
-        return True
-    except Exception as e:
-        logger.error(f"保存设置失败: {e}")
-        return False
-
-def load_user_auth():
-    """从统一设置文件加载用户认证信息"""
-    settings = load_settings()
-    return settings.get("danbooru_username", ""), settings.get("danbooru_api_key", "")
-
-def save_user_auth(username, api_key):
-    """保存用户认证信息到统一设置文件"""
-    settings = load_settings()
-    settings["danbooru_username"] = username
-    settings["danbooru_api_key"] = api_key
-    return save_settings(settings)
-
-def load_gelbooru_auth():
-    """从统一设置文件加载Gelbooru API认证信息"""
-    settings = load_settings()
-    return settings.get("gelbooru_user_id", ""), settings.get("gelbooru_api_key", "")
-
-def save_gelbooru_auth(user_id, api_key):
-    """保存Gelbooru API认证信息到统一设置文件"""
-    settings = load_settings()
-    settings["gelbooru_user_id"] = user_id
-    settings["gelbooru_api_key"] = api_key
-    return save_settings(settings)
-
-def get_site_credentials(adapter):
-    """返回站点适配器需要的认证参数。Danbooru 使用 HTTP Basic Auth，Gelbooru 使用 query 参数。"""
-    if adapter.key == "gelbooru":
-        user_id, api_key = load_gelbooru_auth()
-        return {"user_id": user_id, "api_key": api_key}
-    return {}
-
-def has_required_site_credentials(adapter, credentials):
-    """检查当前站点适配器的必要凭据是否已配置。"""
-    if adapter.key == "gelbooru":
-        return bool(credentials.get("user_id") and credentials.get("api_key"))
-    return True
-
-def load_favorites():
-    """从统一设置文件加载收藏列表"""
-    settings = load_settings()
-    return settings.get("favorites", [])
-
-def save_favorites(favorites):
-    """保存收藏列表到统一设置文件"""
-    settings = load_settings()
-    settings["favorites"] = favorites
-    return save_settings(settings)
-
-def load_language():
-    """从统一设置文件加载语言设置"""
-    settings = load_settings()
-    return settings.get("language", "zh")
-
-def save_language(language):
-    """保存语言设置到统一设置文件"""
-    settings = load_settings()
-    settings["language"] = language
-    return save_settings(settings)
-
-def load_blacklist():
-    """从统一设置文件加载黑名单"""
-    settings = load_settings()
-    return settings.get("blacklist", [])
-
-def save_blacklist(blacklist_items):
-    """保存黑名单到统一设置文件"""
-    settings = load_settings()
-    settings["blacklist"] = blacklist_items
-    return save_settings(settings)
-
-def load_filter_tags():
-    """从统一设置文件加载提示词过滤设置"""
-    settings = load_settings()
-    return settings.get("filter_tags", []), settings.get("filter_enabled", True)
-
-def save_filter_tags(filter_tags, enabled):
-    """保存提示词过滤设置到统一设置文件"""
-    settings = load_settings()
-    settings["filter_tags"] = filter_tags
-    settings["filter_enabled"] = enabled
-    return save_settings(settings)
-
-def load_ui_settings():
-    """从统一设置文件加载UI设置"""
-    settings = load_settings()
-    return {
-        "autocomplete_enabled": settings.get("autocomplete_enabled", True),
-        "tooltip_enabled": settings.get("tooltip_enabled", True),
-        "autocomplete_max_results": settings.get("autocomplete_max_results", 20),
-        "selected_categories": settings.get("selected_categories", ["copyright", "character", "general"]),
-        "multi_select_enabled": settings.get("multi_select_enabled", False),
-        "source_site": settings.get("source_site", "danbooru"),
-        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False)
-    }
-
-def save_ui_settings(ui_settings):
-    """保存UI设置到统一设置文件"""
-    settings = load_settings()
-    settings["autocomplete_enabled"] = ui_settings.get("autocomplete_enabled", True)
-    settings["tooltip_enabled"] = ui_settings.get("tooltip_enabled", True)
-    settings["autocomplete_max_results"] = ui_settings.get("autocomplete_max_results", 20)
-    settings["selected_categories"] = ui_settings.get("selected_categories", ["copyright", "character", "general"])
-    settings["multi_select_enabled"] = ui_settings.get("multi_select_enabled", False)
-    settings["source_site"] = ui_settings.get("source_site", "danbooru")
-    settings["gelbooru_display_all_site_content"] = ui_settings.get("gelbooru_display_all_site_content", False)
-    return save_settings(settings)
-
-# ================================
-# Tag翻译系统
-# ================================
-
-class TagTranslationSystem:
-    """Tag翻译系统，负责加载、处理和查询汉化数据"""
-    
-    def __init__(self):
-        self.en_to_cn = {}  # 英文->中文映射
-        self.cn_to_en = {}  # 中文->英文映射
-        self.cn_search_index = {}  # 中文搜索索引
-        self.loaded = False
-        self._translation_cache = {}  # 翻译缓存
-        self._search_cache = {}  # 搜索缓存
-        self.max_cache_size = 1000  # 最大缓存条目数
-        
-    def load_translation_data(self):
-        """加载所有汉化数据文件"""
-        if self.loaded:
-            return True
-            
-        try:
-            zh_cn_dir = os.path.join(PLUGIN_DIR, "zh_cn")
-            
-            # 加载JSON格式数据
-            self._load_json_data(zh_cn_dir)
-            # 加载CSV格式数据
-            self._load_csv_data(zh_cn_dir)
-            # 加载角色CSV数据
-            self._load_character_csv_data(zh_cn_dir)
-            
-            # 构建下划线匹配映射
-            self._build_underscore_variants()
-            # 构建中文搜索索引
-            self._build_chinese_search_index()
-            
-            self.loaded = True
-            return True
-            
-        except Exception as e:
-            logger.error(f"[翻译系统] 加载失败: {e}")
-            return False
-    
-    def _load_json_data(self, zh_cn_dir):
-        """加载JSON格式的翻译数据"""
-        json_file = os.path.join(zh_cn_dir, "all_tags_cn.json")
-        if os.path.exists(json_file):
-            try:
-                with open(json_file, 'r', encoding='utf-8') as f:
-                    data = json.load(f)
-                    for en_tag, cn_tag in data.items():
-                        if en_tag and cn_tag:
-                            self.en_to_cn[en_tag.strip()] = cn_tag.strip()
-                            self.cn_to_en[cn_tag.strip()] = en_tag.strip()
-            except Exception as e:
-                logger.error(f"[翻译系统] JSON加载失败: {e}")
-    
-    def _load_csv_data(self, zh_cn_dir):
-        """加载CSV格式的翻译数据"""
-        csv_file = os.path.join(zh_cn_dir, "danbooru.csv")
-        if os.path.exists(csv_file):
-            try:
-                with open(csv_file, 'r', encoding='utf-8') as f:
-                    reader = csv.reader(f)
-                    count = 0
-                    for row in reader:
-                        if len(row) >= 2 and row[0] and row[1]:
-                            en_tag = row[0].strip()
-                            cn_tag = row[1].strip()
-                            # 如果已存在翻译，跳过（保持第一个找到的）
-                            if en_tag not in self.en_to_cn:
-                                self.en_to_cn[en_tag] = cn_tag
-                            if cn_tag not in self.cn_to_en:
-                                self.cn_to_en[cn_tag] = en_tag
-                            count += 1
-            except Exception as e:
-                logger.error(f"[翻译系统] CSV加载失败: {e}")
-    
-    def _load_character_csv_data(self, zh_cn_dir):
-        """加载角色CSV格式的翻译数据（格式：中文名称,英文tag）"""
-        csv_file = os.path.join(zh_cn_dir, "wai_characters.csv")
-        if os.path.exists(csv_file):
-            try:
-                with open(csv_file, 'r', encoding='utf-8') as f:
-                    reader = csv.reader(f)
-                    count = 0
-                    for row in reader:
-                        if len(row) >= 2 and row[0] and row[1]:
-                            cn_tag = row[0].strip()
-                            en_tag = row[1].strip()
-                            # 如果已存在翻译，跳过（保持第一个找到的）
-                            if en_tag not in self.en_to_cn:
-                                self.en_to_cn[en_tag] = cn_tag
-                            if cn_tag not in self.cn_to_en:
-                                self.cn_to_en[cn_tag] = en_tag
-                            count += 1
-            except Exception as e:
-                logger.error(f"[翻译系统] 角色CSV加载失败: {e}")
-    
-    def _build_underscore_variants(self):
-        """构建下划线变体映射，处理有无下划线的匹配问题"""
-        variants_to_add = {}
-        
-        for en_tag, cn_tag in list(self.en_to_cn.items()):
-            # 为有下划线的tag生成无下划线版本
-            if '_' in en_tag:
-                no_underscore = en_tag.replace('_', '')
-                if no_underscore not in self.en_to_cn:
-                    variants_to_add[no_underscore] = cn_tag
-            
-            # 为无下划线的tag生成可能的下划线版本（基于常见模式）
-            else:
-                # 在数字和字母之间添加下划线 (如: 1girl -> 1_girl)
-                with_underscore = re.sub(r'(\d)([a-zA-Z])', r'\1_\2', en_tag)
-                if with_underscore != en_tag and with_underscore not in self.en_to_cn:
-                    variants_to_add[with_underscore] = cn_tag
-        
-        # 添加变体到主字典
-        self.en_to_cn.update(variants_to_add)
-    
-    def _build_chinese_search_index(self):
-        """构建中文搜索索引，支持部分匹配"""
-        for cn_tag in self.cn_to_en.keys():
-            # 为中文tag的每个字符建立索引
-            for i, char in enumerate(cn_tag):
-                if char not in self.cn_search_index:
-                    self.cn_search_index[char] = set()
-                self.cn_search_index[char].add(cn_tag)
-                
-                # 也为子字符串建立索引（2-3字符的组合）
-                for length in [2, 3]:
-                    if i + length <= len(cn_tag):
-                        substring = cn_tag[i:i + length]
-                        if substring not in self.cn_search_index:
-                            self.cn_search_index[substring] = set()
-                        self.cn_search_index[substring].add(cn_tag)
-        
-        # 转换set为list以便JSON序列化
-        for key in self.cn_search_index:
-            self.cn_search_index[key] = list(self.cn_search_index[key])
-            
-    
-    def translate_tag(self, en_tag):
-        """翻译单个英文tag到中文"""
-        if not self.loaded:
-            self.load_translation_data()
-        
-        tag_key = en_tag.strip()
-        
-        # 检查缓存
-        if tag_key in self._translation_cache:
-            return self._translation_cache[tag_key]
-        
-        # 查找翻译
-        translation = self.en_to_cn.get(tag_key)
-        
-        # 添加到缓存
-        if len(self._translation_cache) < self.max_cache_size:
-            self._translation_cache[tag_key] = translation
-        
-        return translation
-    
-    def translate_tags_batch(self, en_tags):
-        """批量翻译英文tags"""
-        if not self.loaded:
-            self.load_translation_data()
-        
-        result = {}
-        for tag in en_tags:
-            translation = self.en_to_cn.get(tag.strip())
-            if translation:
-                result[tag] = translation
-        return result
-    
-    def search_chinese_tags(self, query, limit=10):
-        """搜索中文tag，返回匹配的中文tag及对应英文tag，支持模糊搜索"""
-        if not self.loaded:
-            self.load_translation_data()
-        
-        query = query.strip()
-        if not query:
-            return []
-        
-        # 检查搜索缓存
-        cache_key = f"{query}:{limit}"
-        if cache_key in self._search_cache:
-            return self._search_cache[cache_key]
-        
-        matches = {}  # 使用字典存储匹配结果和权重
-        
-        # 1. 精确匹配（权重10）
-        if query in self.cn_to_en:
-            matches[query] = 10
-        
-        # 2. 前缀匹配（权重8）
-        for cn_tag in self.cn_to_en.keys():
-            if cn_tag.startswith(query) and cn_tag not in matches:
-                matches[cn_tag] = 8
-        
-        # 3. 索引匹配（权重6）
-        if query in self.cn_search_index:
-            for cn_tag in self.cn_search_index[query]:
-                if cn_tag not in matches:
-                    matches[cn_tag] = 6
-        
-        # 4. 包含匹配（权重4）
-        for cn_tag in self.cn_to_en.keys():
-            if query in cn_tag and cn_tag not in matches:
-                matches[cn_tag] = 4
-        
-        # 5. 模糊匹配（权重2）- 支持字符顺序模糊匹配
-        if len(query) >= 2:
-            query_chars = set(query)
-            for cn_tag in self.cn_to_en.keys():
-                if cn_tag not in matches:
-                    tag_chars = set(cn_tag)
-                    # 如果查询字符的50%以上都在tag中，认为是模糊匹配
-                    if len(query_chars & tag_chars) / len(query_chars) >= 0.5:
-                        matches[cn_tag] = 2
-        
-        # 6. 部分字符匹配（权重1）
-        for char in query:
-            if char in self.cn_search_index:
-                for cn_tag in self.cn_search_index[char]:
-                    if cn_tag not in matches:
-                        matches[cn_tag] = 1
-        
-        # 按权重和长度排序
-        sorted_matches = sorted(matches.items(), key=lambda x: (-x[1], len(x[0])))
-        
-        # 转换为结果格式并限制数量
-        results = []
-        for cn_tag, weight in sorted_matches[:limit]:
-            en_tag = self.cn_to_en.get(cn_tag)
-            if en_tag:
-                results.append({
-                    'chinese': cn_tag,
-                    'english': en_tag,
-                    'weight': weight
-                })
-        
-        # 添加到缓存
-        if len(self._search_cache) < self.max_cache_size:
-            self._search_cache[cache_key] = results
-        
-        return results
-
-# 全局翻译系统实例
-translation_system = TagTranslationSystem()
-
-# 预加载翻译数据
-def preload_translation_data():
-    """预加载翻译数据，在服务器启动时调用"""
-    try:
-        success = translation_system.load_translation_data()
-        if not success:
-            logger.warning("[翻译系统] 预加载失败")
-    except Exception as e:
-        logger.error(f"[翻译系统] 预加载异常: {e}")
-
-# 在模块加载时预加载翻译数据
-preload_translation_data()
-
-def check_network_connection(source="danbooru"):
-    """Check network connectivity for the selected gallery source."""
-    adapter = get_site_adapter(source)
-    try:
-        # 使用一个简单的公开API端点来检测连接
-        if adapter.key == "gelbooru":
-            ui_settings = load_ui_settings()
-            session = _get_gelbooru_session(ui_settings.get("gelbooru_display_all_site_content", False))
-            response = session.get(
-                adapter.posts_url,
-                params=adapter.build_public_posts_params("", 1, 1, None),
-                timeout=(8, 10),
-            )
-            return response.status_code == 200, False
-
-        test_url = f"{BASE_URL}/posts.json?limit=1"
-        response = _danbooru_request("GET", test_url, timeout=10)
-        return response.status_code == 200, False
-    except requests.exceptions.Timeout:
-        logger.error("网络连接超时")
-        return False, True
-    except requests.exceptions.RequestException as e:
-        logger.error(f"网络连接失败: {e}")
-        return False, True
-    except Exception as e:
-        logger.error(f"网络检测发生未知错误: {e}")
-        return False, True
-
-def verify_danbooru_auth(username, api_key):
-    """验证Danbooru用户认证"""
-    if not username or not api_key:
-        return False, False
-    try:
-        test_url = f"{BASE_URL}/profile.json?login={username}&api_key={api_key}"
-        response = _danbooru_request("GET", test_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
-        is_valid = response.status_code == 200
-        return is_valid, False
-    except Exception as e:
-        logger.error(f"验证用户认证失败: {e}")
-        return False, True
-
-def get_user_favorites(username, api_key):
-    """获取用户的收藏列表"""
-    try:
-        favorites_url = f"{BASE_URL}/favorites.json?login={username}&api_key={api_key}"
-        response = _danbooru_request("GET", favorites_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
-        if response.status_code == 200:
-            return response.json()
-        return []
-    except Exception as e:
-        logger.error(f"获取用户收藏列表失败: {e}")
-        return []
-
-# --- 省略其他不相关的路由和函数以保持简洁 ---
-
-def get_gelbooru_favorites(user_id, api_key, limit=1000):
-    """Fetch Gelbooru favorite post IDs for the configured user."""
-    if not user_id or not api_key:
-        return []
-    if not str(user_id).isdigit():
-        raise ValueError("Gelbooru User ID must be numeric")
-
-    adapter = get_site_adapter("gelbooru")
-    credentials = {"user_id": user_id, "api_key": api_key}
-
-    # Gelbooru's documented favorite DAPI may return an empty list for valid API
-    # credentials, while the site's own favorites link uses the fav:<user_id> tag.
-    favorite_posts = []
-    page = 1
-    per_page = min(max(int(limit), 1), 100)
-    while len(favorite_posts) < limit:
-        params = adapter.build_posts_params(f"fav:{user_id}", per_page, page, None)
-        params = adapter.apply_auth_params(params, credentials)
-        response = _danbooru_request("GET", adapter.posts_url, params=params, timeout=15)
-        response.raise_for_status()
-        posts = adapter.normalize_posts_response(response.json())
-        if not posts:
-            break
-        favorite_posts.extend(str(post.get("id")) for post in posts if post.get("id"))
-        if len(posts) < per_page:
-            break
-        page += 1
-
-    if favorite_posts:
-        return favorite_posts[:limit]
-
-    all_ids = []
-    page = 1
-
-    while len(all_ids) < limit:
-        params = adapter.build_favorites_params(user_id, per_page, page)
-        params = adapter.apply_auth_params(params, credentials)
-        response = _danbooru_request("GET", adapter.posts_url, params=params, timeout=15)
-        if response.status_code == 401:
-            raise requests.exceptions.HTTPError("Gelbooru favorite API authentication failed", response=response)
-        response.raise_for_status()
-        page_ids = adapter.normalize_favorites_response(response.json())
-        if not page_ids:
-            break
-        all_ids.extend(page_ids)
-        if len(page_ids) < per_page:
-            break
-        page += 1
-
-    return all_ids[:limit]
-
-def add_gelbooru_favorite(post_id, user_id, api_key):
-    """Add a Gelbooru favorite via the site's favorite endpoint."""
-    if not user_id or not api_key:
-        return False, "请先在设置中配置 Gelbooru User ID 和 API Key"
-
-    session = _get_gelbooru_session(load_ui_settings().get("gelbooru_display_all_site_content", False))
-    response = session.get(
-        "https://gelbooru.com/public/addfav.php",
-        params={"id": str(post_id), "user_id": user_id, "api_key": api_key},
-        headers=_gelbooru_browser_headers("*/*"),
-        timeout=(8, 15),
-    )
-    response.raise_for_status()
-    body = (response.text or "").strip()
-    if body == "1":
-        return True, "已收藏，无需重复操作"
-    if body == "2":
-        return False, "Gelbooru 返回未登录；该站点的添加收藏接口可能不接受 API-only 认证"
-    return True, "收藏成功"
-
-def remove_gelbooru_favorite(post_id, user_id, api_key):
-    """Remove a Gelbooru favorite via the site's favorite page endpoint."""
-    if not user_id or not api_key:
-        return False, "请先在设置中配置 Gelbooru User ID 和 API Key"
-
-    session = _get_gelbooru_session(load_ui_settings().get("gelbooru_display_all_site_content", False))
-    response = session.get(
-        "https://gelbooru.com/index.php",
-        params={
-            "page": "favorites",
-            "s": "delete",
-            "id": str(post_id),
-            "user_id": user_id,
-            "api_key": api_key,
-        },
-        headers=_gelbooru_browser_headers("text/html,*/*"),
-        allow_redirects=False,
-        timeout=(8, 15),
-    )
-    if response.status_code in (200, 302, 303):
-        location = response.headers.get("Location", "")
-        if "account" in location and "login" in location:
-            return False, "Gelbooru 返回登录页；该站点的取消收藏接口可能不接受 API-only 认证"
-        return True, "取消收藏成功"
-    response.raise_for_status()
-    return True, "取消收藏成功"
-
-@PromptServer.instance.routes.post("/danbooru_gallery/favorites/add")
-async def add_favorite(request):
-    """添加收藏"""
-    try:
-        data = await request.json()
-        post_id = data.get("post_id")
-        source = data.get("source", "danbooru")
-        adapter = get_site_adapter(source)
-
-        if not post_id:
-            return web.json_response({"success": False, "error": "缺少post_id"})
-
-        if adapter.key == "gelbooru":
-            user_id, gelbooru_api_key = load_gelbooru_auth()
-            try:
-                ok, message = add_gelbooru_favorite(post_id, user_id, gelbooru_api_key)
-                return web.json_response({"success": ok, "message": message, "error": None if ok else message})
-            except requests.exceptions.Timeout:
-                logger.error("[Gelbooru] 添加收藏请求超时")
-                return web.json_response({"success": False, "error": "Gelbooru 收藏请求超时，请稍后重试"})
-            except requests.exceptions.RequestException as e:
-                logger.error(f"[Gelbooru] 添加收藏请求失败: {type(e).__name__}")
-                return web.json_response({"success": False, "error": "Gelbooru 收藏请求失败，请检查网络或稍后重试"})
-
-        username, api_key = load_user_auth()
-        if not username or not api_key:
-            return web.json_response({"success": False, "error": "请先在设置中配置用户名和API Key"})
-
-        # 验证认证
-        is_valid, is_network_error = verify_danbooru_auth(username, api_key)
-        if is_network_error:
-            return web.json_response({"success": False, "error": "网络错误，无法连接到Danbooru服务器"})
-        if not is_valid:
-            return web.json_response({"success": False, "error": "认证无效，请检查用户名和API Key"})
-
-        try:
-            favorite_url = f"{BASE_URL}/favorites.json?login={username}&api_key={api_key}"
-            response = _danbooru_request(
-                "POST",
-                favorite_url,
-                auth=HTTPBasicAuth(username, api_key),
-                data={"post_id": post_id},
-                timeout=15,
-            )
-
-
-            if response.status_code in [200, 201]:
-                favorites = load_favorites()
-                if str(post_id) not in favorites:
-                    favorites.append(str(post_id))
-                    save_favorites(favorites)
-                return web.json_response({"success": True, "message": "收藏成功"})
-            
-            try:
-                error_data = response.json()
-                reason = error_data.get("reason", "未知")
-                message = error_data.get("message", "没有提供具体信息")
-            except (json.JSONDecodeError, ValueError):
-                error_data = {}
-                reason = "无法解析响应"
-                message = response.text
-
-            if response.status_code == 422 and "You have already favorited this post" in message:
-                favorites = load_favorites()
-                if str(post_id) not in favorites:
-                    favorites.append(str(post_id))
-                    save_favorites(favorites)
-                return web.json_response({"success": True, "message": "已收藏，无需重复操作"})
-                
-            error_map = {
-                401: "认证失败，请检查用户名和API Key",
-                403: "权限不足，可能需要Gold账户或更高权限",
-                404: "图片不存在",
-                429: "请求过于频繁，请稍后重试 (Rate Limited)",
-            }
-            
-            error_message = error_map.get(response.status_code, f"收藏失败，状态码: {response.status_code}, 原因: {message}")
-            logger.error(error_message)
-            return web.json_response({"success": False, "error": error_message})
-
-        except requests.exceptions.Timeout:
-            logger.error("添加收藏时网络请求超时")
-            return web.json_response({"success": False, "error": "网络请求超时"})
-        except requests.exceptions.RequestException as e:
-            logger.error(f"添加收藏时网络请求失败: {e}")
-            return web.json_response({"success": False, "error": f"网络请求失败: {e}"})
-        except Exception as e:
-            import traceback
-            logger.error(f"添加收藏时发生严重错误: {e}")
-            logger.error(traceback.format_exc())
-            return web.json_response({"success": False, "error": f"服务器内部错误: {e}"}, status=500)
-
-    except Exception as e:
-        logger.error(f"添加收藏接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)}, status=500)
-
-@PromptServer.instance.routes.post("/danbooru_gallery/favorites/remove")
-async def remove_favorite(request):
-    """移除收藏"""
-    try:
-        data = await request.json()
-        post_id = data.get("post_id")
-        source = data.get("source", "danbooru")
-        adapter = get_site_adapter(source)
-
-        if not post_id:
-            return web.json_response({"success": False, "error": "缺少post_id"})
-
-        if adapter.key == "gelbooru":
-            user_id, gelbooru_api_key = load_gelbooru_auth()
-            try:
-                ok, message = remove_gelbooru_favorite(post_id, user_id, gelbooru_api_key)
-                return web.json_response({"success": ok, "message": message, "error": None if ok else message})
-            except requests.exceptions.Timeout:
-                logger.error("[Gelbooru] 取消收藏请求超时")
-                return web.json_response({"success": False, "error": "Gelbooru 取消收藏请求超时，请稍后重试"})
-            except requests.exceptions.RequestException as e:
-                logger.error(f"[Gelbooru] 取消收藏请求失败: {type(e).__name__}")
-                return web.json_response({"success": False, "error": "Gelbooru 取消收藏请求失败，请检查网络或稍后重试"})
-        
-        username, api_key = load_user_auth()
-        if not username or not api_key:
-            return web.json_response({"success": False, "error": "请先在设置中配置用户名和API Key"})
-
-        # 验证认证
-        is_valid, is_network_error = verify_danbooru_auth(username, api_key)
-        if is_network_error:
-            return web.json_response({"success": False, "error": "网络错误，无法连接到Danbooru服务器"})
-        if not is_valid:
-            return web.json_response({"success": False, "error": "认证无效，请检查用户名和API Key"})
-        
-        try:
-            # 直接使用帖子ID删除收藏
-            delete_url = f"{BASE_URL}/favorites/{post_id}.json?login={username}&api_key={api_key}"
-            delete_response = _danbooru_request("DELETE", delete_url, auth=HTTPBasicAuth(username, api_key), timeout=15)
-
-
-            if delete_response.status_code in [200, 204]:
-                favorites = load_favorites()
-                if str(post_id) in favorites:
-                    favorites.remove(str(post_id))
-                    save_favorites(favorites)
-                return web.json_response({"success": True, "message": "取消收藏成功"})
-            elif delete_response.status_code == 404:
-                # 如果收藏不存在，视为已删除
-                favorites = load_favorites()
-                if str(post_id) in favorites:
-                    favorites.remove(str(post_id))
-                    save_favorites(favorites)
-                return web.json_response({"success": True, "message": "该图片未在云端收藏，本地已同步"})
-
-            # 如果有收藏记录但删除失败，解析错误
-            try:
-                error_data = delete_response.json()
-                reason = error_data.get("reason", "未知")
-                message = error_data.get("message", "没有提供具体信息")
-            except (json.JSONDecodeError, ValueError):
-                error_data = {}
-                reason = "无法解析响应"
-                message = delete_response.text
-
-            error_map = {
-                401: "认证失败，请检查用户名和API Key",
-                403: "权限不足，可能需要Gold账户",
-                404: "收藏记录不存在",
-                429: "请求过于频繁，请稍后重试 (Rate Limited)",
-            }
-
-            error_message = error_map.get(delete_response.status_code, f"取消收藏失败，状态码: {delete_response.status_code}, 原因: {message}")
-            logger.error(error_message)
-            return web.json_response({"success": False, "error": error_message})
-
-        except requests.exceptions.Timeout:
-            logger.error("移除收藏时网络请求超时")
-            return web.json_response({"success": False, "error": "网络请求超时"})
-        except requests.exceptions.RequestException as e:
-            logger.error(f"移除收藏时网络请求失败: {e}")
-            return web.json_response({"success": False, "error": f"网络请求失败: {e}"})
-        except Exception as e:
-            import traceback
-            logger.error(f"移除收藏时发生严重错误: {e}")
-            logger.error(traceback.format_exc())
-            return web.json_response({"success": False, "error": f"服务器内部错误: {e}"}, status=500)
-
-    except Exception as e:
-        logger.error(f"移除收藏接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)}, status=500)
-
-@PromptServer.instance.routes.get("/danbooru_gallery/user_auth")
-async def get_user_auth_route(request):
-    """获取用户认证信息"""
-    try:
-        username, api_key = load_user_auth()
-        gelbooru_user_id, gelbooru_api_key = load_gelbooru_auth()
-        has_auth = bool(username and api_key)
-        return web.json_response({
-            "success": True,
-            "username": username,
-            "api_key": api_key,
-            "has_auth": has_auth,
-            "gelbooru_user_id": gelbooru_user_id,
-            "gelbooru_api_key": gelbooru_api_key,
-            "gelbooru_has_auth": bool(gelbooru_user_id and gelbooru_api_key)
-        })
-    except Exception as e:
-        logger.error(f"获取用户认证接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)}, status=500)
-
-@PromptServer.instance.routes.get("/danbooru_gallery/favorites")
-async def get_favorites_route(request):
-    """获取收藏列表"""
-    try:
-        source = request.query.get("source") or load_ui_settings().get("source_site", "danbooru")
-        adapter = get_site_adapter(source)
-        if adapter.key == "gelbooru":
-            user_id, gelbooru_api_key = load_gelbooru_auth()
-            if not user_id or not gelbooru_api_key:
-                return web.json_response({
-                    "success": False,
-                    "favorites": [],
-                    "source": adapter.key,
-                    "error": "请先在设置中配置 Gelbooru User ID 和 API Key"
-                })
-            try:
-                favorites = get_gelbooru_favorites(user_id, gelbooru_api_key)
-                return web.json_response({"success": True, "favorites": favorites, "source": adapter.key})
-            except requests.exceptions.Timeout:
-                logger.error("[Gelbooru] 获取收藏列表超时")
-                return web.json_response({
-                    "success": False,
-                    "favorites": [],
-                    "source": adapter.key,
-                    "error": "Gelbooru 收藏列表读取超时，请稍后重试"
-                })
-            except requests.exceptions.HTTPError as e:
-                status_code = e.response.status_code if e.response is not None else "unknown"
-                logger.error(f"[Gelbooru] 获取收藏列表失败: HTTP {status_code}")
-                return web.json_response({
-                    "success": False,
-                    "favorites": [],
-                    "source": adapter.key,
-                    "error": "Gelbooru 收藏列表读取失败，请检查 User ID/API Key 是否有效"
-                })
-            except ValueError as e:
-                logger.error(f"[Gelbooru] 收藏列表配置无效: {e}")
-                return web.json_response({
-                    "success": False,
-                    "favorites": [],
-                    "source": adapter.key,
-                    "error": "Gelbooru User ID 必须是数字 ID，不是用户名"
-                })
-            except requests.exceptions.RequestException as e:
-                logger.error(f"[Gelbooru] 获取收藏列表请求失败: {type(e).__name__}")
-                return web.json_response({
-                    "success": False,
-                    "favorites": [],
-                    "source": adapter.key,
-                    "error": "Gelbooru 收藏列表请求失败，请检查网络或稍后重试"
-                })
-
-        favorites = load_favorites()
-        return web.json_response({"success": True, "favorites": favorites, "source": adapter.key})
-    except Exception as e:
-        logger.error(f"获取收藏列表接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)}, status=500)
-
-@PromptServer.instance.routes.post("/danbooru_gallery/user_auth")
-async def save_user_auth_route(request):
-    """保存用户认证信息"""
-    try:
-        data = await request.json()
-        username = data.get("username", "")
-        api_key = data.get("api_key", "")
-        gelbooru_user_id = data.get("gelbooru_user_id", "")
-        gelbooru_api_key = data.get("gelbooru_api_key", "")
-        if save_user_auth(username, api_key) and save_gelbooru_auth(gelbooru_user_id, gelbooru_api_key):
-            return web.json_response({"success": True})
-        else:
-            return web.json_response({"success": False, "error": "无法保存用户认证信息"}, status=500)
-    except Exception as e:
-        logger.error(f"保存用户认证接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)}, status=500)
-
-@PromptServer.instance.routes.get("/danbooru_gallery/check_network")
-async def check_network(request):
-    """检测网络连接状态"""
-    try:
-        source = request.query.get("source") or load_ui_settings().get("source_site", "danbooru")
-        adapter = get_site_adapter(source)
-        is_connected, is_network_error = check_network_connection(adapter.key)
-        return web.json_response({
-            "success": True,
-            "connected": is_connected,
-            "network_error": is_network_error,
-            "source": adapter.key
-        })
-    except Exception as e:
-        logger.error(f"网络检测接口错误: {e}")
-        return web.json_response({"success": False, "error": "网络检测失败", "network_error": True}, status=500)
-
-@PromptServer.instance.routes.post("/danbooru_gallery/verify_auth")
-async def verify_auth(request):
-    """验证用户认证"""
-    try:
-        data = await request.json()
-        username = data.get("username", "")
-        api_key = data.get("api_key", "")
-
-        if not username or not api_key:
-            return web.json_response({"success": False, "error": "缺少用户名或API Key"})
-
-        is_valid, is_network_error = verify_danbooru_auth(username, api_key)
-        return web.json_response({"success": True, "valid": is_valid, "network_error": is_network_error})
-    except Exception as e:
-        logger.error(f"验证认证接口错误: {e}")
-        return web.json_response({"success": False, "error": "网络错误", "network_error": True}, status=500)
-
-# 图片代理并发上限：浏览器一次打开一页会 lazy-load 多张缩略图，没有上限会导致
-# 后端同时发出十几个 CDN 请求，配合全局限流会形成长队列；限到 3 并发即可让缩略图
-# 平滑流入，又避免瞬时流量把 CF 的 rate rule 触发。
-_image_proxy_semaphore = None
-_gelbooru_session = None
-_gelbooru_session_display_all = None
-_gelbooru_session_lock = threading.Lock()
-
-def _get_image_proxy_semaphore():
-    global _image_proxy_semaphore
-    if _image_proxy_semaphore is None:
-        _image_proxy_semaphore = asyncio.Semaphore(1)
-    return _image_proxy_semaphore
-
-def _gelbooru_browser_headers(accept="text/html,*/*"):
-    return {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36",
-        "Accept": accept,
-        "Referer": "https://gelbooru.com/",
-    }
-
-def _gelbooru_set_cookie(session, name, value):
-    for domain in ("gelbooru.com", ".gelbooru.com"):
-        session.cookies.set(name, value, domain=domain, path="/")
-
-def _gelbooru_public_page_requires_options(html_text):
-    """Detect Gelbooru's anonymous page that says results are hidden by site options."""
-    if not html_text:
-        return False
-    return (
-        "Check your blacklist" in html_text
-        and "Nobody here but us" in html_text
-    )
-
-def _configure_gelbooru_display_all_session(session):
-    """Apply Gelbooru anonymous options for fringe/gore searches."""
-    _gelbooru_set_cookie(session, "fringeBenefits", "yup")
-    _gelbooru_set_cookie(session, "post_threshold", "0")
-    _gelbooru_set_cookie(session, "comment_threshold", "0")
-
-    options_response = session.get(
-        "https://gelbooru.com/index.php",
-        params={"page": "account", "s": "options"},
-        timeout=(8, 15),
-    )
-    options_response.raise_for_status()
-
-    csrf_match = re.search(r'name=["\']csrf-token["\']\s+value=["\']([^"\']+)["\']', options_response.text, re.IGNORECASE)
-    csrf_token = csrf_match.group(1) if csrf_match else ""
-    if not csrf_token:
-        logger.warning("[Gelbooru] options CSRF token was not found; Display all site content may not persist")
-
-    response = session.post(
-        "https://gelbooru.com/index.php?page=account&s=options",
-        data={
-            "tags": "",
-            "fringeBenefits": "on",
-            "cthreshold": "0",
-            "pthreshold": "0",
-            "my_tags": "",
-            "ad_type[]": ["1", "2", "3"],
-            "show_comments": "on",
-            "searchPostView": "on",
-            "csrf-token": csrf_token,
-            "submit": "Save",
-        },
-        timeout=(8, 15),
-    )
-    response.raise_for_status()
-
-    _gelbooru_set_cookie(session, "fringeBenefits", "yup")
-    _gelbooru_set_cookie(session, "post_threshold", "0")
-    _gelbooru_set_cookie(session, "comment_threshold", "0")
-
-    fringe_enabled = bool(re.search(r'name=["\']fringeBenefits["\'][^>]*checked', response.text, re.IGNORECASE))
-    blacklist_empty = bool(re.search(r'<textarea\b[^>]*\bid=["\']tags["\'][^>]*>\s*</textarea>', response.text, re.IGNORECASE))
-    if fringe_enabled:
-        logger.info("[Gelbooru] Display all site content enabled for anonymous session")
-    else:
-        logger.warning("[Gelbooru] Display all site content submitted, but options page did not show it as checked")
-    if not blacklist_empty:
-        logger.warning("[Gelbooru] Tag blacklist may not be empty after options submit")
-
-def _get_gelbooru_session(display_all_site_content=False, force_refresh=False):
-    """Return a Gelbooru session, optionally enabling the public fringe content option."""
-    global _gelbooru_session, _gelbooru_session_display_all
-
-    display_all_site_content = bool(display_all_site_content)
-    with _gelbooru_session_lock:
-        if not force_refresh and _gelbooru_session is not None and _gelbooru_session_display_all == display_all_site_content:
-            return _gelbooru_session
-
-        session = requests.Session()
-        session.headers.update(_gelbooru_browser_headers())
-
-        if display_all_site_content:
-            try:
-                _configure_gelbooru_display_all_session(session)
-            except requests.exceptions.RequestException as e:
-                logger.warning(f"[Gelbooru] Failed to enable Display all site content; continuing with normal session: {e}")
-        if False and display_all_site_content:
-            session.cookies.set("fringeBenefits", "yup", domain="gelbooru.com", path="/")
-            try:
-                options_response = session.get(
-                    "https://gelbooru.com/index.php",
-                    params={"page": "account", "s": "options"},
-                    timeout=(8, 15),
-                )
-                csrf_match = re.search(r'name=["\']csrf-token["\']\s+value=["\']([^"\']+)["\']', options_response.text, re.IGNORECASE)
-                csrf_token = csrf_match.group(1) if csrf_match else ""
-                if not csrf_token:
-                    logger.warning("[Gelbooru] 未找到 options CSRF token，Display all site content 可能无法保存")
-
-                response = session.post(
-                    "https://gelbooru.com/index.php?page=account&s=options",
-                    data={
-                        "tags": "",
-                        "fringeBenefits": "on",
-                        "cthreshold": "0",
-                        "pthreshold": "0",
-                        "my_tags": "",
-                        "ad_type[]": ["1", "2", "3"],
-                        "show_comments": "on",
-                        "searchPostView": "on",
-                        "csrf-token": csrf_token,
-                        "submit": "Save",
+import { app } from "/scripts/app.js";
+import { $el } from "/scripts/ui.js";
+import { globalAutocompleteCache } from "../global/autocomplete_cache.js";
+import { AutocompleteUI } from "../global/autocomplete_ui.js";
+import { toastManagerProxy } from "../global/toast_manager.js";
+import { globalMultiLanguageManager } from "../global/multi_language.js";
+
+import { createLogger, loggerClient } from '../global/logger_client.js';
+
+// 创建logger实例
+const logger = createLogger('danbooru_gallery');
+
+app.registerExtension({
+    name: "Comfy.DanbooruGallery",
+    async beforeRegisterNodeDef(nodeType, nodeData) {
+        if (nodeData.name === "DanbooruGalleryNode") {
+            // 使用全局多语言系统（danbooru命名空间）
+            const t = (key) => globalMultiLanguageManager.t(`danbooru.${key}`);
+
+            // 本地存储函数
+            const saveToLocalStorage = (key, value) => {
+                try {
+                    localStorage.setItem(`danbooru_gallery_${key}`, JSON.stringify(value));
+                } catch (e) {
+                    logger.warn(`[Danbooru Gallery] Failed to save to localStorage: ${key}`, e);
+                }
+            };
+
+            const loadFromLocalStorage = (key, defaultValue) => {
+                try {
+                    const item = localStorage.getItem(`danbooru_gallery_${key}`);
+                    return item ? JSON.parse(item) : defaultValue;
+                } catch (e) {
+                    logger.warn(`[Danbooru Gallery] Failed to load from localStorage: ${key}`, e);
+                    return defaultValue;
+                }
+            };
+
+            // 比较两个标签字符串是否相同（忽略标签顺序）
+            const compareTagStrings = (str1, str2) => {
+                // 处理null、undefined和空字符串的情况
+                if (!str1 && !str2) return true;
+                if (!str1 || !str2) return false;
+
+                // 分割、排序、比较
+                const tags1 = str1.trim().split(/\s+/).filter(t => t).sort();
+                const tags2 = str2.trim().split(/\s+/).filter(t => t).sort();
+
+                // 数量不同直接返回false
+                if (tags1.length !== tags2.length) return false;
+
+                // 逐个比较标签
+                return tags1.every((tag, index) => tag === tags2[index]);
+            };
+
+            const onNodeCreated = nodeType.prototype.onNodeCreated;
+            nodeType.prototype.onNodeCreated = function () {
+                onNodeCreated?.apply(this, arguments);
+                this.setSize([780, 938]);
+
+                // 保存节点实例引用
+                const nodeInstance = this;
+
+                // 存储每张图片的原始标签数据，用于重置和编辑状态判断
+                const originalPostCache = {};
+
+                // 创建隐藏的 selection_data widget（仍保留用于兼容/回退）
+                const selectionWidget = this.addWidget("text", "selection_data", JSON.stringify({}), () => { }, {
+                    serialize: true // 确保序列化
+                });
+
+                // 确保widget不可见
+                if (selectionWidget) {
+                    selectionWidget.computeSize = () => [0, -4]; // 返回0宽度和负高度来隐藏
+                    selectionWidget.draw = () => { }; // 覆盖draw方法，不绘制任何内容
+                    selectionWidget.type = "hidden"; // 设置为隐藏类型
+                    Object.defineProperty(selectionWidget, 'hidden', { value: true, writable: false }); // 标记为隐藏
+                }
+
+                // 创建隐藏的 filter_data widget
+                const filterWidget = this.addWidget("text", "filter_data", JSON.stringify({ startTime: null, endTime: null, startPage: null }), () => { }, {
+                    serialize: true // 确保序列化
+                });
+
+                // 确保widget不可见
+                if (filterWidget) {
+                    filterWidget.computeSize = () => [0, -4];
+                    filterWidget.draw = () => { };
+                    filterWidget.type = "hidden";
+                    Object.defineProperty(filterWidget, 'hidden', { value: true, writable: false });
+                }
+
+                const container = $el("div.danbooru-gallery");
+                container.style.boxSizing = "border-box";
+
+                // 添加错误显示区域
+                const errorDisplay = $el("div.danbooru-error-display", {
+                    style: {
+                        display: "none",
+                        color: "#dc3545",
+                        marginBottom: "10px",
+                        padding: "8px 12px",
+                        border: "1px solid #dc3545",
+                        borderRadius: "4px",
+                        backgroundColor: "rgba(220, 53, 69, 0.1)",
+                        fontSize: "14px",
+                        fontWeight: "500"
+                    }
+                });
+                container.appendChild(errorDisplay);
+
+                // 添加tag提示显示区域
+                const tagHintDisplay = $el("div.danbooru-tag-hint-display", {
+                    style: {
+                        display: "none",
+                        color: "#17a2b8",
+                        marginBottom: "5px",
+                        padding: "6px 10px",
+                        border: "1px solid #17a2b8",
+                        borderRadius: "4px",
+                        backgroundColor: "rgba(23, 162, 184, 0.1)",
+                        fontSize: "13px",
+                        fontWeight: "500"
+                    }
+                });
+                container.appendChild(tagHintDisplay);
+
+                // 显示错误信息的函数
+                const showError = (message, persistent = false, anchorElement = null) => {
+                    showToast(message, 'error');
+                };
+
+                // 清除错误信息的函数
+                const clearError = () => {
+                    errorDisplay.style.display = "none";
+                };
+
+                // 显示tag提示信息的函数
+                const showTagHint = (message, persistent = false) => {
+                    tagHintDisplay.textContent = message;
+                    tagHintDisplay.style.display = "block";
+                    if (!persistent) {
+                        // 3秒后自动隐藏
+                        setTimeout(() => {
+                            tagHintDisplay.style.display = "none";
+                        }, 3000);
+                    }
+                };
+
+                // 清除tag提示信息的函数
+                const clearTagHint = () => {
+                    tagHintDisplay.style.display = "none";
+                };
+
+                // 检查网络连接状态（30s TTL：上次成功且 30s 内则跳过完整网络往返）
+                const NETWORK_CHECK_TTL = 30000;
+                const checkNetworkStatus = async () => {
+                    if (networkStatus.connected && networkStatus.lastChecked &&
+                        (Date.now() - networkStatus.lastChecked) < NETWORK_CHECK_TTL) {
+                        return true;
+                    }
+                    try {
+                        const source = uiSettings.source_site || "danbooru";
+                        const response = await fetch(`/danbooru_gallery/check_network?source=${encodeURIComponent(source)}`);
+                        const data = await response.json();
+                        const isConnected = data.success && data.connected;
+                        const now = Date.now();
+
+                        // 更新网络状态
+                        networkStatus.connected = isConnected;
+                        networkStatus.lastChecked = now;
+
+                        return isConnected;
+                    } catch (e) {
+                        logger.warn('网络检测失败:', e);
+                        networkStatus.connected = false;
+                        networkStatus.lastChecked = Date.now();
+                        return false;
+                    }
+                };
+
+                this.addDOMWidget("danbooru_gallery_widget", "div", container, {
+                    onDraw: () => { }
+                });
+
+
+                // 确保在 widget 渲染后调整大小
+                setTimeout(() => {
+                    this.onResize(this.size);
+                }, 10);
+
+                let globalTooltip, globalTooltipTimeout;
+                let currentTooltipId = 0; // 用于追踪当前活动的tooltip请求
+                let posts = [], currentPage = 1, isLoading = false, endOfResults = false;
+                let lastPostId = null;
+                let scrollAnchorPostId = null;
+                const seenPostIds = new Set();
+                let selectionQueueId = 0; // FIFO 队列唯一 ID 计数器
+                const nodeInstanceId = crypto.randomUUID ? crypto.randomUUID() : 'node_' + Math.random().toString(36).slice(2, 10);
+                // 标记自己为最后活跃节点（自己节点上的任何交互都更新全局指针）
+                const markActive = () => { window.__lastActiveGalleryNodeId = nodeInstanceId; };
+                let filterState = { startTime: null, endTime: null, startPage: null };
+                let userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false }; // 用户认证信息
+                let userFavorites = []; // 用户收藏列表，确保字符串
+                let networkStatus = { connected: true, lastChecked: 0 }; // 网络状态跟踪
+                let previousSearchValue = ""; // 跟踪搜索框之前的值，用于检测清空操作
+                let temporaryTagEdits = {}; // Keyed by post.id
+
+                // 用户认证管理功能
+                const loadUserAuth = async () => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/user_auth');
+                        const data = await response.json();
+                        userAuth = data;
+                        return data;
+                    } catch (e) {
+                        logger.warn("加载用户认证信息失败:", e);
+                        userAuth = { username: "", api_key: "", has_auth: false, gelbooru_user_id: "", gelbooru_api_key: "", gelbooru_has_auth: false };
+                        return userAuth;
+                    }
+                };
+
+                const saveUserAuth = async (username, api_key, gelbooru_user_id = "", gelbooru_api_key = "") => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/user_auth', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({ username: username, api_key: api_key, gelbooru_user_id, gelbooru_api_key })
+                        });
+                        const data = await response.json();
+                        if (data.success) {
+                            userAuth = {
+                                username,
+                                api_key,
+                                has_auth: Boolean(username && api_key),
+                                gelbooru_user_id,
+                                gelbooru_api_key,
+                                gelbooru_has_auth: Boolean(gelbooru_user_id && gelbooru_api_key)
+                            };
+                        }
+                        return data;
+                    } catch (e) {
+                        logger.warn("保存用户认证信息失败:", e);
+                        return { success: false, error: "网络错误" };
+                    }
+                };
+
+                // 显示提示消息功能
+                const showToast = (message, type = 'info', anchorElement = null) => {
+                    // 使用全局toast管理器，并根据类型设置对应的等级
+                    const toastLevel = getToastLevel(type);
+                    const options = anchorElement ? { targetElement: anchorElement } : {};
+
+                    toastManagerProxy.showToast(message, toastLevel, 3000, options);
+                };
+
+                const currentSource = () => uiSettings.source_site || "danbooru";
+                const hasFavoriteAuth = () => (
+                    currentSource() === "gelbooru"
+                        ? Boolean(userAuth.gelbooru_has_auth)
+                        : Boolean(userAuth.has_auth)
+                );
+                const currentFavoriteTag = () => (
+                    currentSource() === "gelbooru"
+                        ? `fav:${userAuth.gelbooru_user_id || ""}`
+                        : `ordfav:${userAuth.username || ""}`
+                );
+
+                const getToastLevel = (type) => {
+                    // 将toast类型映射到全局toast管理器的等级
+                    const levelMap = {
+                        'success': 'success',
+                        'error': 'error',
+                        'warning': 'warning',
+                        'info': 'info'
+                    };
+                    return levelMap[type] || 'info';
+                };
+
+                // 收藏管理功能
+                const addToFavorites = async (postId, button = null) => {
+                    if (!hasFavoriteAuth()) {
+                        showToast(t('authRequired'), 'warning');
+                        return { success: false, error: t('authRequired') };
+                    }
+
+                    // 显示加载状态
+                    if (button) {
+                        button.disabled = true;
+                        const originalHTML = button.innerHTML;
+                        button.innerHTML = '<div class="spinner"></div>';
+                        button.dataset.originalHTML = originalHTML;
+                    }
+
+                    try {
+                        const response = await fetch('/danbooru_gallery/favorites/add', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({ post_id: postId, source: currentSource() })
+                        });
+                        const data = await response.json();
+
+                        // 恢复按钮状态
+                        if (button) {
+                            button.disabled = false;
+                            if (data.success || data.message === "已收藏，无需重复操作") {
+                                button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="#DC3545" stroke="#DC3545" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+                                </svg>`;
+                                button.title = t('unfavorite');
+                                button.classList.add('favorited');
+                                if (!userFavorites.includes(String(postId))) {
+                                    userFavorites.push(String(postId));
+                                }
+                                // 显示收藏成功提示
+                                showToast(t('favorite') + '成功', 'success', button);
+                            } else {
+                                button.innerHTML = button.dataset.originalHTML || originalHTML;
+                            }
+                            delete button.dataset.originalHTML;
+                        }
+
+                        if (!data.success) {
+                            let errorMsg = data.error || "未知错误";
+                            if (data.error.includes("网络错误")) {
+                                showError(`${errorMsg} - 请检查网络连接`);
+                            } else if (data.error.includes("认证") || data.error.includes("401")) {
+                                errorMsg = `${errorMsg}\n\n${t('authRequired')}`;
+                                if (confirm(errorMsg + "\n\n是否打开设置？")) {
+                                    showSettingsDialog();
+                                }
+                            } else if (data.error.includes("Rate Limited") || data.error.includes("429")) {
+                                showError(`${errorMsg} - 请稍后重试`);
+                            } else {
+                                showError(errorMsg);
+                            }
+                        }
+
+                        return data;
+                    } catch (e) {
+                        logger.warn("添加收藏失败:", e);
+                        showError(`网络错误 - 无法连接到${currentSource() === "gelbooru" ? "Gelbooru" : "Danbooru"}服务器`);
+                        if (button) {
+                            button.disabled = false;
+                            button.innerHTML = button.dataset.originalHTML || '<svg>...</svg>';  // 恢复
+                            delete button.dataset.originalHTML;
+                        }
+                        return { success: false, error: "网络错误" };
+                    }
+                };
+
+                const removeFromFavorites = async (postId, button = null) => {
+                    if (!hasFavoriteAuth()) {
+                        showToast(t('authRequired'), 'warning');
+                        return { success: false, error: t('authRequired') };
+                    }
+
+                    // 显示加载状态
+                    if (button) {
+                        button.disabled = true;
+                        const originalHTML = button.innerHTML;
+                        button.innerHTML = '<div class="spinner"></div>';
+                        button.dataset.originalHTML = originalHTML;
+                    }
+
+                    try {
+                        const response = await fetch('/danbooru_gallery/favorites/remove', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({ post_id: postId, source: currentSource() })
+                        });
+                        let data;
+                        if (response.status === 204) {
+                            // 204 No Content 表示成功，但没有响应体
+                            data = { success: true, message: "取消收藏成功" };
+                        } else {
+                            data = await response.json();
+                        }
+
+                        // 恢复按钮状态
+                        if (button) {
+                            button.disabled = false;
+                            if (data.success) {
+                                button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+                                </svg>`;
+                                button.title = t('favorite');
+                                button.classList.remove('favorited');
+                                const index = userFavorites.indexOf(String(postId));
+                                if (index > -1) {
+                                    userFavorites.splice(index, 1);
+                                }
+                                // 显示取消收藏成功提示
+                                showToast(t('unfavorite') + '成功', 'success', button);
+                            } else {
+                                button.innerHTML = button.dataset.originalHTML || originalHTML;
+                            }
+                            delete button.dataset.originalHTML;
+                        }
+
+                        if (!data.success) {
+                            let errorMsg = data.error || "未知错误";
+                            if (data.error.includes("网络错误")) {
+                                showError(`${errorMsg} - 请检查网络连接`);
+                            } else if (data.error.includes("认证") || data.error.includes("401")) {
+                                errorMsg = `${errorMsg}\n\n${t('authRequired')}`;
+                                if (confirm(errorMsg + "\n\n是否打开设置？")) {
+                                    showSettingsDialog();
+                                }
+                            } else if (data.error.includes("Rate Limited") || data.error.includes("429")) {
+                                showError(`${errorMsg} - 请稍后重试`);
+                            } else {
+                                showError(errorMsg);
+                            }
+                        }
+
+                        return data;
+                    } catch (e) {
+                        logger.warn("移除收藏失败:", e);
+                        showError(`网络错误 - 无法连接到${currentSource() === "gelbooru" ? "Gelbooru" : "Danbooru"}服务器`);
+                        if (button) {
+                            button.disabled = false;
+                            button.innerHTML = button.dataset.originalHTML || '<svg>...</svg>';
+                            delete button.dataset.originalHTML;
+                        }
+                        return { success: false, error: "网络错误" };
+                    }
+                };
+
+                const loadFavorites = async () => {
+                    try {
+                        const response = await fetch(`/danbooru_gallery/favorites?source=${encodeURIComponent(currentSource())}`);
+                        const data = await response.json();
+                        if (!data.success) {
+                            const errorMsg = data.error || "收藏列表读取失败";
+                            logger.warn("加载收藏列表失败:", errorMsg);
+                            if (hasFavoriteAuth()) {
+                                showToast(errorMsg, "warning");
+                            }
+                            userFavorites = [];
+                            return userFavorites;
+                        }
+                        userFavorites = (data.favorites || []).map(id => String(id));
+                        return userFavorites;
+                    } catch (e) {
+                        logger.warn("加载收藏列表失败:", e);
+                        userFavorites = [];
+                        return userFavorites;
+                    }
+                };
+
+                // 语言管理功能
+                const loadLanguage = async () => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/language');
+                        const data = await response.json();
+                        globalMultiLanguageManager.setLanguage(data.language || 'zh', true);
+                    } catch (e) {
+                        logger.warn("加载语言设置失败:", e);
+                        globalMultiLanguageManager.setLanguage('zh', true);
+                    }
+                };
+
+                const saveLanguage = async (language) => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/language', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({ language: language })
+                        });
+                        const data = await response.json();
+                        return data.success;
+                    } catch (e) {
+                        logger.warn("保存语言设置失败:", e);
+                        return false;
+                    }
+                };
+
+                // 更新界面文本
+                const updateInterfaceTexts = () => {
+                    // 更新搜索框
+                    searchInput.placeholder = t('searchPlaceholder');
+
+                    // 更新按钮文本和提示
+                    const categoryButton = categoryDropdown.querySelector('.danbooru-category-button');
+                    if (categoryButton) {
+                        categoryButton.innerHTML = `${t('categories')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
+                        categoryButton.title = t('categoriestooltip');
+                    }
+
+                    const formattingButton = formattingDropdown.querySelector('.danbooru-category-button');
+                    if (formattingButton) {
+                        formattingButton.innerHTML = `${t('formatting')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
+                        formattingButton.title = t('formattingTooltip');
+                    }
+
+                    const ratingButton = ratingSelect.querySelector('.danbooru-category-button');
+                    if (ratingButton) {
+                        ratingButton.title = t('ratingTooltip');
+                        updateRatingButtonLabel();
+                    }
+
+                    // 更新分级选项
+                    const ratingLabels = ratingSelect.querySelectorAll('.danbooru-category-item label');
+                    ratingLabels.forEach((label) => {
+                        const key = label.dataset.ratingKey;
+                        if (key) {
+                            label.textContent = t(key);
+                        }
+                    });
+
+                    // 更新类别标签
+                    const categoryItems = categoryDropdown.querySelectorAll('.danbooru-category-item label');
+                    const categoryKeys = ['artist', 'copyright', 'character', 'general', 'meta'];
+                    categoryItems.forEach((label, index) => {
+                        if (categoryKeys[index]) {
+                            label.textContent = t(categoryKeys[index]);
+                        }
+                    });
+
+                    // 更新格式选项
+                    const formatItems = formattingDropdown.querySelectorAll('.danbooru-category-item label');
+                    if (formatItems.length >= 2) {
+                        formatItems[0].textContent = t('escapeBrackets');
+                        formatItems[1].textContent = t('replaceUnderscores');
+                    }
+
+                    // 更新按钮tooltip
+                    rankingButton.title = t('rankingTooltip');
+                    favoritesButton.title = t('favorites');
+                    refreshButton.title = t('refreshTooltip');
+                    settingsButton.title = t('settings');
+                    filterButton.title = t('filterTooltip');
+
+                    // 更新排行榜按钮文本
+                    const rankingIcon = rankingButton.querySelector('.icon');
+                    if (rankingIcon) {
+                        rankingButton.innerHTML = rankingIcon.outerHTML + t('ranking');
+                    }
+
+                    // 更新收藏夹按钮文本
+                    const favoritesIcon = favoritesButton.querySelector('.icon');
+                    if (favoritesIcon) {
+                        favoritesButton.innerHTML = favoritesIcon.outerHTML + t('favorites');
+                    }
+
+                    // 更新加载状态文本
+                    const loadingElement = imageGrid.querySelector('.danbooru-loading');
+                    if (loadingElement) {
+                        loadingElement.textContent = t('loading');
+                    }
+
+                    // 更新侧边栏按钮文本（如果设置对话框已打开）
+                    const sidebarButtons = document.querySelectorAll('.sidebar-button');
+                    sidebarButtons.forEach(button => {
+                        const key = button.dataset.key;
+                        if (key) {
+                            const titleSpan = button.querySelector('.sidebar-button-title');
+                            if (titleSpan) {
+                                titleSpan.textContent = t(key + 'Section');
+                            }
+                        }
+                    });
+                };
+
+                const searchInput = $el("input.danbooru-search-input", { type: "text", placeholder: t('searchPlaceholder'), title: t('searchPlaceholder') });
+                const SOURCE_SITES = [
+                    { value: "danbooru", label: "Danbooru" },
+                    { value: "gelbooru", label: "Gelbooru" },
+                ];
+                const sourceSelect = $el("select.danbooru-source-select", {
+                    title: t('sourceTooltip')
+                }, SOURCE_SITES.map(site => $el("option", {
+                    value: site.value,
+                    textContent: site.label
+                })));
+                const displayAllSiteContentToggle = $el("label.danbooru-gelbooru-display-all-toggle", {
+                    title: t('displayAllSiteContentTooltip'),
+                    style: { display: "none" }
+                }, [
+                    $el("input", { type: "checkbox" }),
+                    $el("span", { textContent: t('displayAllSiteContent') })
+                ]);
+                const updateSourceState = () => {
+                    const selectedSource = uiSettings.source_site || "danbooru";
+                    sourceSelect.value = selectedSource;
+                    const favoritesDisabled = false;
+                    favoritesButton.disabled = favoritesDisabled;
+                    favoritesButton.style.opacity = favoritesDisabled ? "0.45" : "";
+                    favoritesButton.title = favoritesDisabled ? t('sourceFavoritesUnsupported') : t('favorites');
+                    displayAllSiteContentToggle.style.display = selectedSource === "gelbooru" ? "inline-flex" : "none";
+                    const displayAllInput = displayAllSiteContentToggle.querySelector("input");
+                    if (displayAllInput) {
+                        displayAllInput.checked = Boolean(uiSettings.gelbooru_display_all_site_content);
+                    }
+                };
+                const RATING_VALUES = ["general", "sensitive", "questionable", "explicit"];
+                const TAG_CATEGORY_ORDER = ["artist", "copyright", "character", "general", "meta"];
+                const normalizePostRating = (rating) => {
+                    const map = { g: "general", s: "sensitive", q: "questionable", e: "explicit" };
+                    return map[rating] || rating;
+                };
+                const createRatingDropdown = () => {
+                    const createRatingCheckbox = (name, checked = false) => {
+                        const id = `danbooru-rating-${name}`;
+                        const checkbox = $el("input", {
+                            type: "checkbox",
+                            id,
+                            name,
+                            checked,
+                            className: "danbooru-category-checkbox danbooru-rating-checkbox"
+                        });
+
+                        return $el("div.danbooru-category-item", [
+                            checkbox,
+                            $el("label", { htmlFor: id, textContent: t(name), dataset: { ratingKey: name } })
+                        ]);
+                    };
+
+                    const allId = "danbooru-rating-all";
+                    const allCheckbox = $el("input", {
+                        type: "checkbox",
+                        id: allId,
+                        name: "__all__",
+                        checked: true,
+                        className: "danbooru-category-checkbox danbooru-rating-checkbox danbooru-rating-all-checkbox"
+                    });
+                    const allItem = $el("div.danbooru-category-item", [
+                        allCheckbox,
+                        $el("label", { htmlFor: allId, textContent: t('all'), dataset: { ratingKey: 'all' } })
+                    ]);
+
+                    const listItems = [
+                        allItem,
+                        createRatingCheckbox("general"),
+                        createRatingCheckbox("sensitive"),
+                        createRatingCheckbox("questionable"),
+                        createRatingCheckbox("explicit")
+                    ];
+
+                    const dropdown = $el("div.danbooru-rating-dropdown.danbooru-category-dropdown", [
+                        $el("button.danbooru-category-button", {
+                            innerHTML: `${t('all')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`,
+                            title: t('ratingTooltip')
+                        }),
+                        $el("div.danbooru-category-list", {}, listItems)
+                    ]);
+
+                    return dropdown;
+                };
+
+                const ratingSelect = createRatingDropdown();
+                const getSelectedRatings = () => {
+                    return Array.from(ratingSelect.querySelectorAll(".danbooru-rating-checkbox:checked"))
+                        .map(i => i.name)
+                        .filter(name => name !== "__all__");
+                };
+                const updateRatingButtonLabel = () => {
+                    const ratingButton = ratingSelect.querySelector('.danbooru-category-button');
+                    if (!ratingButton) return;
+
+                    const selectedRatings = getSelectedRatings();
+                    let buttonText = t('all');
+                    if (selectedRatings.length === 1) {
+                        buttonText = t(selectedRatings[0]);
+                    } else if (selectedRatings.length > 1 && selectedRatings.length < RATING_VALUES.length) {
+                        buttonText = selectedRatings.map(r => t(r)).join(" / ");
+                    }
+
+                    ratingButton.dataset.values = JSON.stringify(selectedRatings);
+                    ratingButton.innerHTML = `${buttonText} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
+                };
+                const applySelectedRatings = (selectedRatings = RATING_VALUES) => {
+                    const targetRatings = (Array.isArray(selectedRatings) && selectedRatings.length > 0)
+                        ? selectedRatings.filter(v => RATING_VALUES.includes(v))
+                        : [...RATING_VALUES];
+
+                    const allCheckbox = ratingSelect.querySelector('.danbooru-rating-all-checkbox');
+                    const ratingCheckboxes = ratingSelect.querySelectorAll('.danbooru-rating-checkbox:not(.danbooru-rating-all-checkbox)');
+                    ratingCheckboxes.forEach((checkbox) => {
+                        checkbox.checked = targetRatings.includes(checkbox.name);
+                    });
+                    if (allCheckbox) {
+                        allCheckbox.checked = targetRatings.length === RATING_VALUES.length;
+                    }
+                    updateRatingButtonLabel();
+                };
+                const bindRatingDropdownEvents = () => {
+                    const allCheckbox = ratingSelect.querySelector('.danbooru-rating-all-checkbox');
+                    const ratingCheckboxes = ratingSelect.querySelectorAll('.danbooru-rating-checkbox:not(.danbooru-rating-all-checkbox)');
+
+                    if (allCheckbox) {
+                        allCheckbox.addEventListener('change', () => {
+                            const checked = allCheckbox.checked;
+                            ratingCheckboxes.forEach(cb => { cb.checked = checked; });
+                            updateRatingButtonLabel();
+                            saveToLocalStorage('ratingValues', checked ? [...RATING_VALUES] : []);
+                            ratingSelect.dispatchEvent(new Event('change'));
+                        });
+                    }
+
+                    ratingCheckboxes.forEach((checkbox) => {
+                        checkbox.addEventListener('change', () => {
+                            const selectedRatings = getSelectedRatings();
+                            if (allCheckbox) {
+                                allCheckbox.checked = selectedRatings.length === RATING_VALUES.length;
+                            }
+                            updateRatingButtonLabel();
+                            saveToLocalStorage('ratingValues', selectedRatings);
+                            ratingSelect.dispatchEvent(new Event('change'));
+                        });
+                    });
+                };
+                bindRatingDropdownEvents();
+                applySelectedRatings(RATING_VALUES);
+
+                const createCategoryCheckbox = (name, checked = false) => { // Default to false, will be set later
+                    const id = `danbooru-category-${name}`;
+                    const checkbox = $el("input", { type: "checkbox", id, name, checked: checked, className: "danbooru-category-checkbox" });
+                    checkbox.addEventListener('change', async () => {
+                        const newSelectedCategories = Array.from(categoryDropdown.querySelectorAll("input:checked")).map(i => i.name);
+                        uiSettings.selected_categories = newSelectedCategories;
+                        saveToLocalStorage('selectedCategories', newSelectedCategories);
+                        await saveUiSettings(uiSettings);
+                        updateSelectionData();
+                    });
+                    return $el("div.danbooru-category-item", [
+                        checkbox,
+                        $el("label", { htmlFor: id, textContent: t(name) })
+                    ]);
+                };
+
+                const categoryDropdown = $el("div.danbooru-category-dropdown", [
+                    $el("button.danbooru-category-button", {
+                        innerHTML: `${t('categories')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`,
+                        title: t('categoriestooltip')
+                    }),
+                    $el("div.danbooru-category-list", {}, [
+                        createCategoryCheckbox("artist"),
+                        createCategoryCheckbox("copyright"),
+                        createCategoryCheckbox("character"),
+                        createCategoryCheckbox("general"),
+                        createCategoryCheckbox("meta")
+                    ])
+                ]);
+
+                const createFormattingCheckbox = (name, label, checked = true) => {
+                    const id = `danbooru-format-${name}`;
+                    const checkbox = $el("input", { type: "checkbox", id, name, checked, className: "danbooru-format-checkbox" });
+                    checkbox.addEventListener('change', async () => {
+                        const newFormattingOptions = {
+                            escapeBrackets: formattingDropdown.querySelector('[name="escapeBrackets"]').checked,
+                            replaceUnderscores: formattingDropdown.querySelector('[name="replaceUnderscores"]').checked,
+                        };
+                        uiSettings.formatting = newFormattingOptions;
+                        saveToLocalStorage('formatting', newFormattingOptions);
+                        await saveUiSettings(uiSettings);
+                        updateSelectionData();
+                    });
+                    return $el("div.danbooru-category-item", [
+                        checkbox,
+                        $el("label", { htmlFor: id, textContent: label })
+                    ]);
+                };
+
+                const formattingDropdown = $el("div.danbooru-formatting-dropdown.danbooru-category-dropdown", [
+                    $el("button.danbooru-category-button", {
+                        innerHTML: `${t('formatting')} <svg class="arrow-down" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`,
+                        title: t('formattingTooltip')
+                    }),
+                    $el("div.danbooru-category-list", {}, [
+                        createFormattingCheckbox("escapeBrackets", t('escapeBrackets')),
+                        createFormattingCheckbox("replaceUnderscores", t('replaceUnderscores')),
+                    ])
+                ]);
+
+                sourceSelect.addEventListener('change', async () => {
+                    uiSettings.source_site = sourceSelect.value;
+                    saveToLocalStorage('sourceSite', uiSettings.source_site);
+                    await saveUiSettings(uiSettings);
+                    await loadFavorites();
+                    updateSourceState();
+                    searchAutocomplete.source = uiSettings.source_site;
+                    posts = [];
+                    Object.keys(originalPostCache).forEach(key => delete originalPostCache[key]);
+                    temporaryTagEdits = {};
+                    updateSelectionData();
+                    fetchAndRender(true);
+                });
+
+                displayAllSiteContentToggle.querySelector("input").addEventListener('change', async (event) => {
+                    uiSettings.gelbooru_display_all_site_content = Boolean(event.target.checked);
+                    saveToLocalStorage('gelbooruDisplayAllSiteContent', uiSettings.gelbooru_display_all_site_content);
+                    await saveUiSettings(uiSettings);
+                    if ((uiSettings.source_site || "danbooru") === "gelbooru") {
+                        posts = [];
+                        Object.keys(originalPostCache).forEach(key => delete originalPostCache[key]);
+                        temporaryTagEdits = {};
+                        updateSelectionData();
+                        fetchAndRender(true);
+                    }
+                });
+
+                document.addEventListener("click", (e) => {
+                    const dropdowns = [categoryDropdown, formattingDropdown, ratingSelect];
+                    dropdowns.forEach(dropdown => {
+                        const list = dropdown.querySelector(".danbooru-category-list");
+                        const button = dropdown.querySelector(".danbooru-category-button");
+
+                        if (!button || !list) return;
+
+                        if (!dropdown.contains(e.target)) {
+                            list.classList.remove("show");
+                            button.classList.remove("open");
+                        } else if (e.target.closest(".danbooru-category-button")) {
+                            // Close other dropdowns
+                            dropdowns.forEach(otherDropdown => {
+                                if (otherDropdown !== dropdown) {
+                                    otherDropdown.querySelector(".danbooru-category-list")?.classList.remove("show");
+                                    const otherButton = otherDropdown.querySelector(".danbooru-category-button");
+                                    otherButton?.classList.remove("open");
+                                }
+                            });
+                            list.classList.toggle("show");
+                            button.classList.toggle("open");
+                        }
+                    });
+                });
+
+                // 排行榜按钮
+                const rankingButton = $el("button.danbooru-ranking-button", {
+                    title: t('rankingTooltip')
+                });
+                rankingButton.innerHTML = `
+                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
+                       <path d="M16 6L19 9L16 12"></path>
+                       <path d="M8 12L5 9L8 6"></path>
+                       <path d="M12 2V22"></path>
+                       <path d="M3 9H21"></path>
+                   </svg>
+                   ${t('ranking')}`;
+
+                // 收藏夹按钮
+                const favoritesButton = $el("button.danbooru-favorites-button", {
+                    title: t('favorites')
+                });
+                favoritesButton.innerHTML = `
+                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
+                       <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+                   </svg>
+                   ${t('favorites')}`;
+
+                // 导出设置
+                const exportSettings = () => {
+                    const settingsToExport = {
+                        language: globalMultiLanguageManager.getLanguage(),
+                        blacklist: currentBlacklist,
+                        prompt_filter: {
+                            enabled: filterEnabled,
+                            tags: currentFilterTags,
+                        },
+                        ui: {
+                            ...uiSettings,
+                            source_site: uiSettings.source_site || "danbooru",
+                            // Ensure formatting is included from the checkboxes directly
+                            formatting: {
+                                escapeBrackets: formattingDropdown.querySelector('[name="escapeBrackets"]').checked,
+                                replaceUnderscores: formattingDropdown.querySelector('[name="replaceUnderscores"]').checked,
+                            }
+                        },
+                    };
+
+                    const blob = new Blob([JSON.stringify(settingsToExport, null, 2)], { type: 'application/json' });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'danbooru_gallery_settings.json';
+                    document.body.appendChild(a);
+                    a.click();
+                    document.body.removeChild(a);
+                    URL.revokeObjectURL(url);
+
+                    showToast(t('exportSuccess'), 'success');
+                };
+
+                // 导入设置
+                const importSettings = (dialog) => {
+                    const input = document.createElement('input');
+                    input.type = 'file';
+                    input.accept = '.json';
+                    input.onchange = (e) => {
+                        const file = e.target.files[0];
+                        if (!file) return;
+                        const reader = new FileReader();
+                        reader.onload = async (event) => {
+                            try {
+                                const s = JSON.parse(event.target.result);
+
+                                const promises = [];
+                                if (s.language && i18n[s.language]) {
+                                    promises.push(saveLanguage(s.language));
+                                }
+                                if (Array.isArray(s.blacklist)) {
+                                    promises.push(saveBlacklist(s.blacklist));
+                                }
+                                if (s.prompt_filter && typeof s.prompt_filter.enabled === 'boolean' && Array.isArray(s.prompt_filter.tags)) {
+                                    promises.push(saveFilterTags(s.prompt_filter.tags, s.prompt_filter.enabled));
+                                }
+                                if (s.ui) {
+                                    // Merge formatting settings correctly
+                                    const newUiSettings = { ...uiSettings, ...s.ui };
+                                    if (s.ui.formatting) {
+                                        newUiSettings.formatting = { ...uiSettings.formatting, ...s.ui.formatting };
+                                    }
+                                    promises.push(saveUiSettings(newUiSettings));
+                                }
+
+                                const results = await Promise.all(promises);
+
+                                if (results.some(res => res === false)) {
+                                    showToast(t('saveFailed'), 'error');
+                                    return;
+                                }
+
+                                showToast(t('importSuccess'), 'success');
+                                dialog.remove();
+
+                                await initializeApp();
+                                showSettingsDialog();
+
+                            } catch (error) {
+                                logger.error("Failed to import settings:", error);
+                                showToast(t('importError'), 'error');
+                            }
+                        };
+                        reader.readAsText(file);
+                    };
+                    input.click();
+                };
+
+                // 创建设置页面对话框
+                const showSettingsDialog = (initialState = {}) => {
+                    const dialog = $el("div.danbooru-settings-dialog", {
+                        style: {
+                            position: "fixed",
+                            top: "0",
+                            left: "0",
+                            width: "100%",
+                            height: "100%",
+                            backgroundColor: "rgba(0, 0, 0, 0.7)",
+                            zIndex: "10000",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center"
+                        }
+                    });
+
+                    const dialogContent = $el("div.danbooru-settings-dialog-content", {
+                        style: {
+                            backgroundColor: "var(--comfy-menu-bg)",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "12px",
+                            padding: "24px",
+                            width: "800px",
+                            maxWidth: "90vw",
+                            height: "600px",
+                            maxHeight: "90vh",
+                            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)",
+                            display: "flex",
+                            flexDirection: "column"
+                        }
+                    });
+
+                    const mainContainer = $el("div", {
+                        style: {
+                            display: "flex",
+                            flex: "1",
+                            gap: "20px",
+                            overflow: "hidden"
+                        }
+                    });
+
+
+                    const sidebar = $el("div.danbooru-settings-sidebar", {
+                        style: {
+                            width: "180px",
+                            flexShrink: "0",
+                            borderRight: "1px solid var(--input-border-color)"
+                        }
+                    });
+
+
+                    const scrollContainer = $el("div.danbooru-settings-scroll-container", {
+                        style: {
+                            flex: "1",
+                            overflowY: "auto",
+                            padding: "0 16px"
+                        }
+                    });
+
+                    const title = $el("h2", {
+                        textContent: t('settings'),
+                        style: {
+                            margin: "0 0 20px 0",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "1.5em",
+                            fontWeight: "600",
+                            borderBottom: "2px solid var(--input-border-color)",
+                            paddingBottom: "12px"
+                        }
+                    });
+
+                    // 语言设置部分
+                    const languageSection = $el("div.danbooru-settings-section", {
+                        style: {
+                            marginBottom: "20px",
+                            padding: "16px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "8px",
+                            backgroundColor: "var(--comfy-input-bg)"
+                        }
+                    });
+
+                    const languageTitle = $el("h3", {
+                        textContent: t('languageSettings'),
+                        style: {
+                            margin: "0 0 12px 0",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "1.1em",
+                            fontWeight: "500",
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px"
+                        }
+                    });
+
+                    const languageIcon = $el("span", {
+                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"></circle>
+                            <line x1="2" y1="12" x2="22" y2="12"></line>
+                            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+                        </svg>`
+                    });
+
+                    languageTitle.insertBefore(languageIcon, languageTitle.firstChild);
+
+                    const languageOptions = $el("div", {
+                        style: {
+                            display: "flex",
+                            gap: "12px"
+                        }
+                    });
+
+                    const createLanguageButton = (lang, text) => {
+                        const isActive = globalMultiLanguageManager.getLanguage() === lang;
+                        const button = $el("button", {
+                            textContent: text,
+                            className: `danbooru-language-select-button ${isActive ? 'active' : ''}`,
+                            dataset: { lang: lang } // Store lang in dataset
+                        });
+                        return button;
+                    };
+
+                    const zhButton = createLanguageButton('zh', '中文');
+                    const enButton = createLanguageButton('en', 'English');
+
+                    languageOptions.appendChild(zhButton);
+                    languageOptions.appendChild(enButton);
+
+
+                    languageSection.appendChild(languageTitle);
+                    languageSection.appendChild(languageOptions);
+
+
+                    // 黑名单设置部分
+                    const blacklistSection = $el("div.danbooru-settings-section", {
+                        style: {
+                            marginBottom: "20px",
+                            padding: "16px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "8px",
+                            backgroundColor: "var(--comfy-input-bg)"
+                        }
+                    });
+
+                    const blacklistTitle = $el("h3", {
+                        textContent: t('blacklistSettings'),
+                        style: {
+                            margin: "0 0 8px 0",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "1.1em",
+                            fontWeight: "500",
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px"
+                        }
+                    });
+
+                    const blacklistIcon = $el("span", {
+                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 6h18l-1.5 14H4.5L3 6z"></path>
+                            <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                            <line x1="10" y1="11" x2="10" y2="17"></line>
+                            <line x1="14" y1="11" x2="14" y2="17"></line>
+                        </svg>`
+                    });
+
+                    blacklistTitle.insertBefore(blacklistIcon, blacklistTitle.firstChild);
+
+                    const blacklistDescription = $el("p", {
+                        textContent: t('blacklistDescription'),
+                        style: {
+                            margin: "0 0 12px 0",
+                            color: "#888",
+                            fontSize: "0.9em"
+                        }
+                    });
+
+                    const blacklistTextarea = $el("textarea", {
+                        placeholder: t('blacklistPlaceholder'),
+                        value: initialState.blacklist ?? currentBlacklist.join('\n'),
+                        style: {
+                            width: "100%",
+                            height: "120px",
+                            padding: "12px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "6px",
+                            backgroundColor: "var(--comfy-menu-bg)",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "14px",
+                            resize: "vertical",
+                            fontFamily: "monospace",
+                            lineHeight: "1.4"
+                        }
+                    });
+
+                    blacklistSection.appendChild(blacklistTitle);
+                    blacklistSection.appendChild(blacklistDescription);
+                    blacklistSection.appendChild(blacklistTextarea);
+
+                    // 提示词过滤设置部分
+                    const filterSection = $el("div.danbooru-settings-section", {
+                        style: {
+                            marginBottom: "20px",
+                            padding: "16px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "8px",
+                            backgroundColor: "var(--comfy-input-bg)"
+                        }
+                    });
+
+                    const filterTitle = $el("h3", {
+                        textContent: t('promptFilterSettings'),
+                        style: {
+                            margin: "0 0 8px 0",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "1.1em",
+                            fontWeight: "500",
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px"
+                        }
+                    });
+
+                    const filterIcon = $el("span", {
+                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
+                        </svg>`
+                    });
+
+                    filterTitle.insertBefore(filterIcon, filterTitle.firstChild);
+
+                    const filterEnableDiv = $el("div", {
+                        style: {
+                            marginBottom: "12px",
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px"
+                        }
+                    });
+
+                    const filterEnableCheckbox = $el("input", {
+                        type: "checkbox",
+                        id: "filterEnableCheckbox",
+                        checked: initialState.filterEnabled ?? filterEnabled,
+                        style: {
+                            width: "16px",
+                            height: "16px"
+                        }
+                    });
+
+                    const filterEnableLabel = $el("label", {
+                        htmlFor: "filterEnableCheckbox",
+                        textContent: t('promptFilterEnable'),
+                        style: {
+                            cursor: "pointer",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "0.9em",
+                            fontWeight: "500"
+                        }
+                    });
+
+                    filterEnableDiv.appendChild(filterEnableCheckbox);
+                    filterEnableDiv.appendChild(filterEnableLabel);
+
+                    const filterDescription = $el("p", {
+                        textContent: t('promptFilterDescription'),
+                        style: {
+                            margin: "0 0 12px 0",
+                            color: "#888",
+                            fontSize: "0.9em"
+                        }
+                    });
+
+                    const filterTextarea = $el("textarea", {
+                        placeholder: t('promptFilterPlaceholder'),
+                        value: initialState.filterTags ?? currentFilterTags.join('\n'),
+                        style: {
+                            width: "100%",
+                            height: "120px",
+                            padding: "12px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "6px",
+                            backgroundColor: "var(--comfy-menu-bg)",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "14px",
+                            resize: "vertical",
+                            fontFamily: "monospace",
+                            lineHeight: "1.4"
+                        }
+                    });
+
+                    filterSection.appendChild(filterTitle);
+                    filterSection.appendChild(filterEnableDiv);
+                    filterSection.appendChild(filterDescription);
+                    filterSection.appendChild(filterTextarea);
+
+                    // 用户认证设置部分
+                    const authSection = $el("div.danbooru-settings-section", {
+                        style: {
+                            marginBottom: "20px",
+                            padding: "16px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "8px",
+                            backgroundColor: "var(--comfy-input-bg)"
+                        }
+                    });
+
+                    const authTitle = $el("h3", {
+                        textContent: t('userAuth'),
+                        style: {
+                            margin: "0 0 8px 0",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "1.1em",
+                            fontWeight: "500",
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px"
+                        }
+                    });
+
+                    const authIcon = $el("span", {
+                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M9 12l2 2 4-4"></path>
+                            <path d="M21 12c-1 0-3-1-3-3s2-3 3-3 3 1 3 3-2 3-3 3"></path>
+                            <path d="M3 12c1 0 3-1 3-3s-2-3-3-3-3 1-3 3 2 3 3 3"></path>
+                            <path d="M12 3v6m0 6v6"></path>
+                        </svg>`
+                    });
+
+                    authTitle.insertBefore(authIcon, authTitle.firstChild);
+
+                    const authDescription = $el("p", {
+                        textContent: t('authDescription'),
+                        style: {
+                            margin: "0 0 12px 0",
+                            color: "#888",
+                            fontSize: "0.9em"
+                        }
+                    });
+
+                    const usernameInput = $el("input", {
+                        type: "text",
+                        placeholder: t('authPlaceholderUsername'),
+                        value: (initialState.username ?? userAuth.username) || "",
+                        style: {
+                            width: "100%",
+                            padding: "8px 12px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "6px",
+                            backgroundColor: "var(--comfy-menu-bg)",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "14px",
+                            marginBottom: "8px"
+                        }
+                    });
+
+                    const apiKeyInput = $el("input", {
+                        type: "password",
+                        placeholder: t('authPlaceholderApiKey'),
+                        value: (initialState.apiKey ?? userAuth.api_key) || "",
+                        style: {
+                            width: "100%",
+                            padding: "8px 12px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "6px",
+                            backgroundColor: "var(--comfy-menu-bg)",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "14px",
+                            marginBottom: "8px"
+                        }
+                    });
+
+                    const gelbooruAuthDescription = $el("p", {
+                        textContent: t('gelbooruAuthDescription'),
+                        style: {
+                            margin: "12px 0 8px 0",
+                            color: "#888",
+                            fontSize: "0.9em"
+                        }
+                    });
+
+                    const gelbooruUserIdInput = $el("input", {
+                        type: "text",
+                        placeholder: t('gelbooruUserIdPlaceholder'),
+                        value: (initialState.gelbooruUserId ?? userAuth.gelbooru_user_id) || "",
+                        style: {
+                            width: "100%",
+                            padding: "8px 12px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "6px",
+                            backgroundColor: "var(--comfy-menu-bg)",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "14px",
+                            marginBottom: "8px"
+                        }
+                    });
+
+                    const gelbooruApiKeyInput = $el("input", {
+                        type: "password",
+                        placeholder: t('gelbooruApiKeyPlaceholder'),
+                        value: (initialState.gelbooruApiKey ?? userAuth.gelbooru_api_key) || "",
+                        style: {
+                            width: "100%",
+                            padding: "8px 12px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "6px",
+                            backgroundColor: "var(--comfy-menu-bg)",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "14px",
+                            marginBottom: "8px"
+                        }
+                    });
+
+                    const apiKeyHelpButton = $el("button", {
+                        textContent: t('apiKeyHelp'),
+                        title: t('apiKeyTooltip'),
+                        style: {
+                            padding: "6px 12px",
+                            border: "1px solid #5865F2",
+                            borderRadius: "4px",
+                            backgroundColor: "transparent",
+                            color: "#5865F2",
+                            cursor: "pointer",
+                            fontSize: "12px",
+                            fontWeight: "500",
+                            transition: "all 0.2s ease"
+                        },
+                        onclick: () => {
+                            window.open('https://danbooru.donmai.us/profile', '_blank');
+                        }
+                    });
+
+                    authSection.appendChild(authTitle);
+                    authSection.appendChild(authDescription);
+                    authSection.appendChild(usernameInput);
+                    authSection.appendChild(apiKeyInput);
+                    authSection.appendChild(gelbooruAuthDescription);
+                    authSection.appendChild(gelbooruUserIdInput);
+                    authSection.appendChild(gelbooruApiKeyInput);
+                    authSection.appendChild(apiKeyHelpButton);
+
+                    // 自动补全设置
+                    const autocompleteSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
+                    const autocompleteTitle = $el("h3", { textContent: t('autocompleteSettings'), style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
+                    const autocompleteDesc = $el("p", { textContent: t('autocompleteEnableDescription'), style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
+                    const autocompleteEnableCheckbox = $el("input", { type: "checkbox", id: "autocompleteEnableCheckbox", checked: initialState.autocompleteEnabled ?? uiSettings.autocomplete_enabled, style: { width: "16px", height: "16px" } });
+                    autocompleteEnableCheckbox.onchange = (e) => { /* 用户界面中的临时状态，无需处理 */ };
+                    const autocompleteEnableLabel = $el("label", { htmlFor: "autocompleteEnableCheckbox", textContent: t('autocompleteEnable'), style: { cursor: "pointer", color: "var(--comfy-input-text)", fontSize: "1em", fontWeight: "500" } });
+                    const autocompleteEnableDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [autocompleteEnableCheckbox, autocompleteEnableLabel]);
+
+                    // 新增：最大补全数量
+                    const autocompleteMaxResultsLabel = $el("label", { htmlFor: "autocompleteMaxResultsInput", textContent: t('autocompleteMaxResults'), style: { color: "var(--comfy-input-text)", fontSize: "0.9em", fontWeight: "500" } });
+                    const autocompleteMaxResultsInput = $el("input", {
+                        type: "number",
+                        id: "autocompleteMaxResultsInput",
+                        title: t('autocompleteEnableDescription'),
+                        value: (initialState.autocompleteMaxResults ?? uiSettings.autocomplete_max_results) || 20,
+                        min: "1",
+                        max: "50",
+                        style: { width: "60px", padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
+                    });
+                    const autocompleteMaxResultsDiv = $el("div", { style: { display: "flex", alignItems: "center" } }, [autocompleteMaxResultsLabel, autocompleteMaxResultsInput]);
+
+                    autocompleteSection.appendChild(autocompleteTitle);
+                    autocompleteSection.appendChild(autocompleteDesc);
+                    autocompleteSection.appendChild(autocompleteEnableDiv);
+                    autocompleteSection.appendChild(autocompleteMaxResultsDiv);
+
+                    // 悬浮提示设置
+                    const tooltipSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
+                    const tooltipTitle = $el("h3", { textContent: t('tooltipSettings'), style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
+                    const tooltipDesc = $el("p", { textContent: t('tooltipEnableDescription'), style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
+                    const tooltipEnableCheckbox = $el("input", { type: "checkbox", id: "tooltipEnableCheckbox", checked: initialState.tooltipEnabled ?? uiSettings.tooltip_enabled, style: { width: "16px", height: "16px" } });
+                    tooltipEnableCheckbox.onchange = (e) => { /* 用户界面中的临时状态，无需处理 */ };
+                    const tooltipEnableLabel = $el("label", { htmlFor: "tooltipEnableCheckbox", textContent: t('tooltipEnable'), style: { cursor: "pointer", color: "var(--comfy-input-text)", fontSize: "1em", fontWeight: "500" } });
+                    const tooltipEnableDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px" } }, [tooltipEnableCheckbox, tooltipEnableLabel]);
+                    tooltipSection.appendChild(tooltipTitle);
+                    tooltipSection.appendChild(tooltipDesc);
+                    tooltipSection.appendChild(tooltipEnableDiv);
+
+                    // 多选模式设置
+                    const selectionModeSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
+                    const selectionModeTitle = $el("h3", { textContent: t('selectionModeSettings'), style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
+                    const selectionModeDesc = $el("p", { textContent: t('selectionModeDescription'), style: { margin: "0 0 12px 0", color: "#888", fontSize: "0.9em" } });
+                    const multiSelectCheckbox = $el("input", { type: "checkbox", id: "multiSelectCheckbox", checked: initialState.multiSelectEnabled ?? uiSettings.multi_select_enabled ?? false, style: { width: "16px", height: "16px" } });
+                    multiSelectCheckbox.onchange = (e) => { /* 用户界面中的临时状态，无需处理 */ };
+                    const multiSelectLabel = $el("label", { htmlFor: "multiSelectCheckbox", textContent: t('multiSelectEnable'), style: { cursor: "pointer", color: "var(--comfy-input-text)", fontSize: "1em", fontWeight: "500" } });
+                    const multiSelectDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px" } }, [multiSelectCheckbox, multiSelectLabel]);
+                    selectionModeSection.appendChild(selectionModeTitle);
+                    selectionModeSection.appendChild(selectionModeDesc);
+                    selectionModeSection.appendChild(multiSelectDiv);
+
+                    // 预加载设置
+                    const preloadSection = $el("div.danbooru-settings-section", { style: { marginBottom: "20px", padding: "16px", border: "1px solid var(--input-border-color)", borderRadius: "8px", backgroundColor: "var(--comfy-input-bg)" } });
+                    const preloadTitle = $el("h3", { textContent: "预加载 / 去重", style: { margin: "0 0 8px 0", color: "var(--comfy-input-text)", fontSize: "1.1em", fontWeight: "500" } });
+                    preloadSection.appendChild(preloadTitle);
+
+                    // 每次增加张数
+                    const preloadCountLabel = $el("label", { htmlFor: "preloadCountInput", textContent: "每次增加缓冲张数：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
+                    const preloadCountInput = $el("input", {
+                        type: "number", id: "preloadCountInput", min: "20", max: "200",
+                        value: (initialState.preloadCount !== undefined ? initialState.preloadCount : uiSettings.preload_count) || 40,
+                        style: { width: "60px", padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
+                    });
+                    const preloadCountDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [preloadCountLabel, preloadCountInput]);
+
+                    // G站防重复模式
+                    const gelbooruDedupLabel = $el("label", { htmlFor: "gelbooruDedupSelect", textContent: "G站防重复：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
+                    const gelbooruDedupSelect = $el("select", {
+                        id: "gelbooruDedupSelect",
+                        style: { padding: '4px', marginLeft: '8px', backgroundColor: 'var(--comfy-menu-bg)', color: 'var(--comfy-input-text)', border: '1px solid var(--input-border-color)', borderRadius: '4px' }
+                    }, [
+                        $el("option", { value: "off", textContent: "关闭（可使用2个tag）" }),
+                        $el("option", { value: "on", textContent: "开启（限1个tag）" }),
+                        $el("option", { value: "on_auth", textContent: "开启·已配密钥（多tag可用）" }),
+                    ]);
+                    gelbooruDedupSelect.value = initialState.gelbooruDedupMode !== undefined ? initialState.gelbooruDedupMode : (uiSettings.gelbooru_dedup_mode || "off");
+                    const gelbooruDedupDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" } }, [gelbooruDedupLabel, gelbooruDedupSelect]);
+
+                    // 全局日志
+                    const globalLogLabel = $el("label", { htmlFor: "globalLogCheck", textContent: "启用全局日志：", style: { color: "var(--comfy-input-text)", fontSize: "0.9em" } });
+                    const globalLogCheck = $el("input", {
+                        type: "checkbox", id: "globalLogCheck",
+                        checked: initialState.globalLogging !== undefined ? initialState.globalLogging : (uiSettings.global_logging || false),
+                        style: { width: "16px", height: "16px" }
+                    });
+                    const globalLogDiv = $el("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginBottom: "8px" } }, [globalLogCheck, globalLogLabel]);
+
+                    preloadSection.appendChild(preloadCountDiv);
+                    preloadSection.appendChild(gelbooruDedupDiv);
+                    preloadSection.appendChild(globalLogDiv);
+
+                    // 创建侧边栏按钮和内容区域的映射
+                    const sections = {
+                        'general': { title: t('generalSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>', elements: [languageSection] },
+                        'user': { title: t('userSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>', elements: [authSection] },
+                        'content': { title: t('contentSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18l-1.5 14H4.5L3 6z"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>', elements: [blacklistSection] },
+                        'prompt': { title: t('promptSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>', elements: [filterSection] },
+                        'ui': { title: t('uiSection'), icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="3" y1="9" x2="21" y2="9"></line><line x1="9" y1="21" x2="9" y2="9"></line></svg>', elements: [autocompleteSection, tooltipSection, selectionModeSection] },
+                        'preload': { title: "预加载", icon: '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>', elements: [preloadSection] },
+                    };
+
+                    const setActiveSection = (key) => {
+                        // 更新按钮样式
+                        sidebar.querySelectorAll('.sidebar-button').forEach(btn => {
+                            if (btn.dataset.key === key) {
+                                btn.classList.add('active');
+                            } else {
+                                btn.classList.remove('active');
+                            }
+                        });
+
+
+                        // 显示对应的内容
+                        scrollContainer.innerHTML = '';
+                        if (sections[key] && sections[key].elements.length > 0) {
+                            sections[key].elements.forEach(el => scrollContainer.appendChild(el));
+                        }
+                    };
+
+                    // 创建侧边栏按钮
+                    Object.keys(sections).forEach(key => {
+                        const section = sections[key];
+                        const button = $el("button.sidebar-button", {
+                            dataset: { key: key },
+                            onclick: () => setActiveSection(key),
+                        });
+                        button.appendChild($el("div.sidebar-button-icon", { innerHTML: section.icon }));
+                        button.appendChild($el("span.sidebar-button-title", { textContent: section.title }));
+                        sidebar.appendChild(button);
+                    });
+
+                    // 设置初始活动区域
+                    setActiveSection('general');
+
+                    // 社交按钮
+                    const githubButton = $el("button", {
+                        innerHTML: `
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+                            </svg>
+                            <span style="margin-left: 8px;">GitHub</span>
+                        `,
+                        title: t('githubTooltip'),
+                        style: {
+                            padding: "10px 16px",
+                            border: "1px solid #24292e",
+                            borderRadius: "6px",
+                            backgroundColor: "#24292e",
+                            color: "white",
+                            cursor: "pointer",
+                            fontSize: "14px",
+                            fontWeight: "500",
+                            transition: "all 0.2s ease",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            minWidth: "80px"
+                        },
+                        onclick: () => {
+                            window.open('https://github.com/Aaalice233/ComfyUI-Danbooru-Gallery', '_blank');
+                        }
+                    });
+
+                    const discordButton = $el("button", {
+                        innerHTML: `
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.196.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.30z"></path>
+                            </svg>
+                            <span style="margin-left: 8px;">Discord</span>
+                        `,
+                        title: t('discordTooltip'),
+                        style: {
+                            padding: "10px 16px",
+                            border: "1px solid #5865F2",
+                            borderRadius: "6px",
+                            backgroundColor: "#5865F2",
+                            color: "white",
+                            cursor: "pointer",
+                            fontSize: "14px",
+                            fontWeight: "500",
+                            transition: "all 0.2s ease",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            minWidth: "80px"
+                        },
+                        onclick: () => {
+                            window.open('https://discord.gg/aaalice', '_blank');
+                        }
+                    });
+
+                    // 按钮区域
+                    const buttonContainer = $el("div", {
+                        style: {
+                            display: "flex",
+                            gap: "12px",
+                            marginTop: "24px",
+                            justifyContent: "space-between",
+                            alignItems: "center"
+                        }
+                    });
+
+                    // 左侧社交按钮容器
+                    const socialButtonsContainer = $el("div", {
+                        style: {
+                            display: "flex",
+                            gap: "8px"
+                        }
+                    });
+
+                    socialButtonsContainer.appendChild(githubButton);
+                    socialButtonsContainer.appendChild(discordButton);
+
+                    // 右侧主要按钮容器
+                    const mainButtonsContainer = $el("div", {
+                        style: {
+                            display: "flex",
+                            gap: "12px"
+                        }
+                    });
+
+                    const importExportButtonStyle = {
+                        padding: "10px 20px",
+                        border: "1px solid var(--input-border-color)",
+                        borderRadius: "6px",
+                        backgroundColor: "var(--comfy-input-bg)",
+                        color: "var(--comfy-input-text)",
+                        cursor: "pointer",
+                        fontSize: "14px",
+                        fontWeight: "500",
+                        transition: "all 0.2s ease"
+                    };
+
+                    const importButton = $el("button", {
+                        textContent: t('importSettings'),
+                        style: importExportButtonStyle,
+                        onclick: () => importSettings(dialog)
+                    });
+
+                    const exportButton = $el("button", {
+                        textContent: t('exportSettings'),
+                        style: importExportButtonStyle,
+                        onclick: exportSettings
+                    });
+
+                    const cancelButton = $el("button", {
+                        textContent: t('cancel'),
+                        style: {
+                            padding: "10px 20px",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "6px",
+                            backgroundColor: "var(--comfy-input-bg)",
+                            color: "var(--comfy-input-text)",
+                            cursor: "pointer",
+                            fontSize: "14px",
+                            fontWeight: "500",
+                            transition: "all 0.2s ease"
+                        },
+                        onclick: () => dialog.remove()
+                    });
+
+                    const saveButton = $el("button", {
+                        textContent: t('save'),
+                        style: {
+                            padding: "10px 20px",
+                            border: "2px solid #7B68EE",
+                            borderRadius: "6px",
+                            backgroundColor: "#7B68EE",
+                            color: "white",
+                            cursor: "pointer",
+                            fontSize: "14px",
+                            fontWeight: "600",
+                            transition: "all 0.2s ease"
+                        },
+                        onclick: async () => {
+                            const blacklistText = blacklistTextarea.value.trim();
+                            const newBlacklist = blacklistText ? blacklistText.split('\n').map(tag => tag.trim()).filter(tag => tag) : [];
+
+                            const filterText = filterTextarea.value.trim();
+                            const newFilterTags = filterText ? filterText.split('\n').map(tag => tag.trim()).filter(tag => tag) : [];
+                            const newFilterEnabled = filterEnableCheckbox.checked;
+
+                            // 保存用户认证信息
+                            const newUsername = usernameInput.value.trim();
+                            const newApiKey = apiKeyInput.value.trim();
+                            const newGelbooruUserId = gelbooruUserIdInput.value.trim();
+                            const newGelbooruApiKey = gelbooruApiKeyInput.value.trim();
+                            let authSuccess = true;
+                            if (
+                                newUsername !== userAuth.username ||
+                                newApiKey !== userAuth.api_key ||
+                                newGelbooruUserId !== userAuth.gelbooru_user_id ||
+                                newGelbooruApiKey !== userAuth.gelbooru_api_key
+                            ) {
+                                const authResult = await saveUserAuth(newUsername, newApiKey, newGelbooruUserId, newGelbooruApiKey);
+                                authSuccess = authResult.success;
+                                if (authSuccess) {
+                                    await loadFavorites(); // 登录成功后重新加载收藏夹
+                                } else {
+                                    showToast(authResult.error || "保存认证信息失败", 'error');
+                                    return;
+                                }
+                            }
+
+                            const newAutocompleteEnabled = autocompleteEnableCheckbox.checked;
+                            const newTooltipEnabled = tooltipEnableCheckbox.checked;
+                            const newAutocompleteMaxResults = parseInt(autocompleteMaxResultsInput.value, 10);
+                            const newSelectedCategories = Array.from(categoryDropdown.querySelectorAll("input:checked")).map(i => i.name);
+                            const newMultiSelectEnabled = multiSelectCheckbox.checked;
+
+                            // 保存所有设置
+                            const [blacklistSuccess, filterSuccess, uiSettingsSuccess] = await Promise.all([
+                                saveBlacklist(newBlacklist),
+                                saveFilterTags(newFilterTags, newFilterEnabled),
+                                saveUiSettings({
+                                    autocomplete_enabled: newAutocompleteEnabled,
+                                    tooltip_enabled: newTooltipEnabled,
+                                    autocomplete_max_results: newAutocompleteMaxResults,
+                                    selected_categories: newSelectedCategories,
+                                    multi_select_enabled: newMultiSelectEnabled,
+                                    source_site: uiSettings.source_site || "danbooru",
+                                    gelbooru_display_all_site_content: uiSettings.gelbooru_display_all_site_content || false
+                                })
+                            ]);
+
+                            if (blacklistSuccess && filterSuccess && authSuccess && uiSettingsSuccess) {
+                                // 同步本地状态
+                                currentBlacklist = newBlacklist;
+                                currentFilterTags = newFilterTags;
+                                filterEnabled = newFilterEnabled;
+                                uiSettings.autocomplete_enabled = newAutocompleteEnabled;
+                                uiSettings.tooltip_enabled = newTooltipEnabled;
+                                uiSettings.autocomplete_max_results = newAutocompleteMaxResults;
+                                uiSettings.selected_categories = newSelectedCategories;
+                                uiSettings.multi_select_enabled = newMultiSelectEnabled;
+                                uiSettings.source_site = sourceSelect.value || uiSettings.source_site || "danbooru";
+
+                                // 保存 preload/dedup/global_logging
+                                let newPreloadCount = parseInt(preloadCountInput.value, 10);
+                                if (isNaN(newPreloadCount)) newPreloadCount = 40;
+                                newPreloadCount = Math.min(Math.max(newPreloadCount, 20), 200);
+                                uiSettings.preload_count = newPreloadCount;
+                                saveToLocalStorage('preload_count', newPreloadCount);
+
+                                const newGelbooruDedupMode = ["off", "on", "on_auth"].includes(gelbooruDedupSelect.value) ? gelbooruDedupSelect.value : "off";
+                                uiSettings.gelbooru_dedup_mode = newGelbooruDedupMode;
+                                saveToLocalStorage('gelbooru_dedup_mode', newGelbooruDedupMode);
+
+                                const newGlobalLogging = globalLogCheck.checked;
+                                uiSettings.global_logging = newGlobalLogging;
+                                saveToLocalStorage('global_logging', newGlobalLogging);
+                                loggerClient.setConsoleOutput(newGlobalLogging);
+                                updateSelectionData();
+
+                                dialog.remove();
+                                showToast(t('saveSuccess'), 'success');
+
+                                // 重新过滤当前已加载的帖子
+                                const filteredPosts = posts.filter(post => !isPostFiltered(post));
+                                imageGrid.innerHTML = "";
+                                filteredPosts.forEach(renderPost);
+
+                                // 如果过滤后帖子太少，自动加载更多
+                                if (filteredPosts.length < 20) {
+                                    fetchAndRender(false);
+                                }
+                            } else {
+                                showToast(t('saveFailed'), 'error');
+                            }
+                        }
+                    });
+
+                    mainButtonsContainer.appendChild(importButton);
+                    mainButtonsContainer.appendChild(exportButton);
+                    mainButtonsContainer.appendChild(cancelButton);
+                    mainButtonsContainer.appendChild(saveButton);
+
+                    buttonContainer.appendChild(socialButtonsContainer);
+                    buttonContainer.appendChild(mainButtonsContainer);
+
+                    dialogContent.appendChild(title);
+                    mainContainer.appendChild(sidebar);
+                    mainContainer.appendChild(scrollContainer);
+                    dialogContent.appendChild(mainContainer);
+                    dialogContent.appendChild(buttonContainer);
+
+                    dialog.appendChild(dialogContent);
+
+                    // 点击背景关闭对话框
+                    dialog.addEventListener('click', (e) => {
+                        if (e.target === dialog) {
+                            dialog.remove();
+                        }
+                    });
+
+                    // ESC键关闭对话框
+                    const escHandler = (e) => {
+                        if (e.key === 'Escape') {
+                            dialog.remove();
+                            document.removeEventListener('keydown', escHandler);
+                        }
+                    };
+                    document.addEventListener('keydown', escHandler);
+
+                    document.body.appendChild(dialog);
+                    blacklistTextarea.focus();
+
+                    // Add event listeners after all elements are defined
+                    dialog.querySelectorAll('.danbooru-language-select-button').forEach(button => {
+                        button.onclick = async () => {
+                            const lang = button.dataset.lang;
+                            if (globalMultiLanguageManager.getLanguage() === lang) return;
+
+                            // Preserve state
+                            const currentState = {
+                                blacklist: blacklistTextarea.value,
+                                filterTags: filterTextarea.value,
+                                filterEnabled: filterEnableCheckbox.checked,
+                                username: usernameInput.value,
+                                apiKey: apiKeyInput.value,
+                                gelbooruUserId: gelbooruUserIdInput.value,
+                                gelbooruApiKey: gelbooruApiKeyInput.value,
+                                autocompleteEnabled: autocompleteEnableCheckbox.checked,
+                                tooltipEnabled: tooltipEnableCheckbox.checked,
+                                autocompleteMaxResults: autocompleteMaxResultsInput.value,
+                            };
+
+                            const success = await saveLanguage(lang);
+                            if (success) {
+                                globalMultiLanguageManager.setLanguage(lang);
+                                updateInterfaceTexts(); // Update main UI
+                                dialog.remove(); // Close current dialog
+                                showSettingsDialog(currentState); // Re-open with new language and preserved state
+                            } else {
+                                showToast('Failed to save language setting.', 'error');
+                            }
+                        };
+                    });
+                };
+
+                // 创建设置按钮
+                const settingsButton = $el("button.danbooru-settings-button", {
+                    innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
+                        <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
+                        <circle cx="12" cy="12" r="3"></circle>
+                    </svg>`,
+                    title: t('settings'),
+                    onclick: () => {
+                        showSettingsDialog();
+                    }
+                });
+
+                // 创建筛选按钮
+                const filterButton = $el("button.danbooru-filter-button", {
+                    innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
+                        <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
+                    </svg>`,
+                    title: t('filterTooltip'),
+                    onclick: () => {
+                        showFilterDialog();
+                    }
+                });
+
+                const refreshButton = $el("button.danbooru-refresh-button", {
+                    title: t('refreshTooltip')
+                });
+                refreshButton.innerHTML = `
+                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon">
+                       <polyline points="23 4 23 10 17 10"></polyline>
+                       <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+                   </svg>`;
+
+
+                const imageGrid = $el("div.danbooru-image-grid");
+
+                // 创建筛选对话框
+                const showFilterDialog = () => {
+                    const dialog = $el("div.danbooru-settings-dialog", {
+                        style: {
+                            position: "absolute",
+                            top: "0",
+                            left: "0",
+                            width: "100%",
+                            height: "100%",
+                            backgroundColor: "rgba(0, 0, 0, 0.7)",
+                            zIndex: "1000",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center"
+                        },
+                        onclick: (e) => { if (e.target === dialog) dialog.remove(); }
+                    });
+
+                    const content = $el("div.danbooru-settings-dialog-content", {
+                        style: {
+                            width: "420px",
+                            padding: "20px",
+                            backgroundColor: "var(--comfy-menu-bg)",
+                            border: "1px solid var(--input-border-color)",
+                            borderRadius: "12px",
+                            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)",
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: "20px",
+                            position: "relative", // 确保内容在对话框内
+                            zIndex: "1001", // 确保内容在背景之上
+                        }
+                    });
+
+                    const title = $el("h2", {
+                        textContent: t('filter'),
+                        style: {
+                            margin: "0",
+                            color: "var(--comfy-input-text)",
+                            fontSize: "1.3em",
+                            borderBottom: "1px solid var(--input-border-color)",
+                            paddingBottom: "15px"
+                        }
+                    });
+
+                    const body = $el("div", { style: { display: "flex", flexDirection: "column", gap: "20px" } });
+
+                    // 筛选类型选择
+                    const filterType = filterState.startPage ? 'page' : 'time';
+
+                    const createRadio = (name, value, label, checked) => {
+                        const radioId = `filter-type-${value}`;
+                        const radio = $el("input", { type: "radio", name, value, id: radioId, checked, style: { display: 'none' } });
+                        const indicator = $el("span.danbooru-radio-indicator");
+                        const radioLabel = $el("label.danbooru-radio-label", {
+                            htmlFor: radioId,
+                            className: checked ? 'checked' : ''
+                        }, [
+                            indicator,
+                            $el("span", { textContent: label, style: { zIndex: '1', position: 'relative' } })
+                        ]);
+
+                        // Set initial styles for checked state
+                        // The container now IS the label, which contains the hidden radio button.
+                        const container = $el("div.danbooru-radio-button-wrapper", {}, [radio, radioLabel]);
+
+                        return container;
+                    };
+
+                    const timeRadio = createRadio("filter-type", "time", t('filterByTime'), filterType === 'time');
+                    const pageRadio = createRadio("filter-type", "page", t('filterByPage'), filterType === 'page');
+
+                    const radioGroup = $el("div", {
+                        className: "danbooru-radio-group",
+                        style: {
+                            display: "flex",
+                            justifyContent: "center",
+                            alignItems: "center",
+                            gap: "20px",
+                            margin: "10px 0"
+                        }
+                    }, [timeRadio, pageRadio]);
+
+
+                    // 时间范围筛选
+                    const timeSection = $el("div.danbooru-settings-section");
+                    const createInputRow = (label, input) => {
+                        const row = $el("div.danbooru-input-row", {}, [
+                            $el("label", { textContent: label, style: { color: "#ccc", fontSize: "0.9em", userSelect: "none" } }),
+                            input
+                        ]);
+                        // Make the whole row clickable to open the date/time picker
+                        row.addEventListener('click', () => {
+                            try {
+                                input.showPicker();
+                            } catch (e) {
+                                logger.warn("input.showPicker() is not supported on this browser.", e);
+                            }
+                        });
+                        return row;
+                    };
+
+                    const startTimeInput = $el("input", { type: "datetime-local", id: "startTime", value: filterState.startTime || '' });
+                    const endTimeInput = $el("input", { type: "datetime-local", id: "endTime", value: filterState.endTime || '' });
+
+                    timeSection.append(
+                        $el("div", { style: { display: "flex", flexDirection: "column", gap: "10px" } }, [
+                            createInputRow(t('startTime'), startTimeInput),
+                            createInputRow(t('endTime'), endTimeInput)
+                        ])
+                    );
+
+                    // 起始页码筛选
+                    const pageSection = $el("div.danbooru-settings-section");
+                    const startPageInput = $el("input", { type: "number", id: "startPage", min: "1", placeholder: "1", value: filterState.startPage || '' });
+                    pageSection.append(
+                        createInputRow(t('startPage'), startPageInput)
+                    );
+
+                    body.append(radioGroup, timeSection, pageSection);
+
+                    const toggleSections = (type) => {
+                        if (type === 'time') {
+                            timeSection.style.display = 'block';
+                            pageSection.style.display = 'none';
+                        } else {
+                            timeSection.style.display = 'none';
+                            pageSection.style.display = 'block';
+                        }
+                    };
+
+                    toggleSections(filterType);
+
+                    radioGroup.addEventListener('change', (e) => {
+                        if (e.target.name === 'filter-type') {
+
+                            // New robust logic: Iterate through radios and update their labels
+                            radioGroup.querySelectorAll('input[type="radio"]').forEach(radio => {
+                                const label = radioGroup.querySelector(`label[for="${radio.id}"]`);
+                                if (label) {
+                                    const indicator = label.querySelector('.danbooru-radio-indicator');
+
+                                    if (radio.checked) {
+                                        label.classList.add('checked');
+                                        // FORCE INLINE STYLES FOR DEBUGGING
+                                        label.style.setProperty('border-color', '#7B68EE', 'important');
+                                        if (indicator) {
+                                            indicator.style.setProperty('background-color', '#7B68EE', 'important');
+                                            indicator.style.setProperty('border-color', '#7B68EE', 'important');
+                                        }
+                                    } else {
+                                        label.classList.remove('checked');
+                                        // CLEAR INLINE STYLES
+                                        label.style.borderColor = '';
+                                        if (indicator) {
+                                            indicator.style.backgroundColor = '';
+                                            indicator.style.borderColor = '';
+                                        }
+                                    }
+
+                                    // Use a timeout to allow the browser to apply styles before we log them
+                                    setTimeout(() => {
+                                        if (indicator) {
+                                        }
+                                    }, 0);
+
+                                } else {
+                                }
+                            });
+
+                            const selectedValue = e.target.value;
+                            toggleSections(selectedValue);
+                        }
+                    });
+
+                    // 按钮
+                    const footer = $el("div", { style: { display: "flex", justifyContent: "flex-end", gap: "12px", paddingTop: "15px", borderTop: "1px solid var(--input-border-color)" } });
+
+                    const cancelButton = $el("button.danbooru-dialog-button--secondary", {
+                        textContent: t('cancel'),
+                        onclick: () => dialog.remove()
+                    });
+
+                    const resetButton = $el("button.danbooru-dialog-button--secondary", {
+                        textContent: t('reset'),
+                        onclick: () => {
+                            filterState = { startTime: null, endTime: null, startPage: null };
+                            saveToLocalStorage('filterData', filterState);
+                            filterWidget.value = JSON.stringify(filterState);
+                            filterButton.classList.remove('active');
+                            dialog.remove();
+                            fetchAndRender(true);
+                        }
+                    });
+                    const applyButton = $el("button.danbooru-dialog-button--primary", {
+                        textContent: t('apply'),
+                        onclick: () => {
+                            const selectedType = radioGroup.querySelector('input[name="filter-type"]:checked').value;
+
+                            if (selectedType === 'time') {
+                                const startTime = startTimeInput.value;
+                                const endTime = endTimeInput.value;
+                                if (startTime && endTime && new Date(startTime) > new Date(endTime)) {
+                                    showError("结束时间不能早于开始时间。");
+                                    return;
+                                }
+                                filterState.startTime = startTime || null;
+                                filterState.endTime = endTime || null;
+                                filterState.startPage = null;
+                            } else { // page
+                                const startPage = parseInt(startPageInput.value, 10);
+                                if (startPageInput.value && (isNaN(startPage) || startPage < 1)) {
+                                    showError("起始页码必须是大于0的整数。");
+                                    return;
+                                }
+                                filterState.startTime = null;
+                                filterState.endTime = null;
+                                filterState.startPage = isNaN(startPage) ? null : startPage;
+                            }
+
+                            saveToLocalStorage('filterData', filterState);
+                            filterWidget.value = JSON.stringify(filterState);
+
+                            if (filterState.startTime || filterState.endTime || filterState.startPage) {
+                                filterButton.classList.add('active');
+                            } else {
+                                filterButton.classList.remove('active');
+                            }
+
+                            dialog.remove();
+                            fetchAndRender(true);
+                        }
+                    });
+                    footer.append(cancelButton, resetButton, applyButton);
+
+                    content.append(title, body, footer);
+                    dialog.append(content);
+                    container.appendChild(dialog);
+
+                    // Manually trigger change event to set initial visual state
+                    const initialCheckedRadio = radioGroup.querySelector('input[type="radio"]:checked');
+                    if (initialCheckedRadio) {
+                        initialCheckedRadio.dispatchEvent(new Event('change', { bubbles: true }));
+                    }
+                };
+
+                // 黑名单功能
+                let currentBlacklist = [];
+
+                // 提示词过滤功能
+                let currentFilterTags = [];
+                let filterEnabled = true; // 默认开启过滤功能
+                let uiSettings = {
+                    autocomplete_enabled: true,
+                    tooltip_enabled: true,
+                    autocomplete_max_results: 20,
+                    selected_categories: ["copyright", "character", "general"],
+                    multi_select_enabled: false,
+                    source_site: "danbooru",
+                    gelbooru_display_all_site_content: false,
+                    formatting: {
+                        escapeBrackets: true,
+                        replaceUnderscores: true,
+                    }
+                };
+
+                const loadUiSettings = async () => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/ui_settings');
+                        const data = await response.json();
+                        if (data.success) {
+                            uiSettings = {
+                                autocomplete_enabled: data.settings.autocomplete_enabled,
+                                tooltip_enabled: data.settings.tooltip_enabled,
+                                autocomplete_max_results: data.settings.autocomplete_max_results || 20,
+                                selected_categories: data.settings.selected_categories || ["copyright", "character", "general"],
+                                multi_select_enabled: data.settings.multi_select_enabled || false,
+                                source_site: data.settings.source_site || "danbooru",
+                                gelbooru_display_all_site_content: data.settings.gelbooru_display_all_site_content || false,
+                                formatting: data.settings.formatting || { escapeBrackets: true, replaceUnderscores: true }
+                            };
+                        }
+                    } catch (e) {
+                        logger.warn("加载UI设置失败:", e);
+                    }
+                };
+
+                const saveUiSettings = async (settings) => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/ui_settings', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(settings)
+                        });
+                        const data = await response.json();
+                        return data.success;
+                    } catch (e) {
+                        logger.warn("保存UI设置失败:", e);
+                        return false;
+                    }
+                };
+
+                const loadBlacklist = async () => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/blacklist');
+                        const data = await response.json();
+                        currentBlacklist = data.blacklist || [];
+                    } catch (e) {
+                        logger.warn("加载黑名单失败:", e);
+                        currentBlacklist = [];
+                    }
+                };
+
+                const saveBlacklist = async (blacklistItems) => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/blacklist', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({ blacklist: blacklistItems })
+                        });
+                        const data = await response.json();
+                        return data.success;
+                    } catch (e) {
+                        logger.warn("保存黑名单失败:", e);
+                        return false;
+                    }
+                };
+
+                const loadFilterTags = async () => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/filter_tags');
+                        const data = await response.json();
+                        currentFilterTags = data.filter_tags || [];
+                        filterEnabled = data.filter_enabled !== undefined ? data.filter_enabled : true;
+                    } catch (e) {
+                        logger.warn("加载提示词过滤设置失败:", e);
+                        currentFilterTags = [];
+                        filterEnabled = true; // 默认开启
+                    }
+                };
+
+                const saveFilterTags = async (filterTags, enabled) => {
+                    try {
+                        const response = await fetch('/danbooru_gallery/filter_tags', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({ filter_tags: filterTags, filter_enabled: enabled })
+                        });
+                        const data = await response.json();
+                        return data.success;
+                    } catch (e) {
+                        logger.warn("保存提示词过滤设置失败:", e);
+                        return false;
+                    }
+                };
+
+
+                // 文件类型过滤函数 - 只允许静态图像
+                const isValidImageType = (post) => {
+                    // 允许的静态图像文件扩展名
+                    const allowedImageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'bmp', 'tiff', 'tif'];
+
+                    if (post.source_site === "gelbooru" && post._gelbooru_preview_only) {
+                        return true;
+                    }
+
+                    // 检查文件扩展名
+                    if (post.file_ext) {
+                        const fileExt = post.file_ext.toLowerCase();
+                        return allowedImageExtensions.includes(fileExt);
+                    }
+
+                    // 如果没有file_ext字段，尝试从file_url中提取扩展名
+                    if (post.file_url) {
+                        const url = post.file_url.toLowerCase();
+                        const extMatch = url.match(/\.([^.?#]+)(?:\?|#|$)/);
+                        if (extMatch) {
+                            const fileExt = extMatch[1];
+                            return allowedImageExtensions.includes(fileExt);
+                        }
+                    }
+
+                    // 如果无法确定文件类型，默认拒绝
+                    return false;
+                };
+
+                // 本地黑名单过滤函数
+                const isPostBlacklisted = (post) => {
+                    if (!currentBlacklist || currentBlacklist.length === 0) {
+                        return false;
+                    }
+
+                    // 获取帖子的所有标签
+                    const allTags = [];
+                    if (post.tag_string) allTags.push(...post.tag_string.split(' '));
+                    if (post.tag_string_artist) allTags.push(...post.tag_string_artist.split(' '));
+                    if (post.tag_string_copyright) allTags.push(...post.tag_string_copyright.split(' '));
+                    if (post.tag_string_character) allTags.push(...post.tag_string_character.split(' '));
+                    if (post.tag_string_general) allTags.push(...post.tag_string_general.split(' '));
+                    if (post.tag_string_meta) allTags.push(...post.tag_string_meta.split(' '));
+
+                    // 检查是否包含黑名单中的任何标签
+                    for (const blacklistTag of currentBlacklist) {
+                        const normalizedBlacklistTag = blacklistTag.trim().toLowerCase();
+                        if (normalizedBlacklistTag && allTags.some(tag => tag.toLowerCase() === normalizedBlacklistTag)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+
+                // 综合过滤函数 - 检查文件类型和黑名单
+                const isPostFiltered = (post) => {
+                    // 首先检查是否为有效的图像类型
+                    if (!isValidImageType(post)) {
+                        return true; // 如果不是有效图像类型，则过滤掉
+                    }
+
+                    // 然后检查黑名单
+                    return isPostBlacklisted(post);
+                };
+
+                // 获取单个帖子的原始数据
+                const fetchOriginalPost = async (postId) => {
+                    try {
+                        const params = new URLSearchParams({
+                            source: uiSettings.source_site || "danbooru",
+                            "search[tags]": `id:${postId}`,
+                            limit: "1",
+                            page: "1",
+                        });
+                        params.set("gelbooru_display_all_site_content", uiSettings.gelbooru_display_all_site_content ? "1" : "0");
+                        if ((uiSettings.source_site || "danbooru") === "gelbooru") {
+                            params.set("force_public_detail", "1");
+                        }
+                        const response = await fetch(`/danbooru_gallery/posts?${params}`);
+                        const data = await response.json();
+                        if (data && data.length > 0) {
+                            return data[0];
+                        }
+                        return null;
+                    } catch (error) {
+                        logger.error("Failed to fetch original post data:", error);
+                        return null;
+                    }
+                };
+
+                // 反向转换函数：将显示格式的标签转换回Danbooru API格式
+                const splitTagString = (value) => String(value || "").split(/\s+/).map(tag => tag.trim()).filter(Boolean);
+
+                const hasCategorizedTags = (postData) => Boolean(
+                    postData?.tag_string_artist ||
+                    postData?.tag_string_copyright ||
+                    postData?.tag_string_character ||
+                    postData?.tag_string_meta
+                );
+
+                const isUsableOriginalUrl = (postData, url) => Boolean(
+                    url &&
+                    !postData?._gelbooru_preview_only &&
+                    !(postData?.source_site === "gelbooru" && postData?.preview_file_url && url === postData.preview_file_url)
+                );
+
+                const hydrateGelbooruPost = async (postData) => {
+                    const hasUsableOriginal = isUsableOriginalUrl(postData, postData?.file_url);
+                    if (!postData || postData.source_site !== "gelbooru" || postData._gelbooru_hydrated || (hasCategorizedTags(postData) && hasUsableOriginal)) {
+                        return postData;
+                    }
+
+                    const cachedPost = originalPostCache[postData.id];
+                    const cachedHasUsableOriginal = isUsableOriginalUrl(cachedPost, cachedPost?.file_url);
+                    if (cachedPost && (cachedPost._gelbooru_hydrated || (hasCategorizedTags(cachedPost) && cachedHasUsableOriginal))) {
+                        return originalPostCache[postData.id];
+                    }
+
+                    const hydratedPost = await fetchOriginalPost(postData.id);
+                    if (!hydratedPost) {
+                        return postData;
+                    }
+
+                    const mergedPost = { ...postData, ...hydratedPost, _gelbooru_hydrated: true };
+                    const postIndex = posts.findIndex(p => p.id == postData.id);
+                    if (postIndex !== -1) {
+                        posts[postIndex] = mergedPost;
+                    }
+                    originalPostCache[postData.id] = JSON.parse(JSON.stringify(mergedPost));
+                    return mergedPost;
+                };
+
+                const hydrateGelbooruTooltipPost = hydrateGelbooruPost;
+
+                const getBestImageUrl = (postData, allowPreviewFallback = true) => {
+                    if (!postData) return "";
+                    if (isUsableOriginalUrl(postData, postData.file_url)) return postData.file_url;
+                    if (isUsableOriginalUrl(postData, postData.large_file_url)) return postData.large_file_url;
+                    return allowPreviewFallback ? (postData.preview_file_url || "") : "";
+                };
+
+                const getPostWithOriginalMedia = (postData) => {
+                    const basePost = temporaryTagEdits[postData.id] || postData;
+                    // 同步：帖子在加载时已完成 hydrate，选图时无需再 await 网络请求
+                    return basePost;
+                };
+
+                const proxiedMediaUrl = (url) => `/danbooru_gallery/image_proxy?url=${encodeURIComponent(url)}`;
+
+                const getImageExtension = (postData, imageUrl) => {
+                    if (postData?.file_ext) return postData.file_ext;
+                    const match = String(imageUrl || "").toLowerCase().match(/\.([a-z0-9]+)(?:[?#]|$)/);
+                    return match ? match[1] : "jpg";
+                };
+
+                const getSelectedPromptCategories = () => {
+                    const selected = Array.from(categoryDropdown.querySelectorAll("input:checked"))
+                        .map(i => i.name)
+                        .filter(name => TAG_CATEGORY_ORDER.includes(name));
+                    return selected.length > 0 ? selected : [...TAG_CATEGORY_ORDER];
+                };
+
+                const buildCategorizedTagLists = (postData) => {
+                    const categorizedTags = Object.fromEntries(TAG_CATEGORY_ORDER.map(category => [category, []]));
+                    const seen = new Set();
+
+                    const addTag = (category, tag) => {
+                        const cleanTag = String(tag || "").trim();
+                        if (!cleanTag || seen.has(cleanTag)) return;
+                        categorizedTags[category].push(cleanTag);
+                        seen.add(cleanTag);
+                    };
+
+                    TAG_CATEGORY_ORDER.forEach(category => {
+                        splitTagString(postData?.[`tag_string_${category}`]).forEach(tag => addTag(category, tag));
+                    });
+
+                    if (Object.values(categorizedTags).every(tags => tags.length === 0)) {
+                        splitTagString(postData?.tag_string).forEach(tag => addTag("general", tag));
+                    }
+
+                    return categorizedTags;
+                };
+
+                const normalizeTagForFilter = (tag) => String(tag || "")
+                    .trim()
+                    .toLowerCase()
+                    .replace(/\\([()])/g, '$1')
+                    .replace(/[,\s]+/g, '_')
+                    .replace(/^_+|_+$/g, '');
+
+                const getFilterTagSet = () => {
+                    if (!filterEnabled || currentFilterTags.length === 0) {
+                        return null;
+                    }
+                    return new Set(currentFilterTags.map(normalizeTagForFilter).filter(Boolean));
+                };
+
+                const shouldKeepPromptTag = (tag, filterTagSet) => {
+                    if (!filterTagSet) return true;
+                    return !filterTagSet.has(normalizeTagForFilter(tag));
+                };
+
+                const formatPromptTag = (tag) => {
+                    const escapeBrackets = formattingDropdown.querySelector('[name="escapeBrackets"]')?.checked ?? true;
+                    const replaceUnderscores = formattingDropdown.querySelector('[name="replaceUnderscores"]')?.checked ?? true;
+                    let processedTag = String(tag || "").trim();
+                    if (!processedTag) return "";
+                    if (replaceUnderscores) {
+                        processedTag = processedTag.replace(/_/g, ' ');
+                    }
+                    if (escapeBrackets) {
+                        processedTag = processedTag.replaceAll('(', '\\(').replaceAll(')', '\\)');
+                    }
+                    return processedTag;
+                };
+
+                const convertTagsToApiFormat = (tagsString) => {
+                    if (!tagsString) return "";
+
+                    // 只按逗号分割标签，保持空格作为标签名称的一部分
+                    const tags = tagsString.split(',').filter(tag => tag.trim() !== '');
+
+                    return tags.map(tag => {
+                        let convertedTag = tag.trim();
+
+                        // 1. 反转义括号：\( -> (, \) -> )
+                        convertedTag = convertedTag.replace(/\\([()])/g, '$1');
+
+                        // 2. 空格转换为下划线（如果包含空格且不是特殊tag）
+                        // 特殊tag通常以冒号开头（如 order:rank, ordfav:username）
+                        if (!convertedTag.includes(':')) {
+                            convertedTag = convertedTag.replace(/\s+/g, '_');
+                        }
+
+                        return convertedTag;
+                    }).join(' ');
+                };
+
+                let currentTags = ""; // 追踪当前搜索条件，用于决定是否重置游标（搜索条件变化时清空 lastPostId）
+
+                const fetchAndRender = async (reset = false) => {
+                    if (isLoading) return;
+                    if (endOfResults && !reset) return;
+                    isLoading = true;
+                    refreshButton.classList.add("loading");
+                    refreshButton.disabled = true;
+
+                    const loadingIndicator = imageGrid.querySelector('.danbooru-loading');
+                    if (!loadingIndicator) {
+                        imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
+                    }
+
+                    if (reset) {
+                        currentPage = filterState.startPage || 1;
+                        const newTags = searchInput.value.trim();
+                        if (newTags !== currentTags) {
+                            lastPostId = null;
+                            scrollAnchorPostId = null;
+                            seenPostIds.clear();
+                        } else if (scrollAnchorPostId) {
+                            // 搜索条件没变 + 有锚点 → 用锚点做游标，往下接
+                            lastPostId = scrollAnchorPostId;
+                        }
+                        currentTags = newTags;
+
+                        posts = [];
+                        endOfResults = false;
+                        imageGrid.innerHTML = "";
+                        imageGrid.insertAdjacentHTML('beforeend', `<p class="danbooru-status danbooru-loading">${t('loading')}</p>`);
+                    }
+
+                    // 网络检查
+                    const isNetworkConnected = await checkNetworkStatus();
+                    if (!isNetworkConnected) {
+                        console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");
+                        imageGrid.innerHTML = `<p class="danbooru-status error">网络连接失败，请检查网络连接后重试</p>`;
+                        isLoading = false;
+                        refreshButton.classList.remove("loading");
+                        refreshButton.disabled = false;
+                        const indicator = imageGrid.querySelector('.danbooru-loading');
+                        if (indicator) indicator.remove();
+                        return;
+                    } else {
+                        clearError();
+                    }
+
+                    let parseFailed = false;
+                    try {
+                        const searchValue = searchInput.value.trim();
+                        const tags = searchValue.split(',').filter(tag => tag.trim() !== '');
+                        const tagCount = tags.length;
+
+                        if (tagCount > 2) {
+                            showTagHint('搜索只考虑前两个tag，第三个及后续tag将被忽略', false);
+                        } else {
+                            clearTagHint();
+                        }
+
+                        let apiFormattedTags = convertTagsToApiFormat(searchValue);
+
+                        // 添加日期筛选
+                        if (filterState.startTime || filterState.endTime) {
+                            const start = filterState.startTime ? new Date(filterState.startTime).toISOString().split('T')[0] : '';
+                            const end = filterState.endTime ? new Date(filterState.endTime).toISOString().split('T')[0] : '';
+                            apiFormattedTags += ` date:${start}..${end}`;
+                        }
+
+                        const src = uiSettings.source_site || "danbooru";
+                        const dedup = uiSettings.gelbooru_dedup_mode || "off";
+                        const selectedRatings = getSelectedRatings();
+                        const sendAll = selectedRatings.length === 0 || selectedRatings.length === RATING_VALUES.length;
+                        const ratingForServer = sendAll ? "" : selectedRatings.join(",");
+                        const params = new URLSearchParams({
+                            "source": src,
+                            "gelbooru_display_all_site_content": uiSettings.gelbooru_display_all_site_content ? "1" : "0",
+                            "gelbooru_dedup_mode": dedup,
+                            "search[tags]": apiFormattedTags.trim(),
+                            "search[rating]": ratingForServer,
+                            limit: "40",
+                            page: currentPage,
+                        });
+
+                        // 游标分页：D站始终用游标；G站仅当 dedup 非 off 时
+                        const useCursor = src === "danbooru" || (src === "gelbooru" && dedup !== "off");
+                        if (useCursor && lastPostId) {
+                            params.set("before_id", lastPostId);
+                        }
+
+                        // G站游标模式下 pid 恒为 0，不允许当前页推进
+                        const gelbooruCursorMode = (src === "gelbooru" && dedup !== "off");
+
+                        const response = await fetch(`/danbooru_gallery/posts?${params}`);
+                        const rawText = await response.text();
+
+                        // 防御性 JSON 解析：后端偶发返回非 JSON（错误页/半截响应），此时不销毁已有内容
+                        let newPosts;
+                        try {
+                            newPosts = JSON.parse(rawText);
+                        } catch (parseErr) {
+                            logger.warn(`[fetchAndRender] 响应解析失败(status=${response.status})，本次跳过:`, parseErr?.message || parseErr);
+                            parseFailed = true;
+                            newPosts = [];
+                        }
+                        if (!Array.isArray(newPosts)) newPosts = [];
+
+                        if (parseFailed) {
+                            if (reset) {
+                                imageGrid.innerHTML = `<p class="danbooru-status error">响应解析失败(status=${response.status})</p>`;
+                                return;
+                            }
+                            renderPost({ error: `响应解析失败(status=${response.status})` });
+                            return;
+                        }
+
+                        // 先分离 error 占位格与正常 post
+                        const errorPosts = newPosts.filter(p => p && p.error);
+                        const normalRaw = newPosts.filter(p => !p || !p.error);
+
+                        // 去重：seenPostIds 中已存在的跳过（防止 G站 pid 失效产生的重复被加入 posts 数组）
+                        const freshRaw = normalRaw.filter(p => !seenPostIds.has(String(p.id)));
+                        freshRaw.forEach(p => seenPostIds.add(String(p.id)));
+
+                        // 对正常格做过滤
+                        const filteredPosts = freshRaw.filter(post => !isPostFiltered(post));
+
+                        if (errorPosts.length > 0) {
+                            if (reset && filteredPosts.length === 0 && freshRaw.length === 0) {
+                                // 首次加载全是 error 格：整屏错误
+                                imageGrid.innerHTML = `<p class="danbooru-status error">${errorPosts[0].error}</p>`;
+                                return;
+                            }
+                            // 续加载/混合正常格：追加 error 格
+                            errorPosts.forEach(renderPost);
+                        }
+
+                        if (newPosts.length === 0 && errorPosts.length === 0) {
+                            endOfResults = true;
+                            if (reset) {
+                                imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
+                            }
+                            return;
+                        }
+
+                        if (filteredPosts.length === 0 && freshRaw.length === 0 && reset && errorPosts.length === 0) {
+                            imageGrid.innerHTML = `<p class="danbooru-status">${t('noResults')}</p>`;
+                            return;
+                        }
+
+                        // 确保即使在 cursor 模式下过滤掉了所有正常图片也能推进游标
+                        if (normalRaw.length > 0) {
+                            lastPostId = normalRaw[normalRaw.length - 1].id;
+                        }
+
+                        // G站游标模式下 pid 恒定不推进；D站正常推进 page
+                        if (!gelbooruCursorMode) {
+                            currentPage++;
+                        }
+
+                        posts.push(...filteredPosts);
+                        filteredPosts.forEach(renderPost);
+
+                        // 去重陷阱检测：本页有返回值但全部是已见过的 → 判定到底
+                        if (freshRaw.length === 0 && normalRaw.length > 0 && !reset) {
+                            endOfResults = true;
+                            logger.warn(`[fetchAndRender] 本页 ${newPosts.length} 张全是重复，判定到底/分页失效，停止加载`);
+                            return;
+                        }
+
+                        // Filter-cascade guard
+                        if (filteredPosts.length === 0 && !reset) {
+                            await new Promise(r => setTimeout(r, 1500));
+                        }
+
+                    } catch (e) {
+                        // 首次加载→整屏错误；滚动续拉→保留内容+加错误格
+                        if (reset) {
+                            imageGrid.innerHTML = `<p class="danbooru-status error">${e.message}</p>`;
+                        } else {
+                            logger.warn('[fetchAndRender] 加载失败，保留已有内容:', e?.message || e);
+                            renderPost({ error: `请求失败: ${e.message}` });
+                        }
+                    } finally {
+                        isLoading = false;
+                        refreshButton.classList.remove("loading");
+                        refreshButton.disabled = false;
+                        const indicator = imageGrid.querySelector('.danbooru-loading');
+                        if (indicator) indicator.remove();
+                        // 刷新后还原滚动位置
+                        if (reset && scrollAnchorPostId) {
+                            // 等 maybeLoadMore 链走完（多个 setTimeout(…,0)）后尝试还原
+                            const attemptScroll = (retries = 8) => {
+                                const target = imageGrid.querySelector(`[data-post-id="${scrollAnchorPostId}"]`);
+                                if (target) {
+                                    target.scrollIntoView({ block: "start", behavior: "instant" });
+                                    return;
+                                }
+                                if (retries > 0) {
+                                    setTimeout(() => attemptScroll(retries - 1), 150);
+                                }
+                            };
+                            setTimeout(() => attemptScroll(), 300);
+                        }
+                        // 每次加载完成后检查是否需要补充更多（maybeLoadMore）
+                        if (!endOfResults && !parseFailed) {
+                            maybeLoadMore();
+                        }
+                    }
+                };
+
+                const maybeLoadMore = () => {
+                    if (isLoading || endOfResults) return;
+                    const bufferTarget = parseInt(uiSettings.preload_count, 10) || 40;
+                    const scrollH = imageGrid.scrollHeight;
+                    let viewedCount = 0;
+                    if (scrollH > 0) {
+                        const viewedRatio = Math.min(1, (imageGrid.scrollTop + imageGrid.clientHeight) / scrollH);
+                        viewedCount = Math.floor(posts.length * viewedRatio);
+                    }
+                    const aheadBuffer = posts.length - viewedCount;
+                    if (aheadBuffer < bufferTarget) {
+                        // 异步触发避免递归撑爆调用栈
+                        setTimeout(() => fetchAndRender(false), 0);
+                    }
+                };
+
+                // Queue 按钮拦截：每次点击时将当前选中快照推入后端 FIFO 队列
+                const _hookQueueButton = () => {
+                    // 兼容不同 ComfyUI 前端版本：data-testid（新版）/ #comfy-queue-btn（旧版）
+                    const queueBtn = document.querySelector('[data-testid="queue-button"]') || document.getElementById("comfy-queue-btn");
+                    if (!queueBtn) { setTimeout(_hookQueueButton, 500); return; }
+                    queueBtn.addEventListener("click", async () => {
+                        // 只处理最后活跃的节点，其他画廊节点跳过
+                        if (window.__lastActiveGalleryNodeId !== nodeInstanceId) return;
+                        const selectedWrappers = imageGrid.querySelectorAll('.danbooru-image-wrapper.selected');
+                        if (selectedWrappers.length === 0) return;
+                        const selections = [];
+                        for (const wrapper of selectedWrappers) {
+                            const postId = wrapper.dataset.postId;
+                            const postData = posts.find(p => p.id == postId) || temporaryTagEdits[postId];
+                            if (postData) {
+                                const prompt = buildPromptForPost(postData);
+                                const mediaPost = getPostWithOriginalMedia(postData);
+                                const imageUrl = getBestImageUrl(mediaPost, false);
+                                selections.push({ post_id: postId, prompt, image_url: imageUrl });
+                            }
+                        }
+                        if (selections.length === 0) return;
+                        selectionQueueId++;
+                        await fetch("/danbooru_gallery/selection_queue_push", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ item: { selections, _queue_id: selectionQueueId, nodeId: nodeInstanceId }, nodeId: nodeInstanceId })
+                        });
+                    }, true); // useCapture = true：在原始 onclick 之前触发
+                };
+                setTimeout(_hookQueueButton, 1000);
+
+                const resizeGrid = () => {
+                    try {
+                        const cs = window.getComputedStyle(imageGrid);
+                        const rowGap = parseInt(cs.getPropertyValue('grid-row-gap')) || parseInt(cs.rowGap) || 5;
+                        const rowHeight = parseInt(cs.getPropertyValue('grid-auto-rows')) || 1;
+
+                        Array.from(imageGrid.children).forEach((wrapper) => {
+                            const img = wrapper.querySelector('img');
+                            if (img && img.clientHeight > 0) {
+                                const spans = Math.ceil((img.clientHeight + rowGap) / (rowHeight + rowGap));
+                                wrapper.style.gridRowEnd = `span ${spans}`;
+                            }
+                        });
+                    } catch (e) {
+                        // 计算失败不影响主体流程
+                    }
+                }
+
+                // Pre-reserve grid space from post dimensions so rate-limited async loads
+                // don't cause the waterfall to jump every time an image arrives.
+                let cachedColumnWidth = 0;
+                const getColumnWidth = () => {
+                    if (cachedColumnWidth > 0) return cachedColumnWidth;
+                    try {
+                        const cs = window.getComputedStyle(imageGrid);
+                        const template = cs.gridTemplateColumns;
+                        if (template && template !== 'none') {
+                            const cols = template.split(' ');
+                            const px = parseFloat(cols[0]);
+                            if (px > 0) cachedColumnWidth = px;
+                        }
+                    } catch (e) {}
+                    return cachedColumnWidth || 150; // grid 未 layout 时保底 150px
+                };
+                const computeSpanFromDims = (imgW, imgH) => {
+                    const colW = getColumnWidth();
+                    if (!colW || !imgW || !imgH) return 0;
+                    const cs = window.getComputedStyle(imageGrid);
+                    const rowGap = parseInt(cs.gridRowGap) || parseInt(cs.rowGap) || 5;
+                    const rowHeight = parseInt(cs.gridAutoRows) || 1;
+                    const renderedH = colW * (imgH / imgW);
+                    return Math.ceil((renderedH + rowGap) / (rowHeight + rowGap));
+                };
+                // Coalesce rapid onload calls (rate-limited loads fire 200ms apart; batching
+                // to one reflow per frame avoids N² layout work as the page fills in).
+                let resizeGridTimer = null;
+                const scheduleResizeGrid = () => {
+                    if (resizeGridTimer) return;
+                    resizeGridTimer = requestAnimationFrame(() => {
+                        resizeGridTimer = null;
+                        resizeGrid();
+                    });
+                };
+
+                const showEditPanel = (post) => {
+                    markActive();
+                    // 在打开编辑面板时，检查当前图像是否被选中
+                    // 强制将当前编辑的图像设置为选中状态，并更新 selectionWidget
+                    const currentSelectedElement = imageGrid.querySelector('.danbooru-image-wrapper.selected');
+                    if (currentSelectedElement && currentSelectedElement.dataset.postId && currentSelectedElement.dataset.postId != post.id) { // 检查 dataset.postId 是否存在
+                        currentSelectedElement.classList.remove('selected');
+
+                    }
+                    const targetWrapper = imageGrid.querySelector(`.danbooru-image-wrapper[data-post-id="${post.id}"]`);
+                    if (targetWrapper) {
+                        targetWrapper.classList.add('selected');
+                        // 触发一次点击事件来更新 selectionWidget
+                        // 注意：这里直接调用 onclick 可能会导致事件冒泡问题，
+                        // 更好的方式是直接更新 selectionWidget 的值
+                        // targetWrapper.querySelector('img').click();
+                        // 而是直接更新 selectionWidget
+                        updateSelectionData();
+                    }
+                    const isPostCurrentlySelected = true; // 因为我们已经强制选中了
+
+
+                    if (!temporaryTagEdits[post.id]) {
+                        // Create a deep copy for editing if it doesn't exist
+                        temporaryTagEdits[post.id] = JSON.parse(JSON.stringify(post));
+                    }
+                    const editablePost = temporaryTagEdits[post.id];
+
+                    // Panel container
+                    const panel = $el("div.danbooru-edit-panel", {
+                        style: {
+                            position: "fixed", top: "0", left: "0", width: "100%", height: "100%",
+                            backgroundColor: "rgba(0, 0, 0, 0.7)", zIndex: "10001",
+                            display: "flex", alignItems: "center", justifyContent: "center"
+                        }
+                    });
+
+                    // Panel content
+                    const content = $el("div.danbooru-edit-panel-content", {
+                        style: {
+                            backgroundColor: "var(--comfy-menu-bg)", border: "1px solid var(--input-border-color)",
+                            borderRadius: "12px", padding: "20px", width: "700px", maxWidth: "90vw",
+                            maxHeight: "80vh", display: "flex", flexDirection: "column",
+                            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)"
+                        }
+                    });
+
+                    // Title
+                    const titleBar = $el("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "15px" } }, [
+                        $el("h2", { textContent: t('editPanelTitle'), style: { margin: "0", color: "var(--comfy-input-text)", fontSize: "1.3em" } }),
+                        $el("button.danbooru-edit-panel-close-button", {
+                            innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`,
+                            title: t('close'),
+                            onclick: () => closePanel(isPostCurrentlySelected) // 将捕获到的选中状态传递给 closePanel
+                        })
+                    ]);
+
+                    const tagsContainer = $el("div.danbooru-edit-tags-container", { style: { overflowY: "auto", flex: "1", paddingRight: "10px" } });
+
+                    const closePanel = async (wasSelectedOnOpen) => { // 接收打开面板时的选中状态
+                        panel.remove();
+                        const currentPostInArray = posts.find(p => p.id == post.id); // 获取posts数组中最新的post数据
+                        if (!currentPostInArray) {
+                            return;
+                        }
+
+                        // 准备数据，如果被编辑过则使用临时数据
+                        let postDataToRender = temporaryTagEdits[post.id];
+
+                        // 获取原始数据，用于比较
+                        const originalPost = originalPostCache[post.id];
+
+                        // 检查是否有实际编辑
+                        let hasActualEdits = false;
+                        if (postDataToRender && originalPost) {
+                            const categories = ["artist", "copyright", "character", "general", "meta"];
+                            for (const category of categories) {
+                                if (!compareTagStrings(originalPost[`tag_string_${category}`], postDataToRender[`tag_string_${category}`])) {
+                                    hasActualEdits = true;
+                                    break;
+                                }
+                            }
+                            if (!hasActualEdits && !compareTagStrings(originalPost.tag_string, postDataToRender.tag_string)) {
+                                hasActualEdits = true;
+                            }
+                        }
+
+                        if (hasActualEdits) {
+                            // 如果有实际编辑，用编辑后的数据更新posts数组
+                            const postIndex = posts.findIndex(p => p.id == post.id);
+                            if (postIndex !== -1) {
+                                posts[postIndex] = JSON.parse(JSON.stringify(postDataToRender)); // 确保深拷贝
+                            }
+                        } else {
+                            // 如果没有实际编辑，清理临时副本
+                            temporaryTagEdits[post.id] = undefined;
+                            postDataToRender = currentPostInArray; // 确保渲染时使用 posts 数组中的当前数据
+                        }
+
+                        // 重新渲染该post
+                        const oldPostElement = imageGrid.querySelector(`.danbooru-image-wrapper[data-post-id="${post.id}"]`);
+
+                        const postIndex = posts.findIndex(p => p.id == post.id);
+                        const newPostElement = createPostElement(posts[postIndex]); // 使用 posts 数组中的最新数据
+                        if (newPostElement) {
+                            if (oldPostElement && oldPostElement.parentNode) {
+                                oldPostElement.parentNode.replaceChild(newPostElement, oldPostElement);
+                            } else {
+                                imageGrid.prepend(newPostElement);
+                            }
+                            resizeGrid();
+                        } else {
+                            if (oldPostElement) {
+                                oldPostElement.remove();
+                            }
+                        }
+
+                        // 无论是否编辑，如果打开面板时是选中状态，都强制更新selectionWidget和选中样式
+                        if (wasSelectedOnOpen) {
+                            // 重新给新元素添加选中状态
+                            if (newPostElement) {
+                                newPostElement.classList.add('selected');
+
+                            }
+                            updateSelectionData();
+                        } else { // 如果打开面板时未选中，则清除所有选中的图像和提示词
+
+                            imageGrid.querySelectorAll('.danbooru-image-wrapper.selected').forEach(w => {
+
+                                w.classList.remove('selected');
+                            });
+                            if (nodeInstance && nodeInstance.widgets) {
+                                const selectionWidget = nodeInstance.widgets.find(w => w.name === "selection_data");
+                                if (selectionWidget) {
+                                    selectionWidget.value = JSON.stringify({});
+                                    selectionWidget.callback();
+
+                                }
+                            }
+                        }
+
+                        // 重新计算 isTrulyEdited 状态并更新指示器 (这里调用 updateEditedStatus 会基于新的逻辑进行判断)
+                        // 注意：这里不再需要手动删除 temporaryTagEdits，因为 updateEditedStatus 会在判断为未编辑时将其设置为 undefined
+                        let indicator = newPostElement ? newPostElement.querySelector('.danbooru-edited-indicator') : null;
+                        if (newPostElement) {
+                            // 确保 newPostElement 已经添加到 DOM 中，updateEditedStatus 才能找到 indicator
+                            // 或者直接传递 isTrulyEdited 状态
+                            updateEditedStatus(newPostElement, post.id); // 调用更新函数
+                        }
+                    };
+
+                    content.appendChild(titleBar);
+                    content.appendChild(tagsContainer);
+
+                    // Add a footer for action buttons
+                    const editPanelFooter = $el("div", {
+                        style: {
+                            display: "flex",
+                            justifyContent: "flex-end", // Changed to align items to the end (right)
+                            alignItems: "center",
+                            marginTop: "15px",
+                            paddingTop: "15px",
+                            borderTop: "1px solid var(--input-border-color)",
+                            gap: "10px", // Add some gap between buttons
+                        }
+                    });
+
+                    // "Copy Tags to Clipboard" button
+                    const copyTagsButton = $el("button", {
+                        innerHTML: `📋 ${t('copyTags')}`,
+                        style: {
+                            padding: "8px 15px",
+                            border: "1px solid #7B68EE",
+                            borderRadius: "6px",
+                            backgroundColor: "transparent",
+                            color: "#7B68EE",
+                            cursor: "pointer",
+                            fontSize: "14px",
+                            fontWeight: "500",
+                            transition: "all 0.2s ease"
+                        },
+                        onclick: async () => {
+                            // Collect selected categories from checkboxes
+                            const selectedCategoriesCheckboxes = panel.querySelectorAll('.danbooru-edit-category-checkbox:checked');
+                            const selectedCategoriesToCopy = Array.from(selectedCategoriesCheckboxes).map(cb => cb.name);
+
+                            const postToCopy = temporaryTagEdits[post.id] || post;
+                            const formattedTags = buildPromptForPost(postToCopy, selectedCategoriesToCopy);
+
+                            if (formattedTags) {
+                                try {
+                                    await navigator.clipboard.writeText(formattedTags);
+                                    showToast(t('copyTagsSuccess'), 'success', copyTagsButton);
+                                } catch (err) {
+                                    showToast(t('copyTagsFail'), 'error', copyTagsButton);
+                                    logger.error('Failed to copy: ', err);
+                                }
+                            } else {
+                                showToast(t('noTagsToCopy'), 'info', copyTagsButton);
+                            }
+                        }
+                    });
+                    editPanelFooter.appendChild(copyTagsButton);
+
+                    // "Reset Tags" button (moved and restyled)
+                    const resetTagsButton = $el("button.danbooru-reset-tags-button", {
+                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg> ${t('resetTags')}`,
+                        title: t('resetTags'),
+                        onclick: async () => {
+                            // 1. 从缓存中获取原始post数据
+                            const originalPostData = originalPostCache[post.id];
+
+                            if (originalPostData) {
+                                // 2. Update posts array with original data
+                                const postIndex = posts.findIndex(p => p.id === post.id);
+                                if (postIndex !== -1) {
+                                    posts[postIndex] = JSON.parse(JSON.stringify(originalPostData)); // 确保深拷贝
+                                }
+
+                                // 3. Clear temporaryTagEdits for this post
+                                temporaryTagEdits[post.id] = undefined;
+
+                                // 4. Re-render tags in the panel with the original data
+                                renderTagsInPanel(tagsContainer, originalPostData, panel);
+
+                                // 5. Update "edited" indicator on the main grid item
+                                const wrapperElement = imageGrid.querySelector(`.danbooru-image-wrapper[data-post-id="${post.id}"]`);
+                                if (wrapperElement) {
+                                    updateEditedStatus(wrapperElement, originalPostData.id);
+                                }
+
+                                // 6. Update selectionWidget if the post is currently selected
+                                if (isPostCurrentlySelected) {
+                                    updateSelectionData();
+                                }
+                                showToast(t('resetTags') + '成功', 'success', resetTagsButton);
+                            } else {
+                                // 如果缓存中没有原始数据，尝试从服务器获取一次
+                                const fetchedOriginalPost = await fetchOriginalPost(post.id);
+                                if (fetchedOriginalPost) {
+                                    originalPostCache[post.id] = JSON.parse(JSON.stringify(fetchedOriginalPost)); // 缓存获取到的数据
+                                    // 再次调用自身，以使用缓存中的数据进行重置
+                                    showToast('已从服务器获取原始标签，请再次点击重置。', 'info', resetTagsButton);
+                                    // 重新渲染面板
+                                    renderTagsInPanel(tagsContainer, originalPostCache[post.id], panel);
+                                } else {
+                                    showError('未能获取原始标签，请检查网络或稍后重试。', false, resetTagsButton);
+                                }
+                            }
+                        }
+                    });
+                    editPanelFooter.appendChild(resetTagsButton);
+
+                    content.appendChild(editPanelFooter);
+                    panel.appendChild(content);
+
+                    // Close panel when clicking background
+                    panel.addEventListener('click', (e) => {
+                        if (e.target === panel) {
+                            closePanel();
+                        }
+                    });
+
+                    document.body.appendChild(panel);
+
+                    renderTagsInPanel(tagsContainer, editablePost, panel);
+                };
+
+                const renderTagsInPanel = async (tagsContainer, postData, panel) => {
+                    tagsContainer.innerHTML = ''; // Clear existing tags
+
+                    const createClickableTagSpan = (tag, category, translation = null) => {
+                        const displayText = translation ? `${tag} [${translation}]` : tag;
+                        const span = $el("span", {
+                            textContent: displayText,
+                            className: `danbooru-tooltip-tag danbooru-clickable-tag tag-category-${category}`,
+                        });
+
+                        const removeExistingMenus = () => {
+                            document.querySelectorAll('.danbooru-tag-context-menu').forEach(menu => menu.remove());
+                        };
+
+                        span.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            removeExistingMenus();
+
+                            const menu = $el("div.danbooru-tag-context-menu", {
+                                style: {
+                                    position: 'absolute',
+                                    zIndex: '10002',
+                                    backgroundColor: 'var(--comfy-menu-bg)',
+                                    border: '1px solid var(--input-border-color)',
+                                    borderRadius: '6px',
+                                    boxShadow: '0 2px 10px rgba(0,0,0,0.3)',
+                                    padding: '5px',
+                                }
+                            });
+
+                            const searchOption = $el("div.danbooru-context-menu-item", {
+                                textContent: '🔍 ' + t('search'),
+                                onclick: () => {
+                                    const currentVal = searchInput.value.trim();
+                                    const apiTag = tag.replace(/\s+/g, '_');
+                                    let newValue;
+                                    if (currentVal && !/,\s*$/.test(currentVal)) {
+                                        newValue = `${currentVal}, ${apiTag}, `;
+                                    } else if (currentVal) {
+                                        newValue = `${currentVal} ${apiTag}, `;
+                                    } else {
+                                        newValue = `${apiTag}, `;
+                                    }
+                                    searchInput.value = newValue;
+                                    searchInput.dispatchEvent(new Event('input'));
+                                    fetchAndRender(true);
+                                    menu.remove();
+                                }
+                            });
+
+                            const deleteOption = $el("div.danbooru-context-menu-item", {
+                                textContent: '🗑️ ' + t('delete'),
+                                onclick: () => {
+                                    if (postData[`tag_string_${category}`]) {
+                                        const tags = postData[`tag_string_${category}`].split(' ');
+                                        const index = tags.indexOf(tag);
+                                        if (index > -1) {
+                                            tags.splice(index, 1);
+                                            postData[`tag_string_${category}`] = tags.join(' ');
+                                        }
+                                    }
+                                    // 强制重新渲染以更新状态
+                                    renderTagsInPanel(tagsContainer, temporaryTagEdits[postData.id] || postData, panel);
+                                    menu.remove();
+                                }
+                            });
+
+                            menu.appendChild(searchOption);
+                            menu.appendChild(deleteOption);
+
+                            document.body.appendChild(menu);
+
+                            const rect = span.getBoundingClientRect();
+                            menu.style.left = `${rect.left}px`;
+                            menu.style.top = `${rect.bottom + 5}px`;
+
+                            const closeMenuHandler = (event) => {
+                                if (!menu.contains(event.target)) {
+                                    menu.remove();
+                                    document.removeEventListener('click', closeMenuHandler, true);
+                                }
+                            };
+                            document.addEventListener('click', closeMenuHandler, true);
+                        });
+
+                        return span;
+                    };
+
+                    const categoryOrder = TAG_CATEGORY_ORDER;
+                    const categorizedTags = { artist: new Set(), copyright: new Set(), character: new Set(), general: new Set(), meta: new Set() };
+
+                    if (postData.tag_string_artist) postData.tag_string_artist.split(' ').forEach(t => categorizedTags.artist.add(t));
+                    if (postData.tag_string_copyright) postData.tag_string_copyright.split(' ').forEach(t => categorizedTags.copyright.add(t));
+                    if (postData.tag_string_character) postData.tag_string_character.split(' ').forEach(t => categorizedTags.character.add(t));
+                    if (postData.tag_string_general) postData.tag_string_general.split(' ').forEach(t => categorizedTags.general.add(t));
+                    if (postData.tag_string_meta) postData.tag_string_meta.split(' ').forEach(t => categorizedTags.meta.add(t));
+
+                    if (Object.values(categorizedTags).every(s => s.size === 0) && postData.tag_string) {
+                        postData.tag_string.split(' ').forEach(t => categorizedTags.general.add(t));
+                    }
+
+                    const allTags = Array.from(new Set(categoryOrder.flatMap(cat => Array.from(categorizedTags[cat])))).filter(Boolean);
+
+                    let translations = {};
+                    if (globalMultiLanguageManager.getLanguage() === 'zh' && allTags.length > 0) {
+                        try {
+                            const response = await fetch('/danbooru_gallery/translate_tags_batch', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ tags: allTags })
+                            });
+                            const data = await response.json();
+                            if (data.success) translations = data.translations;
+                        } catch (error) { logger.warn("Tag translation failed for edit panel:", error); }
+                    }
+
+                    categoryOrder.forEach(categoryName => {
+                        const tags = categorizedTags[categoryName];
+                        if (tags.size > 0) {
+                            const section = $el("div.danbooru-edit-panel-section"); // Changed class name for clarity
+
+                            // Add a checkbox for each category in the edit panel
+                            const categoryCheckboxId = `edit-panel-category-${categoryName}`;
+                            const categoryCheckbox = $el("input", {
+                                type: "checkbox",
+                                id: categoryCheckboxId,
+                                name: categoryName,
+                                checked: getSelectedPromptCategories().includes(categoryName),
+                                className: "danbooru-edit-category-checkbox"
+                            });
+                            const categoryLabel = $el("label", {
+                                htmlFor: categoryCheckboxId,
+                                textContent: t(categoryName),
+                                style: { marginLeft: "5px", fontWeight: "600", color: "#b0b3b8" } // Style to match header
+                            });
+
+                            const categoryHeader = $el("div", { style: { display: "flex", alignItems: "center", marginBottom: "4px" } }, [categoryCheckbox, categoryLabel]);
+                            section.appendChild(categoryHeader);
+                            const tagsWrapper = $el("div.danbooru-tooltip-tags-wrapper");
+                            tags.forEach(tag => {
+                                if (!tag) return;
+                                const translation = translations[tag];
+                                tagsWrapper.appendChild(createClickableTagSpan(tag, categoryName, translation));
+                            });
+
+                            // Add "+" button for adding new tags
+                            const addButton = $el("button.danbooru-add-tag-button", {
+                                textContent: "+",
+                                title: t('addTag'),
+                                onclick: (e) => {
+                                    e.stopPropagation();
+                                    addButton.style.display = 'none'; // Hide the add button
+
+                                    const inputContainer = $el("div.danbooru-add-tag-container");
+                                    const input = $el("input.danbooru-add-tag-input", { type: "text", placeholder: t('addTag') + "..." });
+
+                                    inputContainer.appendChild(input);
+                                    tagsWrapper.appendChild(inputContainer);
+
+                                    input.focus();
+
+                                    // 创建智能补全实例
+                                    const tagAutocomplete = new AutocompleteUI({
+                                        inputElement: input,
+                                        language: globalMultiLanguageManager.getLanguage(),
+                                        source: uiSettings.source_site || "danbooru",
+                                        maxSuggestions: uiSettings.autocomplete_max_results || 20,
+                                        customClass: 'danbooru-tag-editor-autocomplete',
+                                        formatTag: (tag) => {
+                                            // 应用格式化设置
+                                            let processedTag = tag;
+                                            if (uiSettings.formatting && uiSettings.formatting.replaceUnderscores) {
+                                                processedTag = processedTag.replace(/_/g, ' ');
+                                            }
+                                            if (uiSettings.formatting && uiSettings.formatting.escapeBrackets) {
+                                                processedTag = processedTag.replaceAll('(', '\\(').replaceAll(')', '\\)');
+                                            }
+                                            return processedTag;
+                                        },
+                                        onSelect: (selectedTag) => {
+                                            const newTag = selectedTag.trim().replace(/\s/g, '_');
+                                            if (newTag) {
+                                                const tagStringKey = `tag_string_${categoryName}`;
+                                                const currentTags = postData[tagStringKey] ? postData[tagStringKey].split(' ') : [];
+                                                if (!currentTags.includes(newTag)) {
+                                                    currentTags.push(newTag);
+                                                    postData[tagStringKey] = currentTags.join(' ');
+                                                }
+                                                // 强制重新渲染以更新状态
+                                                renderTagsInPanel(tagsContainer, temporaryTagEdits[postData.id] || postData, panel);
+                                            }
+                                            tagAutocomplete.destroy();
+                                            inputContainer.remove();
+                                            addButton.style.display = 'inline-flex';
+                                        }
+                                    });
+
+                                    input.addEventListener('keydown', (e) => {
+                                        if (e.key === 'Enter' && input.value.trim()) {
+                                            const newTag = input.value.trim().replace(/\s/g, '_');
+                                            if (newTag) {
+                                                const tagStringKey = `tag_string_${categoryName}`;
+                                                const currentTags = postData[tagStringKey] ? postData[tagStringKey].split(' ') : [];
+                                                if (!currentTags.includes(newTag)) {
+                                                    currentTags.push(newTag);
+                                                    postData[tagStringKey] = currentTags.join(' ');
+                                                }
+                                                renderTagsInPanel(tagsContainer, temporaryTagEdits[postData.id] || postData, panel);
+                                            }
+                                            tagAutocomplete.destroy();
+                                            inputContainer.remove();
+                                            addButton.style.display = 'inline-flex';
+                                        } else if (e.key === 'Escape') {
+                                            tagAutocomplete.destroy();
+                                            inputContainer.remove();
+                                            addButton.style.display = 'inline-flex';
+                                        }
+                                    });
+
+                                    const blurHandler = () => {
+                                        // 延迟以便点击建议能够注册
+                                        setTimeout(() => {
+                                            if (!inputContainer.contains(document.activeElement)) {
+                                                tagAutocomplete.destroy();
+                                                inputContainer.remove();
+                                                addButton.style.display = 'inline-flex';
+                                            }
+                                        }, 200);
+                                    };
+                                    input.addEventListener('blur', blurHandler);
+                                }
+                            });
+                            tagsWrapper.appendChild(addButton);
+
+                            section.appendChild(tagsWrapper);
+                            tagsContainer.appendChild(section);
+                        }
+                    });
+
+                    // After rendering, check if the post is edited and update the main grid item
+                    const postElement = imageGrid.querySelector(`.danbooru-image-wrapper[data-post-id="${postData.id}"]`);
+                    if (postElement) {
+                        updateEditedStatus(postElement, postData.id);
+                    }
+                };
+
+                // 辅助函数：为单个帖子构建提示词
+                const buildPromptForPost = (postData, selectedCategoriesOverride = null) => {
+                    // 同步：G站在加载时已完成 hydrate，选图时 tag_xxx 已就绪，无需再 await 网络请求
+                    const promptPost = temporaryTagEdits[postData.id] || postData;
+
+                    const promptCategories = Array.isArray(selectedCategoriesOverride)
+                        ? selectedCategoriesOverride.filter(name => TAG_CATEGORY_ORDER.includes(name))
+                        : getSelectedPromptCategories();
+                    const categoriesToUse = promptCategories.length > 0 ? promptCategories : [...TAG_CATEGORY_ORDER];
+                    const categorizedPromptTags = buildCategorizedTagLists(promptPost);
+                    const filterTagSet = getFilterTagSet();
+
+                    const orderedFilteredTags = categoriesToUse.flatMap(category => categorizedPromptTags[category] || [])
+                        .filter(tag => shouldKeepPromptTag(tag, filterTagSet));
+
+                    return orderedFilteredTags.map(formatPromptTag).filter(Boolean).join(', ');
+                };
+
+                // 辅助函数：收集所有选中图片的数据并更新 widget
+                const updateSelectionData = () => {
+                    const selectedWrappers = imageGrid.querySelectorAll('.danbooru-image-wrapper.selected');
+                    const selections = [];
+
+                    for (const wrapper of selectedWrappers) {
+                        const postId = wrapper.dataset.postId;
+                        const postData = posts.find(p => p.id == postId) || temporaryTagEdits[postId];
+                        if (postData) {
+                            const prompt = buildPromptForPost(postData);
+                            const updatedPostData = posts.find(p => p.id == postId) || temporaryTagEdits[postId] || postData;
+                            const mediaPost = getPostWithOriginalMedia(updatedPostData);
+                            const imageUrl = getBestImageUrl(mediaPost, false);
+                            selections.push({
+                                post_id: postId,
+                                prompt: prompt,
+                                image_url: imageUrl
+                            });
+                        }
+                    }
+
+                    const selectionData = { selections: selections, nodeId: nodeInstanceId };
+
+                    // 更新 widget（仍保留用于兼容回退）
+                    if (nodeInstance && nodeInstance.widgets) {
+                        const selectionWidget = nodeInstance.widgets.find(w => w.name === "selection_data");
+                        if (selectionWidget) {
+                            selectionWidget.value = JSON.stringify(selectionData);
+                            selectionWidget.callback();
+                        }
+                    }
+
+                    // 标记自己为最后活跃
+                    markActive();
+
+                    // 更新选中计数显示
+                    updateSelectionCount(selections.length);
+                };
+
+                // 辅助函数：更新选中计数显示
+                const updateSelectionCount = (count) => {
+                    const countBadge = document.querySelector('.danbooru-selection-count');
+                    if (countBadge) {
+                        if (count > 0 && uiSettings.multi_select_enabled) {
+                            countBadge.textContent = t('selectedCount').replace('{count}', count);
+                            countBadge.style.display = 'inline-block';
+                        } else {
+                            countBadge.style.display = 'none';
+                        }
+                    }
+                };
+
+                // 辅助函数：清除所有选中
+                const clearAllSelections = () => {
+                    imageGrid.querySelectorAll('.danbooru-image-wrapper.selected').forEach(w => {
+                        w.classList.remove('selected');
+                    });
+                    updateSelectionData();
+                };
+
+                const createPostElement = (post) => {
+                    // error 占位格：红色边框，直接显示错误文本
+                    if (post && post.error) {
+                        const wrapper = $el("div.danbooru-image-wrapper", {
+                            style: { border: '1px solid #ff4444', minHeight: '80px', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#ff4444', fontSize: '0.85em', padding: '8px', textAlign: 'center' }
+                        });
+                        wrapper.dataset.postId = `err_${post.pid || post.page || '?'}`;
+                        wrapper.textContent = post.error;
+                        return wrapper;
+                    }
+
+                    if (!post.id || !post.preview_file_url) return null;
+
+                    const wrapper = $el("div.danbooru-image-wrapper");
+                    wrapper.dataset.postId = post.id; // 显式设置 data-post-id
+
+                    // Reserve grid space up-front from the post's real dimensions so the
+                    // waterfall is stable before thumbnails finish loading.
+                    // G公开页返回的 post 经常 image_width/height=0，按列宽的估算方形保底高度
+                    let reservedSpans = 0;
+                    if (post.image_width && post.image_height) {
+                        reservedSpans = computeSpanFromDims(post.image_width, post.image_height);
+                    }
+                    if (reservedSpans <= 0) {
+                        const colW = getColumnWidth();
+                        const rowGap = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-row-gap')) || parseInt(window.getComputedStyle(imageGrid).rowGap) || 5;
+                        const rowHeight = parseInt(window.getComputedStyle(imageGrid).getPropertyValue('grid-auto-rows')) || 1;
+                        reservedSpans = colW > 0 ? Math.ceil((colW + rowGap) / (rowHeight + rowGap)) : 200;
+                    }
+                    if (reservedSpans > 0) wrapper.style.gridRowEnd = `span ${reservedSpans}`;
+
+                    // 首次创建post元素时，将原始post数据添加到 originalPostCache
+                    if (!originalPostCache[post.id]) {
+                        originalPostCache[post.id] = JSON.parse(JSON.stringify(post));
+                    }
+
+                    // Check and apply edited status on creation
+                    updateEditedStatus(wrapper, post.id);
+
+                    const previewUrl = (post.source_site === "gelbooru")
+                        ? post.preview_file_url
+                        : `${post.preview_file_url}?v=${post.md5}`;
+
+                    const img = $el("img", {
+                        src: `/danbooru_gallery/image_proxy?url=${encodeURIComponent(previewUrl)}`,
+                        onload: scheduleResizeGrid,
+                        onerror: () => { wrapper.style.display = 'none'; },
+                        onclick: (e) => {
+                            e.stopPropagation();
+                            markActive(); // 标记自己为最后活跃节点
+                            const isSelected = wrapper.classList.contains('selected');
+                            const isMultiSelectMode = uiSettings.multi_select_enabled;
+
+                            // 单选模式下，先清除所有其他图像的选中状态
+                            if (!isMultiSelectMode) {
+                                imageGrid.querySelectorAll('.danbooru-image-wrapper').forEach(w => {
+                                    if (w !== wrapper) {
+                                        w.classList.remove('selected');
+                                    }
+                                });
+                            }
+
+                            // 切换当前图像的选中状态
+                            if (!isSelected) {
+                                wrapper.classList.add('selected');
+                            } else {
+                                wrapper.classList.remove('selected');
+                            }
+
+                            // 收集所有选中图片的数据并更新 widget
+                            updateSelectionData();
+                        },
+                    });
+
+                    // 创建下载按钮
+                    const downloadButton = $el("button.danbooru-download-button", {
+                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                            <polyline points="7 10 12 15 17 10"></polyline>
+                            <line x1="12" y1="15" x2="12" y2="3"></line>
+                        </svg>`,
+                        title: t('download'),
+                        onclick: async (e) => {
+                            e.stopPropagation(); // 阻止事件冒泡，避免触发图片选择
+
+                            try {
+                                const mediaPost = getPostWithOriginalMedia(post);
+                                const imageUrl = getBestImageUrl(mediaPost, false);
+                                if (!imageUrl) {
+                                    return;
+                                }
+
+                                // 获取图片文件扩展名
+                                const fileExt = getImageExtension(mediaPost, imageUrl);
+                                const fileName = `danbooru_${post.id}.${fileExt}`;
+
+                                // 通过后端代理下载，避免被 Cloudflare 按 cross-site referer 拦截
+                                const proxyUrl = proxiedMediaUrl(imageUrl);
+                                const response = await fetch(proxyUrl);
+                                const blob = await response.blob();
+                                const url = window.URL.createObjectURL(blob);
+
+                                const a = document.createElement('a');
+                                a.href = url;
+                                a.download = fileName;
+                                document.body.appendChild(a);
+                                a.click();
+                                document.body.removeChild(a);
+                                window.URL.revokeObjectURL(url);
+                            } catch (error) {
+                                // 下载失败，静默处理
+                            }
+                        }
+                    });
+
+                    // 使用全局tooltip实例
+                    if (!globalTooltip) {
+                        globalTooltip = $el("div.danbooru-tag-tooltip", { style: { display: "none", position: "absolute", zIndex: "1000" } });
+                        const tagsContainer = $el("div", { className: "danbooru-tooltip-tags" });
+                        globalTooltip.appendChild(tagsContainer);
+                        document.body.appendChild(globalTooltip);
+                    }
+
+                    const createTagSpan = (tag, category, translation = null) => {
+                        const displayText = translation ? `${tag} [${translation}]` : tag;
+                        return $el("span", {
+                            textContent: displayText,
+                            className: `danbooru-tooltip-tag tag-category-${category}`,
+                        });
+                    };
+
+                    let currentClickHandler = null;
+
+                    wrapper.addEventListener("mouseenter", async (e) => {
+                        if (!uiSettings.tooltip_enabled) return;
+
+                        // 生成新的tooltip ID，使之前的异步请求失效
+                        currentTooltipId++;
+                        const thisTooltipId = currentTooltipId;
+
+                        clearTimeout(globalTooltipTimeout);
+
+                        const tagsContainer = globalTooltip.querySelector('.danbooru-tooltip-tags');
+                        tagsContainer.innerHTML = '';
+                        const postForTooltip = await hydrateGelbooruTooltipPost(post);
+                        if (thisTooltipId !== currentTooltipId) {
+                            return;
+                        }
+
+                        // Details Section
+                        const detailsSection = $el("div.danbooru-tooltip-section");
+                        detailsSection.appendChild($el("div.danbooru-tooltip-category-header", { textContent: t('details') }));
+                        if (postForTooltip.created_at) {
+                            const date = new Date(postForTooltip.created_at);
+                            const formattedDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+                            detailsSection.appendChild($el("div", { textContent: `${t('uploaded')}: ${formattedDate}`, className: "danbooru-tooltip-upload-date" }));
+                        }
+                        if (postForTooltip.image_width && postForTooltip.image_height) {
+                            detailsSection.appendChild($el("div", { textContent: `${t('resolution')}: ${postForTooltip.image_width}×${postForTooltip.image_height}`, className: "danbooru-tooltip-upload-date" }));
+                        }
+                        tagsContainer.appendChild(detailsSection);
+
+                        // Tags Processing
+                        const categoryOrder = TAG_CATEGORY_ORDER;
+                        const categorizedTags = {
+                            artist: new Set(),
+                            copyright: new Set(),
+                            character: new Set(),
+                            general: new Set(),
+                            meta: new Set()
+                        };
+
+                        if (postForTooltip.tag_string_artist) postForTooltip.tag_string_artist.split(' ').forEach(t => categorizedTags.artist.add(t));
+                        if (postForTooltip.tag_string_copyright) postForTooltip.tag_string_copyright.split(' ').forEach(t => categorizedTags.copyright.add(t));
+                        if (postForTooltip.tag_string_character) postForTooltip.tag_string_character.split(' ').forEach(t => categorizedTags.character.add(t));
+                        if (postForTooltip.tag_string_general) postForTooltip.tag_string_general.split(' ').forEach(t => categorizedTags.general.add(t));
+                        if (postForTooltip.tag_string_meta) postForTooltip.tag_string_meta.split(' ').forEach(t => categorizedTags.meta.add(t));
+
+                        // Fallback for older posts or different tag string formats
+                        if (Object.values(categorizedTags).every(s => s.size === 0) && postForTooltip.tag_string) {
+                            postForTooltip.tag_string.split(' ').forEach(t => categorizedTags.general.add(t));
+                        }
+
+                        // 收集所有tags用于批量翻译
+                        const allTags = [];
+                        categoryOrder.forEach(categoryName => {
+                            if (categorizedTags[categoryName].size > 0) {
+                                allTags.push(...Array.from(categorizedTags[categoryName]));
+                            }
+                        });
+
+                        // 批量获取翻译（仅在中文模式下）
+                        let translations = {};
+                        if (globalMultiLanguageManager.getLanguage() === 'zh') {
+                            try {
+                                if (allTags.length > 0) {
+                                    const response = await fetch('/danbooru_gallery/translate_tags_batch', {
+                                        method: 'POST',
+                                        headers: { 'Content-Type': 'application/json' },
+                                        body: JSON.stringify({ tags: allTags })
+                                    });
+                                    const data = await response.json();
+                                    if (data.success) {
+                                        translations = data.translations;
+                                    }
+                                }
+                            } catch (error) {
+                                // 翻译获取失败，继续显示英文标签
+                            }
+                        }
+
+                        // 检查tooltip ID是否仍然有效（防止快速切换时显示过期的tooltip）
+                        if (thisTooltipId !== currentTooltipId) {
+                            return; // 用户已经移动到另一张图片，放弃显示此tooltip
+                        }
+
+                        // Render all tag categories with translations
+                        categoryOrder.forEach(categoryName => {
+                            if (categorizedTags[categoryName].size > 0) {
+                                const section = $el("div.danbooru-tooltip-section");
+                                section.appendChild($el("div.danbooru-tooltip-category-header", { textContent: t(categoryName) }));
+                                const tagsWrapper = $el("div.danbooru-tooltip-tags-wrapper");
+                                categorizedTags[categoryName].forEach(tag => {
+                                    const translation = translations[tag];
+                                    tagsWrapper.appendChild(createTagSpan(tag, categoryName, translation));
+                                });
+                                section.appendChild(tagsWrapper);
+                                tagsContainer.appendChild(section);
+                            }
+                        });
+
+                        globalTooltip.style.display = "block";
+
+                        // 添加点击其他地方隐藏tooltip的保护机制
+                        currentClickHandler = (e) => {
+                            if (!wrapper.contains(e.target) && globalTooltip.style.display !== 'none') {
+                                globalTooltip.style.display = "none";
+                                document.removeEventListener('click', currentClickHandler);
+                                currentClickHandler = null;
+                            }
+                        };
+
+                        // 延迟添加点击监听器，避免立即触发
+                        setTimeout(() => {
+                            if (currentClickHandler) {
+                                document.addEventListener('click', currentClickHandler);
+                            }
+                        }, 10);
+                    });
+
+                    wrapper.addEventListener("mouseleave", () => {
+                        // 增加tooltip ID，使当前的异步请求失效
+                        currentTooltipId++;
+
+                        // 鼠标离开图像时立即隐藏tooltip
+                        globalTooltip.style.display = "none";
+
+                        // 移除点击监听器
+                        if (currentClickHandler) {
+                            document.removeEventListener('click', currentClickHandler);
+                            currentClickHandler = null;
+                        }
+                    });
+
+                    wrapper.addEventListener("mousemove", (e) => {
+                        if (globalTooltip.style.display !== 'block') return;
+                        const rect = globalTooltip.getBoundingClientRect();
+                        const buffer = 15;
+                        let newLeft = e.clientX + buffer, newTop = e.clientY + buffer;
+                        if (newLeft + rect.width > window.innerWidth) newLeft = e.clientX - rect.width - buffer;
+                        if (newTop + rect.height > window.innerHeight) newTop = e.clientY - rect.height - buffer;
+                        globalTooltip.style.left = `${newLeft + window.scrollX}px`;
+                        globalTooltip.style.top = `${newTop + window.scrollY}px`;
+                    });
+
+                    // 总是创建收藏按钮，无论用户是否登录
+                    const currentSearch = searchInput.value.trim();
+                    const postFavoriteTag = currentFavoriteTag();
+                    const inFavoritesMode = hasFavoriteAuth() && postFavoriteTag && currentSearch.includes(postFavoriteTag);
+                    const isFavorited = inFavoritesMode || userFavorites.includes(String(post.id));
+                    const favoriteButton = $el("button.danbooru-favorite-button", {
+                        "data-post-id": post.id,
+                        innerHTML: isFavorited ?
+                            `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="#DC3545" stroke="#DC3545" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+                            </svg>` :
+                            `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+                            </svg>`,
+                        title: isFavorited ? t('unfavorite') : t('favorite'),
+                        className: isFavorited ? 'favorited' : '',
+                        onclick: async (e) => {
+                            e.stopPropagation(); // 阻止事件冒泡，避免触发图片选择
+
+                            // 如果用户未登录，提示登录
+                            if (!hasFavoriteAuth()) {
+                                showToast(t('authRequired'), 'warning');
+                                return;
+                            }
+
+                            // 在操作收藏前验证用户名和API Key的有效性
+
+                            const currentlyFavorited = userFavorites.includes(String(post.id)) || inFavoritesMode;
+                            let result;
+
+                            if (currentlyFavorited) {
+                                // 取消收藏
+                                result = await removeFromFavorites(post.id, favoriteButton);
+                                if (result.success) {
+                                    // 如果在收藏夹视图中，直接移除元素
+                                    const currentSearch = searchInput.value.trim();
+                                    if (postFavoriteTag && currentSearch.includes(postFavoriteTag)) {
+                                        wrapper.remove();
+                                    }
+                                }
+                            } else {
+                                // 添加收藏
+                                result = await addToFavorites(post.id, favoriteButton);
+                            }
+
+                            // 错误已在函数内处理
+                        }
+                    });
+
+                    // 创建按钮容器
+                    const buttonsContainer = $el("div.danbooru-image-buttons");
+
+                    // 创建编辑模式按钮
+                    const editButton = $el("button.danbooru-edit-button", {
+                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                        </svg>`,
+                        title: t('editMode'),
+                        onclick: (e) => {
+                            e.stopPropagation();
+                            showEditPanel(post);
+                        }
+                    });
+
+                    const viewImageButton = $el("button.danbooru-view-image-button", {
+                        innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`,
+                        title: t('viewImage'),
+                        onclick: async (e) => {
+                            e.stopPropagation();
+                            const mediaPost = getPostWithOriginalMedia(post);
+                            const imageUrl = getBestImageUrl(mediaPost, false);
+                            if (imageUrl) {
+                                window.open(proxiedMediaUrl(imageUrl), '_blank', 'noreferrer');
+                            }
+                        }
+                    });
+
+                    buttonsContainer.appendChild(viewImageButton);
+                    buttonsContainer.appendChild(editButton);
+                    buttonsContainer.appendChild(downloadButton);
+                    buttonsContainer.appendChild(favoriteButton);
+
+                    wrapper.appendChild(img);
+                    wrapper.appendChild(buttonsContainer);
+
+                    return wrapper;
+                };
+
+                const renderPost = (post) => {
+                    const element = createPostElement(post);
+                    if (element) {
+                        imageGrid.appendChild(element);
+                    }
+                };
+
+                const observer = new ResizeObserver(() => {
+                    cachedColumnWidth = 0;
+                    resizeGrid();
+                });
+                observer.observe(imageGrid);
+
+                let scrollTimeout;
+                let scrollAnchorTimeout; // 锚点记录的防抖
+                imageGrid.addEventListener("scroll", () => {
+                    if (imageGrid.scrollHeight - imageGrid.scrollTop - imageGrid.clientHeight < 400) {
+                        fetchAndRender(false);
+                    }
+
+                    // Debounced scroll logic for page indicator
+                    clearTimeout(scrollTimeout);
+                    scrollTimeout = setTimeout(updateCurrentPageIndicator, 150);
+
+                    // 记录滚动锚点（每秒；取视野最上方的图往前 8 张，刷新时用其 id 做游标往下接）
+                    clearTimeout(scrollAnchorTimeout);
+                    scrollAnchorTimeout = setTimeout(() => {
+                        const scrollRect = imageGrid.getBoundingClientRect();
+                        let closestIdx = -1, closestDist = Infinity;
+                        const children = Array.from(imageGrid.children);
+                        children.forEach((w, i) => {
+                            const rect = w.getBoundingClientRect();
+                            const dist = Math.abs(rect.top - scrollRect.top);
+                            if (dist < closestDist) { closestDist = dist; closestIdx = i; }
+                        });
+                        if (closestIdx >= 0) {
+                            const anchorIdx = Math.max(0, closestIdx - 8);
+                            const anchorEl = children[anchorIdx];
+                            if (anchorEl && anchorEl.dataset.postId) {
+                                scrollAnchorPostId = anchorEl.dataset.postId;
+                                saveToLocalStorage(`scrollAnchor_${nodeInstanceId}`, scrollAnchorPostId);
+                            }
+                        }
+                    }, 1000);
+                });
+
+                searchInput.addEventListener("keydown", (e) => {
+                    if (e.key === "Enter") {
+                        saveToLocalStorage('searchValue', searchInput.value.trim());
+                        fetchAndRender(true);
+                    }
+                });
+                ratingSelect.addEventListener("change", () => {
+                    if (globalTooltip) {
+                        globalTooltip.style.display = 'none';
+                    }
+                    fetchAndRender(true); // 保留，因为改变评分需要重新加载
+                });
+                // 检查和更新排行榜按钮状态的函数
+                const updateRankingButtonState = () => {
+                    const currentValue = searchInput.value.trim();
+                    const hasRanking = currentValue.includes('order:rank');
+
+                    if (hasRanking) {
+                        rankingButton.classList.add('active');
+                    } else {
+                        rankingButton.classList.remove('active');
+                    }
+                };
+
+                // 排行榜按钮点击事件
+                rankingButton.addEventListener("click", () => {
+                    const currentValue = searchInput.value.trim();
+                    const hasRanking = currentValue.includes('order:rank');
+
+                    if (hasRanking) {
+                        // 移除 order:rank，并清理残留的逗号
+                        let newValue = currentValue.replace(/\s*order:rank\s*/g, '');
+                        // 清理多余的逗号和空格
+                        newValue = newValue.replace(/,\s*,/g, ',').replace(/,\s*$/g, '').replace(/^\s*,/g, '').replace(/\s+/g, ' ').trim();
+                        searchInput.value = newValue;
+                        rankingButton.classList.remove('active');
+                    } else {
+                        // 添加 order:rank
+                        let newValue;
+                        if (currentValue) {
+                            // 如果前面已经有内容，用逗号分隔，但检查末尾是否已有逗号（后面可能有空格）
+                            const hasTrailingComma = /\s*,\s*$/.test(currentValue);
+                            const separator = hasTrailingComma ? ' ' : ', ';
+                            newValue = `${currentValue}${separator}order:rank`;
+                        } else {
+                            newValue = 'order:rank';
+                        }
+                        searchInput.value = newValue;
+                        rankingButton.classList.add('active');
+                    }
+
+                    // 刷新图像
+                    saveToLocalStorage('searchValue', searchInput.value);
+                    fetchAndRender(true);
+                });
+
+                // 监听搜索框变化，更新排行榜按钮状态
+                // 更新收藏夹按钮状态
+                const updateFavoritesButtonState = () => {
+                    // 始终显示收藏夹按钮
+                    favoritesButton.style.display = 'flex';
+
+                    if (!hasFavoriteAuth()) {
+                        favoritesButton.classList.remove('active');
+                        return;
+                    }
+
+                    const currentValue = searchInput.value.trim();
+                    const favTag = currentFavoriteTag();
+                    const hasFavs = Boolean(favTag) && currentValue.includes(favTag);
+                    if (hasFavs) {
+                        favoritesButton.classList.add('active');
+                    } else {
+                        favoritesButton.classList.remove('active');
+                    }
+                };
+
+                // 统一的搜索框输入处理函数
+                const handleSearchInput = () => {
+                    const currentValue = searchInput.value.trim();
+                    if (previousSearchValue !== "" && currentValue === "") {
+                        saveToLocalStorage('searchValue', '');
+                        fetchAndRender(true); // 清空搜索框时自动刷新
+                    }
+                    previousSearchValue = currentValue;
+                    updateRankingButtonState();
+                    updateFavoritesButtonState();
+
+                    const clearButton = searchContainer.querySelector('.danbooru-clear-search-button');
+                    if (clearButton) {
+                        clearButton.style.display = currentValue ? 'block' : 'none';
+                    }
+                };
+
+                searchInput.addEventListener("input", handleSearchInput);
+
+                // 收藏夹按钮点击事件
+                favoritesButton.addEventListener("click", async () => {
+                    if (!hasFavoriteAuth()) {
+                        showToast(t('authRequired'), 'warning');
+                        return;
+                    }
+
+
+                    const favTag = currentFavoriteTag();
+                    if (!favTag) {
+                        showToast(t('authRequired'), 'warning');
+                        return;
+                    }
+                    const currentValue = searchInput.value.trim();
+                    const hasFavs = currentValue.includes(favTag);
+
+                    if (hasFavs) {
+                        // 移除收藏夹标签，并清理残留的逗号
+                        let newValue = currentValue.replace(new RegExp(`\\s*${favTag}\\s*`), '');
+                        // 清理多余的逗号和空格
+                        newValue = newValue.replace(/,\s*,/g, ',').replace(/,\s*$/g, '').replace(/^\s*,/g, '').replace(/\s+/g, ' ').trim();
+                        searchInput.value = newValue;
+                    } else {
+                        let newValue;
+                        if (currentValue) {
+                            // 如果前面已经有内容，用逗号分隔，但检查末尾是否已有逗号（后面可能有空格）
+                            const hasTrailingComma = /\s*,\s*$/.test(currentValue);
+                            const separator = hasTrailingComma ? ' ' : ', ';
+                            newValue = `${currentValue}${separator}${favTag}`;
+                        } else {
+                            newValue = favTag;
+                        }
+                        searchInput.value = newValue;
+                        // 进入收藏夹模式时，不需要手动加载收藏列表，因为 fetchAndRender 会获取
+                    }
+                    updateFavoritesButtonState();
+                    saveToLocalStorage('searchValue', searchInput.value);
+                    fetchAndRender(true);
+                });
+
+                refreshButton.addEventListener("click", () => {
+                    fetchAndRender(true);
+                });
+
+                const searchContainer = $el("div.danbooru-search-container");
+                const clearButton = $el("button.danbooru-clear-search-button", {
+                    innerHTML: '×',
+                    title: t('clearSearch'),
+                    style: {
+                        display: 'none'
                     },
-                    timeout=(8, 15),
-                )
-                fringe_enabled = bool(re.search(r'name=["\']fringeBenefits["\'][^>]*checked', response.text, re.IGNORECASE))
-                if fringe_enabled:
-                    logger.info("[Gelbooru] 已启用 Display all site content 匿名会话")
-                else:
-                    logger.warning("[Gelbooru] 已提交 Display all site content，但返回页未显示 checked")
-            except requests.exceptions.RequestException as e:
-                logger.warning(f"[Gelbooru] 启用 Display all site content 失败，将继续普通会话: {e}")
+                    onclick: () => {
+                        searchInput.value = '';
+                        searchInput.dispatchEvent(new Event('input'));
+                        fetchAndRender(true);
+                    }
+                });
+                searchContainer.appendChild(searchInput);
+                searchContainer.appendChild(clearButton);
 
-        _gelbooru_session = session
-        _gelbooru_session_display_all = display_all_site_content
-        return _gelbooru_session
+                // 选中计数徽章（多选模式时显示，移至底部状态栏）
+                const selectionCountBadge = $el("span.danbooru-selection-count", {
+                    style: {
+                        display: 'none',
+                        padding: '4px 8px',
+                        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+                        color: 'white',
+                        fontSize: '12px',
+                        borderRadius: '4px',
+                        backdropFilter: 'blur(5px)',
+                        whiteSpace: 'nowrap'
+                    }
+                });
 
-def _image_proxy_headers_for_host(host):
-    """Return browser-like headers for image CDNs that are sensitive to generic requests."""
-    if host == "gelbooru.com" or host.endswith(".gelbooru.com"):
-        return _gelbooru_browser_headers("image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
-    return {}
+                // 清除全选按钮（多选模式时显示）
+                const clearSelectionButton = $el("button.danbooru-clear-selection", {
+                    textContent: t('clearAllSelection'),
+                    title: t('clearAllSelection'),
+                    style: {
+                        display: uiSettings.multi_select_enabled ? 'inline-block' : 'none',
+                        padding: '5px 10px',
+                        borderRadius: '4px',
+                        backgroundColor: 'var(--comfy-input-bg)',
+                        border: '1px solid var(--input-border-color)',
+                        color: 'var(--comfy-input-text)',
+                        cursor: 'pointer',
+                        fontSize: '12px'
+                    },
+                    onclick: () => {
+                        clearAllSelections();
+                    }
+                });
 
-def _fetch_supported_media(url):
-    """Fetch image/video bytes using the same site-aware request path as the preview proxy."""
-    parsed = urllib.parse.urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError("invalid media url scheme")
+                // 将包含搜索框和建议面板的容器添加到总控件中
+                container.appendChild($el("div.danbooru-controls", [searchContainer, sourceSelect, displayAllSiteContentToggle, rankingButton, favoritesButton, ratingSelect, categoryDropdown, formattingDropdown, filterButton, clearSelectionButton, settingsButton, refreshButton]));
 
-    host = (parsed.hostname or "").lower()
-    allowed_suffixes = ("donmai.us", "gelbooru.com")
-    if not any(host == suffix or host.endswith(f".{suffix}") for suffix in allowed_suffixes):
-        raise ValueError(f"unsupported media host: {host}")
-
-    if host == "gelbooru.com" or host.endswith(".gelbooru.com"):
-        display_all_site_content = load_ui_settings().get("gelbooru_display_all_site_content", False)
-        session = _get_gelbooru_session(display_all_site_content)
-        response = session.get(
-            url,
-            headers=_image_proxy_headers_for_host(host),
-            timeout=(8, 30),
-        )
-    else:
-        response = _danbooru_request(
-            "GET",
-            url,
-            headers=_image_proxy_headers_for_host(host),
-            timeout=30,
-        )
-
-    response.raise_for_status()
-    content_type = response.headers.get("Content-Type", "application/octet-stream").lower()
-    if content_type and not content_type.startswith(("image/", "application/octet-stream")):
-        raise ValueError(f"upstream returned non-image content: {content_type}")
-    return response.content
-
-def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, display_all_site_content=False):
-    """Fetch Gelbooru posts from public HTML pages when DAPI credentials are unavailable.
-
-    Uses fixed page size GELBOORU_PUBLIC_PAGE_SIZE (42) so pid is decoupled from
-    the frontend's requested limit; the frontend chains multiple page fetches via
-    maybeLoadMore to reach the user's preload_count.
-
-    On transient failure (429/503) it retries once with Retry-After back-off.
-    If retry also fails or the response is non-recoverable, returns an error
-    placeholder object so the frontend can display a per-cell error rather than
-    crashing the whole gallery.
-    """
-    id_match = re.search(r"(?:^|\s)id:(\d+)(?:\s|$)", tags or "")
-    if id_match:
-        refs = [{"id": id_match.group(1)}]
-    else:
-        # 固定页大小，pid 与 frontend 的 limit 解耦
-        pid_value = max(page - 1, 0) * GELBOORU_PUBLIC_PAGE_SIZE
-        params = adapter.build_public_posts_params(tags, limit, page, rating_query)
-        # override pid with fixed page size
-        params["pid"] = pid_value
-
-        session = _get_gelbooru_session(display_all_site_content)
-
-        def _get_list_page(sess):
-            """Inner closure: fetch list page with rate limiting + retry."""
-            for attempt in range(2):
-                _gelbooru_public_throttle.wait()
-                try:
-                    resp = sess.get(adapter.posts_url, params=params, timeout=(8, 15))
-                except requests.exceptions.RequestException as e:
-                    if attempt == 0:
-                        _log_gelbooru_retry_warning(f"网络异常: {e}", pid_value=pid_value)
-                        time.sleep(3)
-                    continue
-
-                if resp.status_code not in (429, 503):
-                    return resp  # 正常（含 200/500/403），交调用方判断
-
-                # 429/503 限流: 读 Retry-After 退避一次
-                retry_after = resp.headers.get("Retry-After")
-                delay = 2.0
-                try:
-                    if retry_after is not None:
-                        delay = min(max(float(retry_after), 0.5), 10.0)
-                except ValueError:
-                    pass
-                if attempt == 0:
-                    _log_gelbooru_retry_warning(f"HTTP {resp.status_code} 限流，{delay:.1f}s 后重试", pid_value=pid_value)
-                    time.sleep(delay)
-                else:
-                    _log_gelbooru_retry_warning(f"重试仍限流({resp.status_code})，跳过本页", pid_value=pid_value)
-                    return None  # 重试仍限流 → 跳过本页
-
-            return None
-
-        list_response = _get_list_page(session)
-        if list_response is None:
-            # 返回 error 占位格（不含 list_response.text 细节）
-            driver_pid = params.get("pid", pid_value)
-            return [{"error": "Gelbooru 服务暂不可用", "pid": driver_pid, "page": page}]
-
-        if display_all_site_content and _gelbooru_public_page_requires_options(list_response.text):
-            logger.warning("[GelbooruPublic] Result page still requested Display all site content; rebuilding session and retrying")
-            session = _get_gelbooru_session(display_all_site_content, force_refresh=True)
-            list_response = _get_list_page(session)
-            if list_response is None:
-                driver_pid = params.get("pid", pid_value)
-                return [{"error": "Gelbooru 服务暂不可用", "pid": driver_pid, "page": page}]
-
-        refs = adapter.extract_public_post_refs(list_response.text, limit)
-        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} refs={len(refs)}")
-
-    if not id_match:
-        return refs
-
-    posts = []
-    for ref in refs:
-        post_id = ref.get("id")
-        if not post_id:
-            continue
-
-        # 0 引用重试：HTML 结构有可能解析失败
-        for attempt in range(2):
-            try:
-                post_response = _get_gelbooru_session(display_all_site_content).get(
-                    adapter.posts_url,
-                    params=adapter.build_public_post_params(post_id),
-                    timeout=(8, 15),
-                )
-                post_response.raise_for_status()
-                post = adapter.normalize_public_post_page(post_id, post_response.text, ref)
-                if post.get("preview_file_url") or post.get("file_url"):
-                    posts.append(post)
-                    break
-            except requests.exceptions.RequestException as e:
-                if attempt == 0:
-                    logger.warning(f"[GelbooruPublic] 帖子页面解析失败/id={post_id} 尝试重试: {e}")
-                    time.sleep(1)
-                else:
-                    logger.warning(f"[GelbooruPublic] 帖子页面解析失败/id={post_id} 放弃: {e}")
-
-    return posts
-
-
-def _log_gelbooru_retry_warning(message, pid_value=None):
-    """Short helper for logging gelbooru public fetch retry messages."""
-    if pid_value is not None:
-        logger.warning(f"[GelbooruPublic] {message} (pid={pid_value})")
-    else:
-        logger.warning(f"[GelbooruPublic] {message}")
-
-@PromptServer.instance.routes.get("/danbooru_gallery/image_proxy")
-async def image_proxy(request):
-    # 浏览器直连 cdn.donmai.us 会被 Cloudflare 按 cross-site <img> 请求挑战并返回 403，
-    # 而后端用描述性 UA (DANBOORU_HEADERS) 能过 CF。转发一次即可让前端拿到缩略图。
-    url = request.query.get("url", "")
-    if not url:
-        return web.Response(status=400, text="missing url")
-
-    try:
-        parsed = urllib.parse.urlparse(url)
-    except Exception:
-        return web.Response(status=400, text="invalid url")
-
-    if parsed.scheme not in ("http", "https"):
-        return web.Response(status=400, text="invalid scheme")
-
-    # SSRF 防护：只允许当前支持图站的图片域名
-    host = (parsed.hostname or "").lower()
-    allowed_suffixes = ("donmai.us", "gelbooru.com")
-    if not any(host == suffix or host.endswith(f".{suffix}") for suffix in allowed_suffixes):
-        return web.Response(status=403, text="host not allowed")
-
-    async with _get_image_proxy_semaphore():
-        try:
-            if host == "gelbooru.com" or host.endswith(".gelbooru.com"):
-                display_all_site_content = load_ui_settings().get("gelbooru_display_all_site_content", False)
-                session = _get_gelbooru_session(display_all_site_content)
-                resp = await asyncio.to_thread(
-                    session.get,
-                    url,
-                    headers=_image_proxy_headers_for_host(host),
-                    timeout=(8, 15),
-                )
-            else:
-                resp = await asyncio.to_thread(
-                    _danbooru_request,
-                    "GET",
-                    url,
-                    headers=_image_proxy_headers_for_host(host),
-                    timeout=15,
-                )
-        except requests.exceptions.RequestException as e:
-            logger.warning(f"[ImageProxy] 上游请求失败 {url}: {e}")
-            return web.Response(status=502, text="upstream error")
-
-    if resp.status_code != 200:
-        logger.debug(f"[ImageProxy] 上游返回 {resp.status_code}: {url}")
-        return web.Response(status=resp.status_code)
-
-    content_type = resp.headers.get("Content-Type", "application/octet-stream")
-    if not content_type.lower().startswith(("image/", "video/")):
-        logger.warning(f"[ImageProxy] 上游返回非媒体内容 {content_type}: {url}")
-        return web.Response(status=502, text="upstream returned non-media content")
-
-    return web.Response(
-        body=resp.content,
-        headers={
-            "Content-Type": content_type,
-            "Cache-Control": "public, max-age=86400",
-        },
-    )
-
-# --- 保留文件中剩余的其他部分 ---
-@PromptServer.instance.routes.get("/danbooru_gallery/posts")
-async def get_posts_for_front(request):
-    query = request.query
-    tags = query.get("search[tags]", "")
-    page = query.get("page", "1")
-    limit = query.get("limit", "100")
-    rating = query.get("search[rating]", "")
-    source = query.get("source", "danbooru")
-    gelbooru_display_all_site_content = query.get("gelbooru_display_all_site_content", "").lower() in ("1", "true", "yes", "on")
-    force_public_detail = query.get("force_public_detail", "").lower() in ("1", "true", "yes", "on")
-    before_id_raw = query.get("before_id", "")
-    gelbooru_dedup_mode = query.get("gelbooru_dedup_mode", "off").strip().lower()
-    if gelbooru_dedup_mode not in ("off", "on", "on_auth"):
-        gelbooru_dedup_mode = "off"
-
-    posts_json_str, = DanbooruGalleryNode.get_posts_internal(
-        tags=tags,
-        limit=int(limit),
-        page=int(page),
-        rating=rating,
-        source=source,
-        gelbooru_display_all_site_content=gelbooru_display_all_site_content,
-        force_public_detail=force_public_detail,
-        before_id=before_id_raw,
-        gelbooru_dedup_mode=gelbooru_dedup_mode,
-    )
-    
-    try:
-        posts_list = json.loads(posts_json_str)
-    except json.JSONDecodeError:
-        posts_list = []
-
-    return web.json_response(posts_list, headers={
-        "Cache-Control": "no-cache, no-store, must-revalidate",
-        "Pragma": "no-cache",
-        "Expires": "0"
-    })
-
-@PromptServer.instance.routes.get("/danbooru_gallery/autocomplete")
-async def get_autocomplete(request):
-    """三层查询机制：数据库 → API → 空结果"""
-    try:
-        query = request.query.get("query", "")
-        limit = int(request.query.get("limit", "20"))
-        source = request.query.get("source", "danbooru")
-        adapter = get_site_adapter(source)
-
-        if not query:
-            return web.json_response([])
-
-        # 加载配置
-        config = load_autocomplete_config()
-
-        # ✅ 第1层：查询本地SQLite数据库
-        if adapter.key == "danbooru" and get_db_manager and config['cache'].get('use_database_query', True):
-            try:
-                db = get_db_manager()
-                db_results = await db.search_tags_by_prefix(query, limit)
-
-                if db_results:
-                    # 数据库有结果，转换格式并返回
-                    formatted_results = [
-                        {
-                            'name': tag['tag'],
-                            'category': tag['category'],
-                            'post_count': tag['post_count'],
-                            'translation': tag.get('translation_cn'),
-                            'aliases': tag.get('aliases', [])
+                // 🔧 重要：在 searchInput 被添加到 DOM 之后才创建智能补全实例
+                // 这样 AutocompleteUI 才能正确获取父元素并将建议容器添加到 DOM
+                const searchAutocomplete = new AutocompleteUI({
+                    inputElement: searchInput,
+                    language: globalMultiLanguageManager.getLanguage(),
+                    source: uiSettings.source_site || "danbooru",
+                    maxSuggestions: uiSettings.autocomplete_max_results || 20,
+                    customClass: 'danbooru-gallery-autocomplete',
+                    formatTag: (tag) => {
+                        // 应用格式化设置
+                        let processedTag = tag;
+                        if (uiSettings.formatting && uiSettings.formatting.replaceUnderscores) {
+                            processedTag = processedTag.replace(/_/g, ' ');
                         }
-                        for tag in db_results
-                    ]
-                    logger.debug(f"[Autocomplete] 数据库查询成功: '{query}' -> {len(formatted_results)}条结果")
-                    return web.json_response(formatted_results)
-                else:
-                    logger.debug(f"[Autocomplete] 数据库无结果: '{query}'")
-            except Exception as e:
-                logger.warning(f"[Autocomplete] 数据库查询失败: {e}，尝试API fallback")
+                        if (uiSettings.formatting && uiSettings.formatting.escapeBrackets) {
+                            processedTag = processedTag.replaceAll('(', '\\(').replaceAll(')', '\\)');
+                        }
+                        return processedTag;
+                    },
+                    onSelect: (tag) => {
+                        // 选择建议后保存
+                        saveToLocalStorage('searchValue', searchInput.value);
+                    }
+                });
+                container.appendChild(imageGrid);
 
-        # ✅ 第2层：Fallback到Danbooru API
-        if config['offline_mode'].get('fallback_to_remote', True):
-            try:
-                timeout = config['offline_mode'].get('remote_timeout_ms', 2000) / 1000.0
+                // 创建底部状态栏容器
+                const bottomStatusBar = $el("div.danbooru-bottom-status", {
+                    style: {
+                        position: 'absolute',
+                        bottom: '10px',
+                        left: '10px',
+                        zIndex: '20',
+                        display: 'flex',
+                        gap: '8px',
+                        alignItems: 'center'
+                    }
+                });
 
-                tags_url = adapter.tags_url
-                params = adapter.build_autocomplete_params(query, limit)
-                credentials = get_site_credentials(adapter)
-                if not has_required_site_credentials(adapter, credentials):
-                    if adapter.key == "gelbooru":
-                        logger.info("[Gelbooru] 未配置 User ID/API Key，改用公开 autocomplete2")
-                        params = adapter.build_public_autocomplete_params(query, limit)
-                        response = _danbooru_request("GET", tags_url, params=params, timeout=timeout)
-                        response.raise_for_status()
-                        return web.json_response(adapter.normalize_public_autocomplete_response(response.json()))
-                    logger.warning(f"[{adapter.key}] 缺少必要认证信息，已跳过自动补全请求")
-                    return web.json_response([])
-                params = adapter.apply_auth_params(params, credentials)
+                // 添加页码指示器
+                const pageIndicator = $el("div.danbooru-page-indicator", {
+                    style: {
+                        display: 'none', // Initially hidden
+                        padding: '4px 8px',
+                        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+                        color: 'white',
+                        fontSize: '12px',
+                        borderRadius: '4px',
+                        backdropFilter: 'blur(5px)'
+                    }
+                });
 
-                username, api_key = load_user_auth()
-                auth = HTTPBasicAuth(username, api_key) if adapter.requires_auth and username and api_key else None
+                // 将页码指示器和选择计数器添加到底部状态栏
+                bottomStatusBar.appendChild(pageIndicator);
+                bottomStatusBar.appendChild(selectionCountBadge);
+                container.appendChild(bottomStatusBar);
 
-                logger.debug(f"[Autocomplete] 调用远程API({adapter.key}): '{query}' (超时: {timeout}s)")
-                response = _danbooru_request("GET", tags_url, params=params, auth=auth, timeout=timeout)
-                response.raise_for_status()
+                const insertNewPost = (post) => {
+                    const newElement = createPostElement(post);
+                    if (newElement) {
+                        imageGrid.prepend(newElement);
+                        newElement.classList.add('new-item');
+                        newElement.addEventListener('animationend', () => newElement.classList.remove('new-item'));
+                        resizeGrid();
+                    }
+                };
 
-                result = adapter.normalize_autocomplete_response(response.json())
+                const updateEditedStatus = (wrapperElement, postId) => {
+                    const originalPost = originalPostCache[postId]; // 从缓存中获取原始数据
+                    const editedPost = temporaryTagEdits[postId];
 
-                # 排序确保按热度排列
-                if isinstance(result, list):
-                    result.sort(key=lambda x: x.get('post_count', 0), reverse=True)
-                    logger.info(f"[Autocomplete] API查询成功({adapter.key}): '{query}' -> {len(result)}条结果")
+                    let isTrulyEdited = false;
+                    if (editedPost && originalPost) {
+                        const categories = ["artist", "copyright", "character", "general", "meta"];
+                        const hasCategoryTags = categories.some(cat => originalPost.hasOwnProperty(`tag_string_${cat}`) || editedPost.hasOwnProperty(`tag_string_${cat}`));
 
-                return web.json_response(result)
+                        if (hasCategoryTags) {
+                            for (const category of categories) {
+                                if (!compareTagStrings(originalPost[`tag_string_${category}`], editedPost[`tag_string_${category}`])) {
+                                    isTrulyEdited = true;
+                                    break;
+                                }
+                            }
+                        } else {
+                            // 如果没有分类标签，检查tag_string是否被编辑
+                            if (!compareTagStrings(originalPost.tag_string, editedPost.tag_string)) {
+                                isTrulyEdited = true;
+                            }
+                        }
+                    }
 
-            except requests.Timeout:
-                logger.warning(f"[Autocomplete] 远程API超时 (>{timeout}s): '{query}'")
-            except requests.exceptions.RequestException as e:
-                logger.warning(f"[Autocomplete] 远程API失败: {e}")
-            except Exception as e:
-                logger.error(f"[Autocomplete] API调用错误: {e}")
+                    const indicator = wrapperElement.querySelector('.danbooru-edited-indicator');
 
-        # ✅ 第3层：返回空结果
-        logger.debug(f"[Autocomplete] 所有查询方式均无结果: '{query}'")
-        return web.json_response([])
+                    if (isTrulyEdited) {
+                        if (!indicator) {
+                            const newIndicator = $el("div.danbooru-edited-indicator", { textContent: t('edited') });
+                            wrapperElement.appendChild(newIndicator);
+                        }
+                    } else {
+                        if (indicator) {
+                            indicator.remove();
+                        }
+                    }
+                    return isTrulyEdited;
+                };
+                // 初始化功能
+                const initializeApp = async () => {
+                    try {
+                        // Try to load filter state from the widget right before we need it
+                        try {
+                            if (filterWidget.value) {
+                                filterState = JSON.parse(filterWidget.value);
+                            }
+                        } catch (e) {
+                            logger.warn("Danbooru Gallery: Could not parse filter state, using default.", e);
+                            filterState = { startTime: null, endTime: null, startPage: null };
+                        }
 
-    except Exception as e:
-        logger.error(f"[Autocomplete] 处理请求时发生错误: {e}")
-        return web.json_response([])
 
-@PromptServer.instance.routes.get("/danbooru_gallery/blacklist")
-async def get_blacklist(request):
-    blacklist = load_blacklist()
-    return web.json_response({"blacklist": blacklist})
+                        let networkConnected = true;
 
-@PromptServer.instance.routes.post("/danbooru_gallery/blacklist")
-async def save_blacklist_route(request):
-    try:
-        data = await request.json()
-        blacklist_items = data.get("blacklist", [])
-        success = save_blacklist(blacklist_items)
-        return web.json_response({"success": success})
-    except Exception as e:
-        logger.error(f"保存黑名单接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)})
+                        await loadUiSettings();
 
-@PromptServer.instance.routes.get("/danbooru_gallery/language")
-async def get_language(request):
-    language = load_language()
-    return web.json_response({"language": language})
+                        // 优先检测网络连接状态
+                        try {
+                            const sourceForNetworkCheck = loadFromLocalStorage('sourceSite', uiSettings.source_site || "danbooru");
+                            const networkResponse = await fetch(`/danbooru_gallery/check_network?source=${encodeURIComponent(sourceForNetworkCheck)}`);
+                            const networkData = await networkResponse.json();
+                            if (!networkData.success || !networkData.connected) {
+                                networkConnected = false;
+                                // 注释掉网络错误toast提示 - 本小姐才不想看到这些烦人的提示呢！
+                                // showError('网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接', true);
+                                console.log("网络错误已隐藏: 网络连接失败 - 无法连接到Danbooru服务器，请检查网络连接");  // 仅在控制台记录
+                            }
+                        } catch (e) {
+                            logger.error('网络检测失败:', e);
+                            networkConnected = false;
+                            // 注释掉网络错误toast提示 - 本小姐才不想看到这些烦人的提示呢！
+                            // showError('网络检测失败 - 请检查网络连接', true);
+                            console.log("网络错误已隐藏: 网络检测失败 - 请检查网络连接");  // 仅在控制台记录
+                        }
 
-@PromptServer.instance.routes.post("/danbooru_gallery/language")
-async def save_language_route(request):
-    try:
-        data = await request.json()
-        language = data.get("language", "zh")
-        success = save_language(language)
-        return web.json_response({"success": success})
-    except Exception as e:
-        logger.error(f"保存语言设置接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)})
+                        // 加载语言设置
+                        await loadLanguage();
 
-@PromptServer.instance.routes.get("/danbooru_gallery/filter_tags")
-async def get_filter_tags(request):
-    filter_tags, filter_enabled = load_filter_tags()
-    return web.json_response({"filter_tags": filter_tags, "filter_enabled": filter_enabled})
+                        // 加载用户认证信息
+                        await loadUserAuth();
 
-@PromptServer.instance.routes.post("/danbooru_gallery/filter_tags")
-async def save_filter_tags_route(request):
-    try:
-        data = await request.json()
-        filter_tags = data.get("filter_tags", [])
-        filter_enabled = data.get("filter_enabled", False)
-        success = save_filter_tags(filter_tags, filter_enabled)
-        return web.json_response({"success": success})
-    except Exception as e:
-        logger.error(f"保存提示词过滤设置接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)})
 
-@PromptServer.instance.routes.get("/danbooru_gallery/ui_settings")
-async def get_ui_settings(request):
-    try:
-        ui_settings = load_ui_settings()
-        return web.json_response({
-            "success": True,
-            "settings": ui_settings
-        })
-    except Exception as e:
-        logger.error(f"[UI_SETTINGS] 获取UI设置接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)})
+                        if (networkConnected && hasFavoriteAuth()) {
+                            await loadFavorites();
+                        }
 
-@PromptServer.instance.routes.post("/danbooru_gallery/ui_settings")
-async def save_ui_settings_route(request):
-    try:
-        data = await request.json()
-        ui_settings = {
-            "autocomplete_enabled": data.get("autocomplete_enabled", True),
-            "tooltip_enabled": data.get("tooltip_enabled", True),
-            "autocomplete_max_results": data.get("autocomplete_max_results", 20),
-            "selected_categories": data.get("selected_categories", ["copyright", "character", "general"]),
-            "multi_select_enabled": data.get("multi_select_enabled", False),
-            "source_site": data.get("source_site", "danbooru"),
-            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False)
+                        // 更新界面文本
+                        updateInterfaceTexts();
+
+                        // 更新收藏夹按钮状态
+                        updateFavoritesButtonState();
+
+                        // 加载黑名单
+                        await loadBlacklist();
+
+                        // 加载提示词过滤设置
+                        await loadFilterTags();
+
+                        // 加载UI设置
+                        const savedSourceSite = loadFromLocalStorage('sourceSite', null);
+                        if (savedSourceSite && SOURCE_SITES.some(site => site.value === savedSourceSite)) {
+                            uiSettings.source_site = savedSourceSite;
+                        }
+                        const savedDisplayAllSiteContent = loadFromLocalStorage('gelbooruDisplayAllSiteContent', null);
+                        if (typeof savedDisplayAllSiteContent === "boolean") {
+                            uiSettings.gelbooru_display_all_site_content = savedDisplayAllSiteContent;
+                        }
+                        updateSourceState();
+                        searchAutocomplete.source = uiSettings.source_site || "danbooru";
+
+                        // 从 localStorage 加载并覆盖筛选状态
+                        const savedSearch = loadFromLocalStorage('searchValue', null);
+                        if (savedSearch !== null) {
+                            searchInput.value = savedSearch;
+                        }
+
+                        const savedRatingValues = loadFromLocalStorage('ratingValues', null);
+                        if (Array.isArray(savedRatingValues) && savedRatingValues.length > 0) {
+                            applySelectedRatings(savedRatingValues);
+                        } else {
+                            const savedRating = loadFromLocalStorage('ratingValue', null);
+                            if (savedRating && RATING_VALUES.includes(savedRating)) {
+                                applySelectedRatings([savedRating]);
+                                saveToLocalStorage('ratingValues', [savedRating]);
+                            } else {
+                                applySelectedRatings(RATING_VALUES);
+                            }
+                        }
+
+                        const savedCategories = loadFromLocalStorage('selectedCategories', null);
+                        if (savedCategories) {
+                            uiSettings.selected_categories = savedCategories;
+                        }
+                        const categoryCheckboxes = categoryDropdown.querySelectorAll('.danbooru-category-checkbox');
+                        categoryCheckboxes.forEach(checkbox => {
+                            checkbox.checked = uiSettings.selected_categories.includes(checkbox.name);
+                        });
+
+                        const savedFormatting = loadFromLocalStorage('formatting', null);
+                        if (savedFormatting) {
+                            uiSettings.formatting = savedFormatting;
+                        }
+                        const escapeBracketsCheckbox = formattingDropdown.querySelector('[name="escapeBrackets"]');
+                        const replaceUnderscoresCheckbox = formattingDropdown.querySelector('[name="replaceUnderscores"]');
+                        if (escapeBracketsCheckbox && uiSettings.formatting) {
+                            escapeBracketsCheckbox.checked = uiSettings.formatting.escapeBrackets;
+                        }
+                        if (replaceUnderscoresCheckbox && uiSettings.formatting) {
+                            replaceUnderscoresCheckbox.checked = uiSettings.formatting.replaceUnderscores;
+                        }
+
+                        const savedFilterData = loadFromLocalStorage('filterData', null);
+                        if (savedFilterData) {
+                            filterState = savedFilterData;
+                            filterWidget.value = JSON.stringify(filterState);
+                        }
+
+                        // 恢复已存储的 preload/dedup/globalLogging（在 loadUiSettings 之后）
+                        const savedPreloadCount = loadFromLocalStorage('preload_count', null);
+                        if (savedPreloadCount !== null) {
+                            const clamped = Math.min(Math.max(parseInt(savedPreloadCount, 10) || 40, 20), 200);
+                            uiSettings.preload_count = clamped;
+                        } else {
+                            uiSettings.preload_count = 40;
+                        }
+                        const savedGelbooruDedupMode = loadFromLocalStorage('gelbooru_dedup_mode', null);
+                        if (savedGelbooruDedupMode && ["off", "on", "on_auth"].includes(savedGelbooruDedupMode)) {
+                            uiSettings.gelbooru_dedup_mode = savedGelbooruDedupMode;
+                        } else {
+                            uiSettings.gelbooru_dedup_mode = "off";
+                        }
+                        const savedGlobalLogging = loadFromLocalStorage('global_logging', null);
+                        if (typeof savedGlobalLogging === "boolean") {
+                            uiSettings.global_logging = savedGlobalLogging;
+                            loggerClient.setConsoleOutput(savedGlobalLogging);
+                        } else {
+                            uiSettings.global_logging = false;
+                            loggerClient.setConsoleOutput(false);
+                        }
+
+                        // 恢复保存的滚动锚点（刷新后用其 id 做游标往下接）
+                        const savedScrollAnchor = loadFromLocalStorage(`scrollAnchor_${nodeInstanceId}`, null);
+                        if (savedScrollAnchor) {
+                            scrollAnchorPostId = savedScrollAnchor;
+                        }
+
+                        // 初始化排行榜按钮状态
+                        updateRankingButtonState();
+
+                        // 根据加载的 filterState 更新筛选按钮状态
+                        if (filterState.startTime || filterState.endTime || filterState.startPage) {
+                            filterButton.classList.add('active');
+                        } else {
+                            filterButton.classList.remove('active');
+                        }
+
+                        // 页面加载时直接获取第一页的帖子（先同步 currentTags，否则重置块会因 '' !== 搜索值而清空锚点）
+                        currentTags = searchInput.value.trim();
+                        fetchAndRender(true);
+
+                    } catch (error) {
+                        logger.error("Danbooru Gallery initialization failed:", error);
+                        showError("图库初始化失败，请检查控制台日志。", true);
+                    }
+                };
+
+                const updateCurrentPageIndicator = () => {
+                    if (posts.length === 0) {
+                        pageIndicator.style.display = 'none';
+                        return;
+                    }
+
+                    const itemsPerPage = 100;
+
+                    // Find the first visible element in the grid
+                    const firstVisibleChild = Array.from(imageGrid.children).find(child => {
+                        const rect = child.getBoundingClientRect();
+                        const gridRect = imageGrid.getBoundingClientRect();
+                        return rect.bottom > gridRect.top && rect.top < gridRect.bottom;
+                    });
+
+                    if (firstVisibleChild) {
+                        const postId = firstVisibleChild.dataset.postId;
+                        const postIndex = posts.findIndex(p => String(p.id) === postId);
+
+                        if (postIndex !== -1) {
+                            const currentPageInView = Math.floor(postIndex / itemsPerPage) + (filterState.startPage || 1);
+                            pageIndicator.textContent = `${t('currentPage')}: ${currentPageInView}`;
+                            pageIndicator.style.display = 'block';
+                        } else {
+                            pageIndicator.style.display = 'none';
+                        }
+                    } else {
+                        pageIndicator.style.display = 'none';
+                    }
+                };
+
+                // 启动应用
+                initializeApp();
+
+                this.onResize = (size) => {
+                    const [width, height] = size;
+                    const contentWidth = Math.max(150, width - 24);
+                    container.style.width = `${contentWidth}px`;
+                    imageGrid.style.width = "100%";
+                    imageGrid.style.boxSizing = "border-box";
+
+                    const controlsHeight = container.querySelector('.danbooru-controls')?.offsetHeight || 0;
+                    if (controlsHeight > 0) {
+                        imageGrid.style.height = `${Math.max(120, height - controlsHeight - 10)}px`;
+                    }
+
+                    cachedColumnWidth = 0;
+                    scheduleResizeGrid();
+                }
+            };
+
+            const onRemoved = nodeType.prototype.onRemoved;
+            nodeType.prototype.onRemoved = function () {
+                // 移除所有可能由该节点创建的全局UI元素
+                const elementsToRemove = document.querySelectorAll(
+                    ".danbooru-settings-dialog, .danbooru-edit-panel, .danbooru-tag-tooltip, .danbooru-tag-context-menu, .danbooru-toast"
+                );
+                elementsToRemove.forEach(el => el.remove());
+
+                // 调用原始的 onRemoved 方法
+                onRemoved?.apply(this, arguments);
+            };
         }
-        success = save_ui_settings(ui_settings)
-        return web.json_response({"success": success})
-    except Exception as e:
-        logger.error(f"保存UI设置接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)})
+    },
+});
 
-@PromptServer.instance.routes.post("/danbooru_gallery/selection_queue_push")
-async def selection_queue_push(request):
-    """前端在每次 Queue 前把当前选中的条目推入对应 nodeId 的 FIFO 桶"""
-    try:
-        data = await request.json()
-        item = data.get("item")
-        node_id = data.get("nodeId", "")
-        if item:
-            global _selection_queue_gen
-            with _selection_queues_lock:
-                _selection_queues[node_id].append(item)
-                _selection_queue_gen += 1
-            logger.debug(f"[SelectionQueue] push node={node_id} → 队列长度 {len(_selection_queues[node_id])}")
-        return web.json_response({"success": True})
-    except Exception as e:
-        logger.error(f"[SelectionQueue] push error: {e}")
-        return web.json_response({"success": False, "error": str(e)})
-
-@PromptServer.instance.routes.post("/danbooru_gallery/selection_queue_pop")
-async def selection_queue_pop(request):
-    """节点执行时从队列头部 pop 一个条目（不移除则 peek）"""
-    try:
-        data = await request.json() if request.can_read_body else {}
-        remove = data.get("remove", True)
-        with _selection_queue_lock:
-            if _selection_queue:
-                item = _selection_queue.popleft() if remove else _selection_queue[0]
-                logger.debug(f"[SelectionQueue] pop → 剩余 {len(_selection_queue)}")
-                return web.json_response({"success": True, "item": item})
-        return web.json_response({"success": True, "item": None})
-    except Exception as e:
-        logger.error(f"[SelectionQueue] pop error: {e}")
-        return web.json_response({"success": False, "error": str(e)})
-
-# ================================
-# Tag翻译API接口
-# ================================
-
-@PromptServer.instance.routes.get("/danbooru_gallery/translate_tag")
-async def translate_tag_route(request):
-    """翻译单个tag"""
-    try:
-        tag = request.query.get("tag", "").strip()
-        if not tag:
-            return web.json_response({"success": False, "error": "缺少tag参数"})
-        
-        translation = translation_system.translate_tag(tag)
-        return web.json_response({
-            "success": True,
-            "tag": tag,
-            "translation": translation
-        })
-    except Exception as e:
-        logger.error(f"翻译tag接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)})
-
-@PromptServer.instance.routes.post("/danbooru_gallery/translate_tags_batch")
-async def translate_tags_batch_route(request):
-    """批量翻译tags"""
-    try:
-        data = await request.json()
-        tags = data.get("tags", [])
-        
-        if not isinstance(tags, list):
-            return web.json_response({"success": False, "error": "tags必须是数组"})
-        
-        translations = translation_system.translate_tags_batch(tags)
-        return web.json_response({
-            "success": True,
-            "translations": translations
-        })
-    except Exception as e:
-        logger.error(f"批量翻译tags接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)})
-
-@PromptServer.instance.routes.get("/danbooru_gallery/search_chinese")
-async def search_chinese_route(request):
-    """中文搜索匹配 - 优先使用FTS5数据库搜索"""
-    try:
-        query = request.query.get("query", "").strip()
-        limit = int(request.query.get("limit", "10"))
-        source = request.query.get("source", "danbooru")
-        adapter = get_site_adapter(source)
-
-        if not query:
-            return web.json_response({"success": True, "results": []})
-
-        # 加载配置
-        config = load_autocomplete_config()
-
-        # ✅ 优先使用FTS5数据库搜索（速度更快，10-50ms → 2-5ms）
-        if adapter.key == "danbooru" and get_db_manager and config['cache'].get('use_database_query', True):
-            try:
-                db = get_db_manager()
-                db_results = await db.search_tags_optimized(query, limit, search_type="chinese")
-
-                if db_results:
-                    # 转换为前端期望的格式
-                    formatted_results = [
-                        {
-                            'tag': tag['tag'],
-                            'translation_cn': tag.get('translation_cn'),
-                            'category': tag['category'],
-                            'post_count': tag['post_count'],
-                            'match_score': tag.get('match_score', 5)
-                        }
-                        for tag in db_results
-                    ]
-                    logger.debug(f"[SearchChinese] FTS5数据库查询: '{query}' -> {len(formatted_results)}条结果")
-                    return web.json_response({
-                        "success": True,
-                        "query": query,
-                        "results": formatted_results
-                    })
-            except Exception as e:
-                logger.warning(f"[SearchChinese] FTS5查询失败: {e}，回退到translation_system")
-
-        # ⚠️ Fallback: 使用旧的translation_system（线性搜索，较慢）
-        try:
-            results = translation_system.search_chinese_tags(query, limit)
-            logger.debug(f"[SearchChinese] translation_system查询: '{query}' -> {len(results)}条结果")
-            return web.json_response({
-                "success": True,
-                "query": query,
-                "results": results
-            })
-        except Exception as e:
-            logger.error(f"[SearchChinese] translation_system查询失败: {e}")
-            return web.json_response({
-                "success": False,
-                "error": str(e)
-            })
-
-    except Exception as e:
-        logger.error(f"中文搜索接口错误: {e}")
-        return web.json_response({"success": False, "error": str(e)})
-
-@PromptServer.instance.routes.get("/danbooru_gallery/autocomplete_with_translation")
-async def get_autocomplete_with_translation(request):
-    """带翻译的自动补全API - 三层查询机制：数据库 → API → 空结果"""
-    try:
-        query = request.query.get("query", "")
-        limit = int(request.query.get("limit", "20"))
-        source = request.query.get("source", "danbooru")
-        adapter = get_site_adapter(source)
-
-        if not query:
-            return web.json_response([])
-
-        # 加载配置
-        config = load_autocomplete_config()
-
-        # ✅ 第1层：查询本地SQLite数据库（已包含翻译）
-        if adapter.key == "danbooru" and get_db_manager and config['cache'].get('use_database_query', True):
-            try:
-                db = get_db_manager()
-                db_results = await db.search_tags_by_prefix(query, limit)
-
-                if db_results:
-                    # 数据库有结果，转换格式（已包含translation_cn）
-                    formatted_results = [
-                        {
-                            'name': tag['tag'],
-                            'category': tag['category'],
-                            'post_count': tag['post_count'],
-                            'translation': tag.get('translation_cn'),
-                            'aliases': tag.get('aliases', [])
-                        }
-                        for tag in db_results
-                    ]
-                    logger.debug(f"[AutocompleteTranslation] 数据库查询成功: '{query}' -> {len(formatted_results)}条结果")
-                    return web.json_response(formatted_results)
-                else:
-                    logger.debug(f"[AutocompleteTranslation] 数据库无结果: '{query}'")
-            except Exception as e:
-                logger.warning(f"[AutocompleteTranslation] 数据库查询失败: {e}，尝试API fallback")
-
-        # ✅ 第2层：Fallback到Danbooru API（需要手动添加翻译）
-        if config['offline_mode'].get('fallback_to_remote', True):
-            try:
-                timeout = config['offline_mode'].get('remote_timeout_ms', 2000) / 1000.0
-
-                tags_url = adapter.tags_url
-                params = adapter.build_autocomplete_params(query, limit)
-                credentials = get_site_credentials(adapter)
-                if not has_required_site_credentials(adapter, credentials):
-                    if adapter.key == "gelbooru":
-                        logger.info("[Gelbooru] 未配置 User ID/API Key，改用公开 autocomplete2")
-                        params = adapter.build_public_autocomplete_params(query, limit)
-                        response = _danbooru_request("GET", tags_url, params=params, timeout=timeout)
-                        response.raise_for_status()
-                        result = adapter.normalize_public_autocomplete_response(response.json())
-                        for tag_data in result:
-                            tag_name = tag_data.get('name', '')
-                            tag_data['translation'] = translation_system.translate_tag(tag_name)
-                        return web.json_response(result)
-                    logger.warning(f"[{adapter.key}] 缺少必要认证信息，已跳过带翻译自动补全请求")
-                    return web.json_response([])
-                params = adapter.apply_auth_params(params, credentials)
-
-                username, api_key = load_user_auth()
-                auth = HTTPBasicAuth(username, api_key) if adapter.requires_auth and username and api_key else None
-
-                logger.debug(f"[AutocompleteTranslation] 调用远程API({adapter.key}): '{query}' (超时: {timeout}s)")
-                response = _danbooru_request("GET", tags_url, params=params, auth=auth, timeout=timeout)
-                response.raise_for_status()
-
-                result = adapter.normalize_autocomplete_response(response.json())
-
-                # 为每个tag添加翻译
-                if isinstance(result, list):
-                    for tag_data in result:
-                        tag_name = tag_data.get('name', '')
-                        translation = translation_system.translate_tag(tag_name)
-                        tag_data['translation'] = translation
-
-                    logger.info(f"[AutocompleteTranslation] API查询成功: '{query}' -> {len(result)}条结果")
-
-                return web.json_response(result)
-
-            except requests.Timeout:
-                logger.warning(f"[AutocompleteTranslation] 远程API超时 (>{timeout}s): '{query}'")
-            except requests.exceptions.RequestException as e:
-                logger.warning(f"[AutocompleteTranslation] 远程API失败: {e}")
-            except Exception as e:
-                logger.error(f"[AutocompleteTranslation] API调用错误: {e}")
-
-        # ✅ 第3层：返回空结果
-        logger.debug(f"[AutocompleteTranslation] 所有查询方式均无结果: '{query}'")
-        return web.json_response([])
-
-    except Exception as e:
-        logger.error(f"[AutocompleteTranslation] 处理请求时发生错误: {e}")
-        return web.json_response([])
-
-class DanbooruGalleryNode:
-    _post_cache = {}
-
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {},
-            "optional": {
-                # 兼容前端 bypass 解析：
-                # 该节点原本只有 hidden 输入，某些前端 bypass 路径会在无可见输入时抛出
-                # "No input found for flattened id ... slot [0]"。
-                # 增加可选透传槽位后，bypass 时不会因缺少输入槽而直接报错。
-                "bypass_image": ("IMAGE", {"forceInput": True}),
-                "bypass_prompts": ("STRING", {"forceInput": True}),
-            },
-            "hidden": {
-                "selection_data": ("STRING", {"default": "{}", "multiline": True, "forceInput": True}),
-            },
-        }
-
-    RETURN_TYPES = ("IMAGE", "STRING")
-    RETURN_NAMES = ("images", "prompts")
-    OUTPUT_IS_LIST = (True, True)
-    FUNCTION = "get_selected_data"
-    CATEGORY = "danbooru"
-    OUTPUT_NODE = True
-
-    @classmethod
-    def IS_CHANGED(cls, selection_data="{}", **kwargs):
-        """返回队首条目的 _queue_id（唯一），队列空时返回 ""（缓存命中不再重复执行）。
-        彻底解决快速选图 1→Queue→2→Queue→... 导致的提示词覆盖竞态。
-        注意：此方法不感知 nodeId，但只要每个节点都有自己的 selection_data widget，
-        每次 Queue 序列化时都会 snapshot 各节点当前值，配合后端 FIFO 分桶即可逐节点隔离。"""
-        if not selection_data or selection_data == "{}":
-            return ""
-        try:
-            data = json.loads(selection_data)
-            node_id = data.get("nodeId", "")
-            with _selection_queues_lock:
-                q = _selection_queues.get(node_id)
-                if q and len(q) > 0:
-                    return str(q[0].get("_queue_id", ""))
-        except (json.JSONDecodeError, TypeError):
-            pass
-        if not selection_data or selection_data == "{}":
-            return ""
-        return selection_data
-
-    def get_selected_data(self, selection_data="{}", **kwargs):
-        """处理选中的图片数据，从 FIFO 队列（按 nodeId 分桶）中 pop，否则回退。"""
-        images = []
-        prompts = []
-        my_node_id = ""
-
-        try:
-            # 解析自己的 selection_data 获取 nodeId
-            if selection_data and selection_data != "{}":
-                data = json.loads(selection_data)
-                my_node_id = data.get("nodeId", "")
-
-            # 从 FIFO 按 nodeId 分桶 pop
-            item = None
-            if my_node_id:
-                with _selection_queues_lock:
-                    q = _selection_queues.get(my_node_id)
-                    if q and len(q) > 0:
-                        item = q.popleft()
-                        logger.debug(f"[SelectionQueue] get_selected_data pop node={my_node_id} → 剩余 {len(q)}")
-
-            if item:
-                selections = item.get("selections", [])
-            else:
-                # 回退：从自己的 widget 读取
-                if not selection_data or selection_data == "{}":
-                    return ([torch.zeros(1, 1, 1, 3)], [""])
-                data = json.loads(selection_data)
-                selections = data.get("selections", [])
-
-            if not selections:
-                return ([torch.zeros(1, 1, 1, 3)], [""])
-
-            for sel in selections:
-                prompt = sel.get("prompt", "")
-                image_url = sel.get("image_url")
-                prompts.append(prompt)
-                if image_url:
-                    try:
-                        img_data = _fetch_supported_media(image_url)
-                        img = Image.open(io.BytesIO(img_data)).convert("RGB")
-                        img_array = np.array(img).astype(np.float32) / 255.0
-                        tensor = torch.from_numpy(img_array)[None,]
-                        images.append(tensor)
-                    except Exception as e:
-                        logger.error(f"加载图片失败 {image_url}: {e}")
-                        images.append(torch.zeros(1, 1, 1, 3))
-                else:
-                    images.append(torch.zeros(1, 1, 1, 3))
-
-            if not images:
-                return ([torch.zeros(1, 1, 1, 3)], [""])
-
-        except Exception as e:
-            logger.error(f"Error processing selection in DanbooruGalleryNode: {e}")
-            return ([torch.zeros(1, 1, 1, 3)], [""])
-
-        return (images, prompts)
-    
-    @staticmethod
-    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False, before_id=None, gelbooru_dedup_mode: str = "off"):
-        settings = load_settings()
-        cache_enabled = settings.get("cache_enabled", True)
-        max_cache_age = settings.get("max_cache_age", 3600)
-        adapter = get_site_adapter(source)
-        if gelbooru_display_all_site_content is None:
-            gelbooru_display_all_site_content = settings.get("gelbooru_display_all_site_content", False)
-
-        if gelbooru_dedup_mode not in ("off", "on", "on_auth"):
-            gelbooru_dedup_mode = "off"
-
-        # before_id分页：化 + 数字校验，防止 page=b; DROP TABLE 类拼接注入
-        before_id = str(before_id).strip() if before_id else ""
-        if before_id and not before_id.isdigit():
-            before_id = ""
-        # order/ordfav/sort变结果顺序，游标会漏图，禁用
-        if before_id and re.search(r'(?:^|\s)(?:order|ordfav|sort):', tags or ''):
-            before_id = ""
-        #仅在 Danbooru（官方 page=b<id>）或 Gelbooru + dedup 开启时生效
-        if before_id and not (
-            adapter.key == "danbooru"
-            or (adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"))
-        ):
-            before_id = ""
-
-        credentials = get_site_credentials(adapter)
-        has_gelbooru_creds = has_required_site_credentials(adapter, credentials)
-
-        # 创建缓存键（rating 归一化排序，避免 "e,q" 与 "q,e" 命中两条缓存）
-        rating_key = ','.join(sorted(r.strip().lower() for r in (rating or '').split(',') if r.strip()))
-        site_options_key = ""
-        if adapter.key == "gelbooru":
-            site_options_key = "display_all" if gelbooru_display_all_site_content else "default"
-            # dedup位影响 tag断数量，须区分，否则 on/off/on_auth 在 before_id 同为空时互相污染
-            site_options_key += f"_dedup_{gelbooru_dedup_mode}"
-        # before_id 入键避免不同游标页相互污染
-        cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}:{before_id}"
-
-        # 判断是否获取收藏列表，如果是清除缓存以避免相同的请求前端列表不更新
-        match = re.search(r'\bordfav:([^\s]+)', tags)
-
-        # 如果启用了缓存，则检查缓存
-        if cache_enabled and not match:
-            if cache_key in DanbooruGalleryNode._post_cache:
-                cached_data, timestamp = DanbooruGalleryNode._post_cache[cache_key]
-                if time.time() - timestamp < max_cache_age:
-                    return (cached_data,)
-
-        # 分离 date: 标签和其他标签
-        date_tag = ''
-        other_tags = []
-        for tag in tags.split(' '):
-            if tag.strip().startswith('date:'):
-                date_tag = tag.strip()
-            elif tag.strip():
-                other_tags.append(tag.strip())
-
-        # 限制其他标签的数量。Gelbooru标模式下 id:<X 占用一个 tag 名额（公开页/2-tag 限制），
-        # on_auth + 已配密钥走 DAPI 时可放宽到更多 tag。
-        if adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"):
-            if gelbooru_dedup_mode == "on_auth" and has_gelbooru_creds:
-                max_tags = 10
-            else:
-                max_tags = 1
-        else:
-            max_tags = 2
-        if len(other_tags) > max_tags:
-            other_tags = other_tags[:max_tags]
-        
-        # 重新组合标签
-        final_tags = ' '.join(other_tags)
-        if date_tag:
-            final_tags = f"{final_tags} {date_tag}".strip()
-
-        rating_query = ""
-        if adapter.key == "danbooru" and rating and rating.lower() != 'all':
-            allowed = {'general', 'sensitive', 'questionable', 'explicit', 'g', 's', 'q', 'e'}
-            rating_values = [r.strip().lower() for r in rating.split(',') if r.strip()]
-            rating_values = [r for r in rating_values if r in allowed]
-            if len(rating_values) == 1:
-                rating_query = f"rating:{rating_values[0]}"
-            elif len(rating_values) > 1:
-                rating_query = ' '.join(f"~rating:{r}" for r in rating_values)
-        elif adapter.key != "danbooru":
-            rating_query = rating
-        
-        tags = final_tags
-        # Gelbooru：拼进 tags（公开页 / DAPI用 tags 参数，见 build_public_posts_params / build_posts_params）
-        if before_id and adapter.key == "gelbooru":
-            tags = f"{tags} id:<{before_id}".strip()
-
-        username, api_key = load_user_auth()
-        auth = HTTPBasicAuth(username, api_key) if adapter.requires_auth and username and api_key else None
-        credentials = get_site_credentials(adapter)
-        if adapter.key == "gelbooru" and force_public_detail:
-            posts = _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, gelbooru_display_all_site_content)
-            result_text = json.dumps(posts, ensure_ascii=False)
-            return (result_text,)
-
-        if not has_required_site_credentials(adapter, credentials):
-            if adapter.key == "gelbooru":
-                logger.info("[Gelbooru] 未配置 User ID/API Key，改用公开网页解析模式")
-                posts = _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, gelbooru_display_all_site_content)
-                result_text = json.dumps(posts, ensure_ascii=False)
-
-                if cache_enabled and not (adapter.key == "gelbooru" and gelbooru_display_all_site_content and not posts):
-                    # 跳过 error 占位格缓存（否则一次限流会让接下来 TTL 内都看不到新图）
-                    has_error_placeholder = posts and any(isinstance(p, dict) and p.get("error") for p in posts)
-                    if not has_error_placeholder:
-                        DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
-
-                return (result_text,)
-            logger.warning(f"[{adapter.key}] 缺少必要认证信息，已跳过帖子请求")
-            return ("[]",)
-            
-        params = adapter.build_posts_params(tags, limit, page, rating_query)
-        params = adapter.apply_auth_params(params, credentials)
-        # Danbooru：走官方 page=b<id>
-        if before_id and adapter.key == "danbooru":
-            params["page"] = f"b{before_id}"
-
-        try:
-            response = _danbooru_request("GET", adapter.posts_url, params=params, auth=auth, timeout=15)
-            if response.status_code == 401 and adapter.key == "gelbooru":
-                logger.warning("[Gelbooru] DAPI 返回 401，改用公开网页解析模式")
-                posts = _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, gelbooru_display_all_site_content)
-            else:
-                response.raise_for_status()
-                posts = adapter.normalize_posts_response(response.json())
-
-            result_text = json.dumps(posts, ensure_ascii=False)
-            
-            # 如果启用了缓存，则存储结果（跳过 error 占位格）
-            if cache_enabled and not (adapter.key == "gelbooru" and gelbooru_display_all_site_content and not posts):
-                has_error_placeholder = posts and any(isinstance(p, dict) and p.get("error") for p in posts)
-                if not has_error_placeholder:
-                    DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
-                # 清理旧缓存（可选，防止内存无限增长）
-                if len(DanbooruGalleryNode._post_cache) > 200: # 假设最多缓存200个请求
-                    oldest_key = min(DanbooruGalleryNode._post_cache.keys(), key=lambda k: DanbooruGalleryNode._post_cache[k][1])
-                    del DanbooruGalleryNode._post_cache[oldest_key]
-            
-            return (result_text,)
-        except requests.exceptions.RequestException as e:
-            logger.error(f"网络请求时发生错误: {e}")
-            return ("[]",)
-        except Exception as e:
-            logger.error(f"发生未知错误: {e}")
-            return ("[]",)
-
-# ComfyUI 必须的字典
-def get_node_class_mappings():
-    return {
-        "DanbooruGalleryNode": DanbooruGalleryNode
+$el("style", {
+    textContent: `
+    /* 搜索容器，用于定位建议面板 */
+    .danbooru-search-container {
+        position: relative;
+        flex-grow: 1;
+        display: flex;
+        align-items: center;
     }
 
-def get_node_display_name_mappings():
-    return {
-        "DanbooruGalleryNode": "D站画廊 (Danbooru Gallery)"
+    .danbooru-search-input {
+        /* padding-right: 28px !important; */ /* 为清空按钮留出空间, 已被新的flex布局取代 */
     }
 
-NODE_CLASS_MAPPINGS = get_node_class_mappings()
-NODE_DISPLAY_NAME_MAPPINGS = get_node_display_name_mappings()
+    .danbooru-clear-search-button {
+        position: absolute;
+        right: 5px;
+        top: 50%;
+        transform: translateY(-50%);
+        background: transparent;
+        border: none;
+        color: #999;
+        cursor: pointer;
+        font-size: 20px;
+        line-height: 1;
+        padding: 0 5px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        transition: all 0.2s;
+    }
+    .danbooru-clear-search-button:hover {
+        background-color: rgba(255, 255, 255, 0.1);
+        color: white;
+    }
+
+    /* 自动补全建议面板 */
+    .danbooru-suggestions-panel {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        min-width: 100%;
+        max-width: 600px;
+        width: auto;
+        background-color: var(--comfy-menu-bg);
+        border: 1px solid var(--input-border-color);
+        border-top: none;
+        border-radius: 0 0 6px 6px;
+        z-index: 1002;
+        max-height: 400px;
+        overflow-y: auto;
+        overflow-x: hidden;
+        box-shadow: 0 8px 16px rgba(0,0,0,0.3);
+        white-space: nowrap;
+    }
+
+    .danbooru-suggestion-item {
+        padding: 8px 12px;
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        transition: background-color 0.2s;
+        min-width: fit-content;
+    }
+
+    .danbooru-suggestion-item:hover,
+    .danbooru-suggestion-item.selected {
+        background-color: rgba(123, 104, 238, 0.3);
+    }
+
+    .danbooru-suggestion-name {
+        color: var(--comfy-input-text);
+        font-weight: 500;
+        flex: 1;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        margin-right: 8px;
+    }
+
+    .danbooru-suggestion-count {
+        color: #888;
+        font-size: 0.9em;
+        flex-shrink: 0;
+    }
+
+    /* 中文搜索建议面板 */
+    .danbooru-chinese-suggestions-panel {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        min-width: 100%;
+        max-width: 500px;
+        width: auto;
+        background-color: var(--comfy-menu-bg);
+        border: 1px solid var(--input-border-color);
+        border-top: none;
+        border-radius: 0 0 6px 6px;
+        z-index: 1003;
+        max-height: 300px;
+        overflow-y: auto;
+        overflow-x: hidden;
+        box-shadow: 0 8px 16px rgba(0,0,0,0.3);
+        white-space: nowrap;
+    }
+
+    .danbooru-chinese-suggestion-item {
+        padding: 8px 12px;
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        transition: background-color 0.2s;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        min-width: fit-content;
+    }
+
+    .danbooru-chinese-suggestion-item:last-child {
+        border-bottom: none;
+    }
+
+    .danbooru-chinese-suggestion-item:hover,
+    .danbooru-chinese-suggestion-item.selected {
+        background-color: rgba(123, 104, 238, 0.3);
+    }
+
+    .danbooru-suggestion-chinese {
+        color: var(--comfy-input-text);
+        font-weight: 600;
+        font-size: 0.95em;
+        margin-right: 8px;
+        flex-shrink: 0;
+    }
+
+    .danbooru-suggestion-english {
+        color: #888;
+        font-size: 0.85em;
+        font-style: italic;
+        flex-shrink: 0;
+    }
+
+    /* Category Dropdown Styles */
+    .danbooru-category-dropdown { position: relative; display: inline-block; }
+    
+    /* Spinner for buttons */
+    .spinner {
+        width: 10px;
+        height: 10px;
+        border: 1px solid currentColor;
+        border-top: 1px solid transparent;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+    }
+   
+   .danbooru-category-button {
+       background-color: var(--comfy-input-bg);
+       color: var(--comfy-input-text);
+       padding: 5px 10px;
+       border: 1px solid var(--input-border-color);
+       border-radius: 4px;
+       cursor: pointer;
+       height: 100%;
+       display: flex;
+       align-items: center;
+       gap: 5px;
+       transition: background-color 0.2s;
+   }
+   .danbooru-category-button:hover { background-color: var(--comfy-menu-bg); }
+   .danbooru-category-button .arrow-down { transition: transform 0.2s ease-in-out; }
+   .danbooru-category-button.open .arrow-down { transform: rotate(180deg); }
+
+   .danbooru-category-list {
+       visibility: hidden;
+       opacity: 0;
+       transform: translateY(-10px);
+       transition: visibility 0.2s, opacity 0.2s, transform 0.2s ease-out;
+       position: absolute;
+       background-color: var(--comfy-menu-bg);
+       border: 1px solid var(--input-border-color);
+       border-radius: 6px;
+       z-index: 1001;
+       min-width: 160px;
+       box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+       padding: 6px;
+       backdrop-filter: blur(5px);
+   }
+   .danbooru-category-list.show {
+       visibility: visible;
+       opacity: 1;
+       transform: translateY(0);
+   }
+
+   .danbooru-category-item {
+       display: flex;
+       align-items: center;
+       padding: 6px 10px;
+       color: var(--comfy-input-text);
+       border-radius: 4px;
+       transition: background-color 0.2s;
+   }
+   .danbooru-category-item:hover { background-color: rgba(255, 255, 255, 0.1); }
+   .danbooru-rating-dropdown .danbooru-category-item { cursor: pointer; }
+   .danbooru-category-item label { margin-left: 10px; cursor: pointer; user-select: none; }
+   
+   .danbooru-category-checkbox {
+       appearance: none;
+       -webkit-appearance: none;
+       width: 16px;
+       height: 16px;
+       border-radius: 4px;
+       border: 2px solid #555;
+       cursor: pointer;
+       position: relative;
+       transition: background-color 0.2s, border-color 0.2s;
+   }
+   .danbooru-category-checkbox:checked {
+       background-color: #7B68EE;
+       border-color: #7B68EE;
+   }
+   .danbooru-category-checkbox:checked::before {
+       content: '✔';
+       font-size: 12px;
+       color: white;
+       position: absolute;
+       top: 50%;
+       left: 50%;
+       transform: translate(-50%, -50%);
+   }
+
+    .danbooru-gallery { width: 100%; display: flex; flex-direction: column; min-height: 200px; }
+    .danbooru-controls { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 5px; align-items: stretch; }
+    .danbooru-auth-controls { display: flex; gap: 5px; }
+    .danbooru-controls > button, .danbooru-controls > div { padding: 5px; border-radius: 4px; border: 1px solid var(--input-border-color); background-color: var(--comfy-input-bg); color: var(--comfy-input-text); }
+    .danbooru-controls > .danbooru-search-container > .danbooru-search-input { background: var(--comfy-input-bg); border: 1px solid var(--input-border-color); padding: 5px 10px; border-radius: 4px; }
+    .danbooru-controls .danbooru-search-input { flex-grow: 1; min-width: 150px; }
+    .danbooru-controls > select { min-width: 100px; }
+    .danbooru-source-select { height: 32px; padding: 5px 8px; border-radius: 4px; border: 1px solid var(--input-border-color); background-color: var(--comfy-input-bg); color: var(--comfy-input-text); }
+    .danbooru-gelbooru-display-all-toggle { height: 32px; align-items: center; gap: 6px; padding: 5px 8px; border-radius: 4px; border: 1px solid var(--input-border-color); background-color: var(--comfy-input-bg); color: var(--comfy-input-text); font-size: 12px; white-space: nowrap; cursor: pointer; }
+    .danbooru-gelbooru-display-all-toggle input { margin: 0; }
+    .danbooru-image-wrapper.new-item { animation: fadeInUp 0.5s ease-out; }
+    @keyframes fadeInUp { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
+    .danbooru-settings-button {
+        flex-grow: 0;
+        width: 40px;
+        height: 40px;
+        aspect-ratio: 1;
+        padding: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: background-color 0.2s, transform 0.2s;
+        background-color: var(--comfy-input-bg);
+        color: var(--comfy-input-text);
+        border: 1px solid var(--input-border-color);
+        border-radius: 6px;
+    }
+    .danbooru-settings-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.1); }
+    .danbooru-settings-button .icon { width: 24px; height: 24px; }
+    .danbooru-refresh-button { flex-grow: 0; width: 40px; height: 40px; aspect-ratio: 1; padding: 8px; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: background-color 0.2s, transform 0.2s; border-radius: 6px; }
+    .danbooru-refresh-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.1); }
+    .danbooru-refresh-button.loading { cursor: not-allowed; }
+    .danbooru-filter-button { flex-grow: 0; width: 40px; height: 40px; aspect-ratio: 1; padding: 8px; display: flex; align-items: center; justify-content: center; cursor: pointer; transition: background-color 0.2s, transform 0.2s, color 0.2s, border-color 0.2s; border-radius: 6px; }
+    .danbooru-filter-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.1); }
+    .danbooru-filter-button.active { background-color: #7B68EE; color: white; border-color: #7B68EE; }
+    .danbooru-refresh-button.loading .icon { animation: spin 1s linear infinite; }
+    @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    .danbooru-ranking-button {
+        flex-grow: 0;
+        width: auto;
+        padding: 5px 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 5px;
+        cursor: pointer;
+        transition: background-color 0.2s, transform 0.2s;
+        font-size: 12px;
+        white-space: nowrap;
+    }
+    .danbooru-ranking-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.05); }
+    .danbooru-ranking-button.active {
+        background-color: #7B68EE;
+        color: white;
+        border-color: #7B68EE;
+    }
+    .danbooru-ranking-button .icon { width: 16px; height: 16px; }
+    
+    /* 收藏夹按钮样式 */
+    .danbooru-favorites-button {
+        flex-grow: 0;
+        width: auto;
+        padding: 5px 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 5px;
+        cursor: pointer;
+        transition: background-color 0.2s, transform 0.2s;
+        font-size: 12px;
+        white-space: nowrap;
+    }
+    .danbooru-favorites-button:hover { background-color: var(--comfy-menu-bg); transform: scale(1.05); }
+    .danbooru-favorites-button.active {
+        background-color: #DC3545; /* Bootstrap's danger color */
+        color: white;
+        border-color: #DC3545;
+    }
+    .danbooru-favorites-button .icon { width: 16px; height: 16px; }
+    .danbooru-image-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); grid-gap: 5px; grid-auto-rows: 1px; overflow-y: auto; background-color: var(--comfy-input-bg); padding: 5px; border-radius: 4px; flex-grow: 1; height: 0; }
+    .danbooru-image-wrapper {
+        grid-row-start: auto;
+        border: 2px solid transparent;
+        transition: border-color 0.2s, transform 0.2s ease-out, box-shadow 0.2s ease-out;
+        border-radius: 6px;
+        overflow: visible !important;
+        position: relative !important; /* Add relative positioning */
+        display: block !important;
+    }
+    .danbooru-image-wrapper:hover {
+        transform: scale(1.05);
+        box-shadow: 0 0 15px rgba(88, 101, 242, 0.7); /* 泛光效果 */
+        z-index: 10;
+        position: relative;
+    }
+    .danbooru-image-wrapper.selected {
+        border-color: #7B68EE; /* A more vibrant purple */
+        box-shadow: 0 0 20px rgba(123, 104, 238, 0.8); /* Stronger glow */
+        transform: scale(1.05);
+        z-index: 11;
+    }
+
+    .danbooru-image-wrapper.selected::after {
+        content: "✓";
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        color: white;
+        font-size: 50px;
+        font-weight: bold;
+        text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
+        z-index: 12;
+        pointer-events: none;
+    }
+    
+    .danbooru-image-wrapper.selected::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: rgba(123, 104, 238, 0.3); /* Semi-transparent overlay */
+        z-index: 11;
+        pointer-events: none;
+    }
+    
+    /* 按钮容器，位于右上角 */
+    .danbooru-image-buttons {
+        position: absolute;
+        top: 3px;
+        right: 3px;
+        display: flex;
+        gap: 2px;
+        opacity: 0;
+        transform: scale(0.9);
+        transition: all 0.2s ease !important;
+        z-index: 15;
+    }
+    
+    .danbooru-image-wrapper:hover .danbooru-image-buttons {
+        opacity: 1;
+        transform: scale(1);
+    }
+
+    /* 通用按钮样式 */
+    .danbooru-image-buttons button {
+        background-color: rgba(0, 0, 0, 0.8) !important;
+        color: white !important;
+        border: none !important;
+        border-radius: 50% !important;
+        width: 20px !important;
+        height: 20px !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        cursor: pointer !important;
+        transition: all 0.2s ease !important;
+        backdrop-filter: blur(5px) !important;
+        -webkit-backdrop-filter: blur(5px) !important;
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    .danbooru-image-buttons button:hover {
+        transform: scale(1.1) !important;
+        background-color: rgba(123, 104, 238, 0.9) !important; /* 统一使用紫色悬浮效果 */
+    }
+
+    /* 收藏按钮特定样式 */
+    .danbooru-favorite-button.favorited {
+        background-color: rgba(220, 53, 69, 0.9) !important; /* DC3545 in rgba */
+        color: white !important;
+    }
+
+    .danbooru-favorite-button.favorited:hover {
+        background-color: rgba(123, 104, 238, 0.9) !important; /* 统一使用紫色悬浮效果 */
+    }
+
+    /* 统一所有按钮的悬浮样式 */
+    .danbooru-download-button:hover,
+    .danbooru-edit-button:hover,
+    .danbooru-view-image-button:hover {
+        background-color: rgba(123, 104, 238, 0.9) !important; /* 统一使用紫色悬浮效果 */
+    }
+
+    /* 可点击的tag样式 */
+    .danbooru-clickable-tag {
+        cursor: pointer !important;
+        transition: transform 0.1s, filter 0.1s !important;
+    }
+    .danbooru-clickable-tag:hover {
+        transform: scale(1.05) !important;
+        filter: brightness(1.2) !important;
+    }
+
+    /* 旧的、独立的按钮样式将被上面的新规则取代或覆盖，为了清晰起见，我将删除它们 */
+    /* 收藏按钮样式 - 位于右上角最右侧 (旧) */
+    .danbooru-gallery .danbooru-image-grid .danbooru-image-wrapper .danbooru-favorite-button-old {
+        position: absolute !important;
+        top: 3px !important;
+        right: 3px !important;
+        bottom: auto !important;
+        left: auto !important;
+        border: none !important;
+        /* Keep this empty or remove it. The styles are now in .danbooru-image-buttons button */
+    }
+    
+    /* All button styles are now handled by .danbooru-image-buttons and its children. */
+    /* The individual hover/visibility rules are replaced by the container's hover effect. */
+    
+    .danbooru-image-grid img {
+        width: 100%;
+        height: auto;
+        cursor: pointer;
+        display: block;
+    }
+    .danbooru-status { text-align: center; width: 100%; margin: 10px 0; color: #ccc; }
+    .danbooru-status.error { color: #f55; }
+    
+        /* New Tooltip Styles */
+        @keyframes danbooru-tooltip-fade-in {
+            from { opacity: 0; transform: scale(0.95); }
+            to { opacity: 1; transform: scale(1); }
+        }
+    
+        .danbooru-tag-tooltip {
+            background-color: rgba(28, 29, 31, 0.9);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 6px;
+            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.6);
+            padding: 8px;
+            max-width: 600px;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+            animation: danbooru-tooltip-fade-in 0.15s ease-out;
+            transition: opacity 0.15s, transform 0.15s;
+            pointer-events: none; /* Disable mouse interaction */
+        }
+
+        .danbooru-tooltip-tags {
+            display: flex;
+            flex-direction: column;
+            gap: 8px; /* Space between sections */
+        }
+
+        .danbooru-tooltip-section {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .danbooru-tooltip-upload-date {
+            color: #a0a3a8;
+            font-size: 0.8em;
+            margin-top: 2px;
+        }
+
+        .danbooru-tooltip-category-header {
+            font-size: 0.85em;
+            font-weight: 600;
+            color: #b0b3b8;
+            margin-bottom: 4px;
+        }
+
+        .danbooru-tooltip-tags-wrapper {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+        }
+    
+        .danbooru-tooltip-tag {
+            font-size: 0.8em;
+            font-weight: 500;
+            color: white;
+            padding: 2px 6px;
+            border-radius: 4px;
+            cursor: default; /* Change cursor to default */
+            transition: none; /* Remove transitions */
+        }
+    
+        .danbooru-tooltip-tag:hover {
+            transform: none; /* Remove hover effect */
+            filter: none; /* Remove hover effect */
+        }
+    
+        .danbooru-tooltip-tag.copied {
+            animation: danbooru-tag-copied-animation 0.6s ease-out;
+        }
+    
+        @keyframes danbooru-tag-copied-animation {
+            0% { transform: scale(1); }
+            50% { transform: scale(1.1); background-color: #ffffff; color: #000000; }
+            100% { transform: scale(1); }
+        }
+        
+        /* Tag Colors */
+        /* Tag Colors based on new categories */
+        .danbooru-tooltip-tag.tag-category-artist { background-color: #FFF3CD; color: #664D03; } /* Artist: Light Yellow */
+        .danbooru-tooltip-tag.tag-category-copyright { background-color: #F8D7DA; color: #58151D; } /* Copyright: Light Pink */
+        .danbooru-tooltip-tag.tag-category-character { background-color: #D4EDDA; color: #155724; } /* Character: Light Green */
+        .danbooru-tooltip-tag.tag-category-general { background-color: #D1ECF1; color: #0C5460; } /* General: Light Blue */
+        .danbooru-tooltip-tag.tag-category-meta { background-color: #F8F9FA; color: #383D41; border: 1px solid #DFE2E5; } /* Meta: Light Grey */
+        
+        /* 黑名单对话框样式 */
+        .danbooru-blacklist-dialog * { box-sizing: border-box; }
+        .danbooru-blacklist-dialog textarea:focus { outline: 2px solid #7B68EE; }
+        .danbooru-blacklist-dialog button:hover { opacity: 0.9; }
+        
+        /* 语言切换按钮样式 */
+        .danbooru-language-button {
+            flex-grow: 0;
+            width: auto;
+            aspect-ratio: 1;
+            padding: 5px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            transition: background-color 0.2s, transform 0.2s;
+        }
+        .danbooru-language-button:hover {
+            background-color: var(--comfy-menu-bg);
+            transform: scale(1.1);
+        }
+        .danbooru-language-button .icon {
+            width: 16px;
+            height: 16px;
+        }
+        .danbooru-language-select-button {
+            padding: 8px 16px;
+            border: 2px solid var(--input-border-color);
+            border-radius: 6px;
+            background-color: var(--comfy-input-bg);
+            color: var(--comfy-input-text);
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: normal;
+            transition: all 0.2s ease;
+        }
+        .danbooru-language-select-button.active {
+            border-color: #7B68EE;
+            background-color: #7B68EE;
+            color: white;
+            font-weight: 600;
+        }
+        .danbooru-language-select-button:hover:not(.active) {
+            border-color: #9a8ee8;
+            background-color: rgba(123, 104, 238, 0.1);
+        }
+        /* 设置对话框样式 */
+        .danbooru-settings-dialog * {
+            box-sizing: border-box;
+        }
+        
+        .danbooru-settings-dialog {
+            /* backdrop-filter: blur(3px); */
+            /* -webkit-backdrop-filter: blur(3px); */
+        }
+        
+        .danbooru-settings-dialog-content {
+            animation: fadeInScale 0.3s ease-out;
+        }
+        
+        @keyframes fadeInScale {
+            from {
+                opacity: 0;
+                transform: scale(0.9);
+            }
+            to {
+                opacity: 1;
+                transform: scale(1);
+            }
+        }
+        
+        .danbooru-settings-dialog-content h2 {
+            padding: 0 10px 12px 10px !important;
+        }
+
+        .danbooru-settings-section {
+            transition: all 0.2s ease;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            margin-bottom: 24px !important;
+        }
+        
+        .danbooru-settings-section:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        }
+        
+        .danbooru-settings-dialog button:hover {
+            opacity: 0.9;
+            transform: translateY(-1px);
+        }
+        
+        .danbooru-settings-dialog button:focus {
+            outline: 2px solid #7B68EE;
+            outline-offset: 2px;
+        }
+        
+        .danbooru-settings-dialog textarea:focus {
+            outline: 2px solid #7B68EE;
+            outline-offset: 1px;
+        }
+        
+        .danbooru-settings-sidebar {
+            display: flex;
+            flex-direction: column;
+            gap: 5px;
+            padding-right: 15px;
+            border-right: 1px solid var(--input-border-color);
+            flex-shrink: 0;
+            width: 180px;
+            box-sizing: border-box;
+            overflow: visible;
+        }
+
+        .sidebar-button {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 12px 15px;
+            border-radius: 8px;
+            cursor: pointer;
+            background-color: transparent;
+            color: var(--comfy-input-text);
+            text-align: left;
+            font-size: 14px;
+            font-weight: 500;
+            transition: background-color 0.2s, color 0.2s;
+            width: 100%;
+            border: none;
+            box-sizing: border-box;
+            justify-content: flex-start;
+        }
+
+        .sidebar-button.active {
+            background-color: rgba(123, 104, 238, 0.2) !important;
+            color: #E0E0E0 !important;
+            font-weight: 600 !important;
+            border: none !important;
+            outline: none !important;
+        }
+
+        .sidebar-button:hover {
+            background-color: rgba(255, 255, 255, 0.1);
+        }
+
+        .sidebar-button-icon {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .sidebar-button svg {
+            stroke-width: 2;
+        }
+
+        .sidebar-button:focus {
+            outline: none;
+        }
+
+        /* 设置对话框滚动容器样式 */
+        .danbooru-settings-scroll-container {
+            scrollbar-width: thin;
+            scrollbar-color: rgba(123, 104, 238, 0.6) transparent;
+        }
+        
+        .danbooru-settings-scroll-container::-webkit-scrollbar {
+            width: 8px;
+        }
+        
+        .danbooru-settings-scroll-container::-webkit-scrollbar-track {
+            background: transparent;
+            border-radius: 4px;
+        }
+        
+        .danbooru-settings-scroll-container::-webkit-scrollbar-thumb {
+            background: rgba(123, 104, 238, 0.6);
+            border-radius: 4px;
+            transition: background 0.2s ease;
+        }
+        
+        .danbooru-settings-scroll-container::-webkit-scrollbar-thumb:hover {
+            background: rgba(123, 104, 238, 0.8);
+        }
+        
+        /* 社交链接按钮样式 */
+        .danbooru-settings-dialog button[title*="GitHub"]:hover {
+            background-color: #1c2128 !important;
+            border-color: #1c2128 !important;
+            transform: translateY(-1px);
+        }
+
+        .danbooru-settings-dialog button[title*="Discord"]:hover {
+            background-color: #4752c4 !important;
+            border-color: #4752c4 !important;
+            transform: translateY(-1px);
+        }
+
+        .danbooru-settings-dialog button[title*="GitHub"]:hover svg,
+        .danbooru-settings-dialog button[title*="Discord"]:hover svg {
+            transform: scale(1.1);
+        }
+
+        /* 移除社交链接按钮的focus效果 */
+        .danbooru-settings-dialog button[title*="GitHub"]:focus,
+        .danbooru-settings-dialog button[title*="Discord"]:focus {
+            outline: none !important;
+        }
+
+        .danbooru-settings-dialog button svg {
+            flex-shrink: 0;
+            transition: transform 0.2s ease;
+        }
+
+        /* Toast提示样式 */
+        #danbooru-gallery-toast-container {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            z-index: 999999;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            align-items: flex-end;
+        }
+        .danbooru-toast {
+            padding: 12px 20px;
+            border-radius: 6px;
+            color: white;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 300px;
+            word-wrap: break-word;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity 0.3s ease-out, transform 0.3s ease-out;
+        }
+        .danbooru-toast.show {
+            opacity: 1;
+            transform: translateX(0);
+        }
+
+        .danbooru-toast-success {
+            background-color: #28a745;
+            border-left: 4px solid #1e7e34;
+        }
+
+        .danbooru-toast-error {
+            background-color: #dc3545;
+            border-left: 4px solid #bd2130;
+        }
+
+        .danbooru-toast-info {
+            background-color: #17a2b8;
+            border-left: 4px solid #117a8b;
+        }
+
+        @keyframes toastSlideIn {
+            from {
+                transform: translateX(100%);
+                opacity: 0;
+            }
+            to {
+                transform: translateX(0);
+                opacity: 1;
+            }
+        }
+
+        .danbooru-toast.fade-out {
+            animation: toastFadeOut 0.3s ease-out forwards;
+        }
+
+        @keyframes toastFadeOut {
+            from {
+                transform: translateX(0);
+                opacity: 1;
+            }
+            to {
+                transform: translateX(100%);
+                opacity: 0;
+            }
+        }
+        `,
+    parent: document.head,
+});
+
+$el("style", {
+    textContent: `
+    /* 编辑面板样式 */
+    .danbooru-edit-panel-content {
+        position: relative;
+    }
+    .danbooru-edit-panel-close-button {
+        background: transparent;
+        border: none;
+        color: var(--comfy-input-text);
+        cursor: pointer;
+        padding: 5px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background-color 0.2s, transform 0.2s;
+    }
+    .danbooru-edit-panel-close-button:hover {
+        background-color: rgba(255, 255, 255, 0.15);
+        transform: rotate(90deg);
+    }
+    /* Styles for the new copy and reset buttons */
+    .danbooru-edit-panel-content button {
+        transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    }
+    .danbooru-edit-panel-content button:hover {
+        background-color: rgba(123, 104, 238, 0.2); /* 统一紫色悬浮效果，增强视觉强度 */
+        border-color: #7B68EE;
+        color: white; /* 悬浮时文字改为白色，提高对比度 */
+        transform: translateY(-2px);
+    }
+    .danbooru-edit-panel-content button:active {
+        background-color: rgba(123, 104, 238, 0.3); /* 点击时进一步加深 */
+        transform: translateY(0);
+    }
+    .danbooru-edit-tags-container {
+        scrollbar-width: thin;
+        scrollbar-color: #555 #333;
+    }
+    .danbooru-edit-tags-container::-webkit-scrollbar {
+        width: 6px;
+    }
+    .danbooru-edit-tags-container::-webkit-scrollbar-track {
+        background: #333;
+        border-radius: 3px;
+    }
+    .danbooru-edit-tags-container::-webkit-scrollbar-thumb {
+        background: #555;
+        border-radius: 3px;
+    }
+    .danbooru-edit-tags-container::-webkit-scrollbar-thumb:hover {
+        background: #777;
+    }
+    .danbooru-view-image-button:hover {
+        background-color: rgba(23, 162, 184, 0.9) !important;
+    }
+    `,
+    parent: document.head
+});
+
+$el("style", {
+    textContent: `
+    .danbooru-tag-context-menu {
+        /* Styles are set in JS, but we can add basics here */
+    }
+    .danbooru-context-menu-item {
+        padding: 8px 12px;
+        cursor: pointer;
+        font-size: 14px;
+        border-radius: 4px;
+        transition: background-color 0.2s;
+    }
+    .danbooru-context-menu-item:hover {
+        background-color: rgba(123, 104, 238, 0.3);
+    }
+    .danbooru-add-tag-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        border: 1px dashed #888;
+        color: #888;
+        background-color: transparent;
+        cursor: pointer;
+        font-size: 16px;
+        margin-left: 5px;
+        transition: all 0.2s;
+    }
+    .danbooru-add-tag-button:hover {
+        background-color: rgba(123, 104, 238, 0.3);
+        color: white;
+        border-style: solid;
+        border-color: #7B68EE;
+    }
+    .danbooru-add-tag-input {
+        background-color: var(--comfy-input-bg);
+        border: 1px solid #7B68EE;
+        color: var(--comfy-input-text);
+        border-radius: 4px;
+        padding: 2px 6px;
+        font-size: 0.8em;
+        margin-left: 5px;
+        outline: none;
+    }
+    .danbooru-reset-tags-button {
+        padding: 8px 15px;
+        border: 1px solid #7B68EE;
+        border-radius: 6px;
+        background-color: transparent;
+        color: #7B68EE;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 500;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+    .danbooru-reset-tags-button:hover {
+        background-color: rgba(123, 104, 238, 0.2);
+        border-color: #7B68EE;
+        color: white;
+        transform: translateY(-2px);
+    }
+    .danbooru-add-tag-container {
+        position: relative;
+        display: inline-block;
+    }
+    .danbooru-add-tag-input {
+        background-color: var(--comfy-input-bg);
+        border: 1px solid #7B68EE;
+        color: var(--comfy-input-text);
+        border-radius: 4px;
+        padding: 2px 6px;
+        font-size: 0.8em;
+        outline: none;
+        width: 120px;
+    }
+    /* These panels are now attached to body, so they need absolute positioning relative to viewport */
+    .danbooru-add-tag-container .danbooru-suggestions-panel,
+    .danbooru-add-tag-container .danbooru-chinese-suggestions-panel,
+    .danbooru-suggestions-panel, /* Add rule for when it's a direct child of body */
+    .danbooru-chinese-suggestions-panel {
+        position: absolute; /* Changed from relative to absolute */
+        z-index: 10003; /* Ensure it's on top of the edit panel */
+        width: auto;
+        min-width: 150px; /* Set a minimum width */
+        max-width: 450px; /* Allow it to be wider */
+        max-height: 300px;
+        overflow-y: auto;
+    }
+    `,
+    parent: document.head
+});
+
+$el("style", {
+    textContent: `
+    .danbooru-settings-section {
+        padding: 16px;
+        border: 1px solid var(--input-border-color);
+        border-radius: 8px;
+        background-color: var(--comfy-input-bg);
+    }
+    .danbooru-settings-dialog input[type="datetime-local"],
+    .danbooru-settings-dialog input[type="number"] {
+        background-color: var(--comfy-menu-bg);
+        color: var(--comfy-input-text);
+        border: 1px solid var(--input-border-color);
+        border-radius: 4px;
+        padding: 8px;
+        user-select: none;
+    }
+    .danbooru-primary-button {
+        padding: 10px 20px;
+        border: 2px solid #7B68EE;
+        border-radius: 6px;
+        background-color: #7B68EE;
+        color: white;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 600;
+        transition: all 0.2s ease;
+    }
+    .danbooru-radio-group {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 20px;
+        margin: 10px 0;
+    }
+    .danbooru-radio-button-wrapper {
+        flex: 0 0 auto;
+        min-width: 140px;
+    }
+    .danbooru-radio-label {
+        padding: 12px 20px;
+        cursor: pointer;
+        transition: all 0.3s ease;
+        background-color: var(--comfy-input-bg);
+        color: var(--comfy-input-text);
+        border: 2px solid var(--input-border-color);
+        border-radius: 8px;
+        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        font-weight: 500;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        transform: translateY(0);
+        position: relative;
+        overflow: hidden;
+    }
+    .danbooru-radio-label:hover {
+        background-color: rgba(123, 104, 238, 0.1);
+        border-color: #7B68EE;
+        color: #7B68EE;
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(123, 104, 238, 0.3);
+    }
+    .danbooru-settings-dialog .danbooru-radio-label.checked {
+        background-color: transparent;
+        color: white;
+        border-color: #7B68EE;
+        box-shadow: 0 4px 12px rgba(123, 104, 238, 0.4);
+        transform: translateY(-1px);
+        font-weight: 600;
+    }
+    .danbooru-settings-dialog .danbooru-radio-label.checked::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: #7B68EE;
+        z-index: 0;
+        transition: transform 0.4s ease;
+        transform: scaleX(1);
+        transform-origin: left;
+    }
+    .danbooru-radio-label::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: #7B68EE;
+        z-index: 0;
+        transition: transform 0.4s ease;
+        transform: scaleX(0);
+        transform-origin: right;
+    }
+    .danbooru-radio-label:hover::before {
+        transform: scaleX(1);
+        transform-origin: left;
+    }
+    .danbooru-settings-dialog .danbooru-radio-label.checked:hover::before {
+        transform: scaleX(1);
+    }
+    .danbooru-settings-dialog .danbooru-radio-label.checked:hover {
+        background-color: transparent;
+        color: white;
+        border-color: #9a8ee8;
+        transform: translateY(-3px);
+        box-shadow: 0 6px 16px rgba(123, 104, 238, 0.5);
+    }
+    .danbooru-settings-dialog .danbooru-radio-label.checked:hover::before {
+        background-color: #9a8ee8;
+    }
+    .danbooru-radio-indicator {
+        display: inline-block;
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        border: 2px solid #888;
+        margin-right: 10px;
+        transition: all 0.2s;
+        flex-shrink: 0;
+        z-index: 1;
+        position: relative;
+    }
+    .danbooru-radio-label:hover .danbooru-radio-indicator {
+        border-color: #7B68EE;
+    }
+    .danbooru-settings-dialog .danbooru-radio-label.checked .danbooru-radio-indicator {
+        background-color: #7B68EE;
+        border-color: #7B68EE;
+        position: relative;
+    }
+    .danbooru-settings-dialog .danbooru-radio-label.checked .danbooru-radio-indicator::before {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 8px;
+        height: 8px;
+        background-color: white;
+        border-radius: 50%;
+        transform: translate(-50%, -50%);
+        z-index: 1;
+    }
+   .danbooru-input-row {
+       display: flex;
+       justify-content: space-between;
+       align-items: center;
+       width: 100%;
+       padding: 8px;
+       border-radius: 6px;
+       transition: background-color 0.2s ease;
+       cursor: pointer;
+       user-select: none;
+   }
+   .danbooru-input-row:hover {
+       background-color: rgba(255, 255, 255, 0.1);
+   }
+   .danbooru-input-row input {
+       cursor: pointer;
+   }
+    .danbooru-dialog-button--secondary {
+       padding: 8px 16px;
+       border: 1px solid var(--input-border-color);
+       border-radius: 6px;
+       background-color: var(--comfy-input-bg);
+       color: var(--comfy-input-text);
+       cursor: pointer;
+       transition: all 0.2s ease;
+   }
+   .danbooru-dialog-button--secondary:hover {
+       background-color: var(--comfy-menu-bg);
+       border-color: #999;
+       transform: translateY(-2px);
+       box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+   }
+
+   .danbooru-dialog-button--primary {
+       padding: 8px 16px;
+       border: 1px solid #7B68EE;
+       border-radius: 6px;
+       background-color: #7B68EE;
+       color: white;
+       cursor: pointer;
+       font-weight: 600;
+       transition: all 0.2s ease;
+   }
+   .danbooru-dialog-button--primary:hover {
+       background-color: #9a8ee8;
+       border-color: #9a8ee8;
+       transform: translateY(-2px);
+       box-shadow: 0 4px 8px rgba(123, 104, 238, 0.3);
+   }
+    `,
+    parent: document.head,
+});
+
+
+$el("style", {
+    textContent: `
+    /* "已编辑" 提示样式 */
+    .danbooru-edited-indicator {
+        position: absolute;
+        top: 5px;
+        left: 5px;
+        background-color: rgba(123, 104, 238, 0.9); /* 紫色背景 */
+        color: white;
+        padding: 3px 8px;
+        font-size: 10px;
+        font-weight: bold;
+        border-radius: 8px;
+        z-index: 15;
+        pointer-events: none;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+        animation: fadeInDown 0.3s ease-out;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    @keyframes fadeInDown {
+        from {
+            opacity: 0;
+            transform: translateY(-10px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+    `,
+    parent: document.head
+});
+
 

--- a/js/global/logger_client.js
+++ b/js/global/logger_client.js
@@ -293,6 +293,12 @@ class LoggerClient {
      */
     setConsoleOutput(enabled) {
         this.consoleOutputEnabled = enabled;
+        // 当全局日志开启时，级别过滤器降到 DEBUG，确保所有日志都能被控制台输出
+        if (enabled) {
+            this.currentLevel = LOG_LEVELS.DEBUG;
+        } else {
+            this.currentLevel = LOG_LEVELS.INFO;
+        }
         this._saveConfig();
     }
 }

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -273,7 +273,9 @@ def load_ui_settings():
         "selected_categories": settings.get("selected_categories", ["copyright", "character", "general"]),
         "multi_select_enabled": settings.get("multi_select_enabled", False),
         "source_site": settings.get("source_site", "danbooru"),
-        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False)
+        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False),
+        "preload_count": settings.get("preload_count", 40),
+        "gelbooru_dedup_mode": settings.get("gelbooru_dedup_mode", "off")
     }
 
 def save_ui_settings(ui_settings):
@@ -286,6 +288,8 @@ def save_ui_settings(ui_settings):
     settings["multi_select_enabled"] = ui_settings.get("multi_select_enabled", False)
     settings["source_site"] = ui_settings.get("source_site", "danbooru")
     settings["gelbooru_display_all_site_content"] = ui_settings.get("gelbooru_display_all_site_content", False)
+    settings["preload_count"] = ui_settings.get("preload_count", 40)
+    settings["gelbooru_dedup_mode"] = ui_settings.get("gelbooru_dedup_mode", "off")
     return save_settings(settings)
 
 # ================================
@@ -1509,7 +1513,9 @@ async def save_ui_settings_route(request):
             "selected_categories": data.get("selected_categories", ["copyright", "character", "general"]),
             "multi_select_enabled": data.get("multi_select_enabled", False),
             "source_site": data.get("source_site", "danbooru"),
-            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False)
+            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False),
+            "preload_count": data.get("preload_count", 40),
+            "gelbooru_dedup_mode": data.get("gelbooru_dedup_mode", "off")
         }
         success = save_ui_settings(ui_settings)
         return web.json_response({"success": success})
@@ -1800,9 +1806,20 @@ class DanbooruGalleryNode:
         if gelbooru_display_all_site_content is None:
             gelbooru_display_all_site_content = settings.get("gelbooru_display_all_site_content", False)
 
-        # 归一化 before_id（游标分页：只取数字，防止注入）
+        # 游标分页（page=b<id>）归一化：只接受纯数字，防注入
         before_id = str(before_id).strip() if before_id else ""
         if before_id and not before_id.isdigit():
+            before_id = ""
+        # order/ordfav/sort 改变 id 降序前提，任何站点都禁用游标（防乱序漏图）
+        gelbooru_dedup_mode = settings.get("gelbooru_dedup_mode", "off")
+        has_sort = bool(re.search(r'(?:^|\s)(?:order|ordfav|sort):', tags or ''))
+        if before_id and has_sort:
+            before_id = ""
+        # D 站默认排序始终用游标；G 站仅当 gelbooru_dedup_mode 开启时用；其余禁用
+        if before_id and not (
+            adapter.key == "danbooru"
+            or (adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"))
+        ):
             before_id = ""
 
         # 创建缓存键（rating 归一化排序，避免 "e,q" 与 "q,e" 命中两条缓存）
@@ -1810,6 +1827,8 @@ class DanbooruGalleryNode:
         site_options_key = ""
         if adapter.key == "gelbooru":
             site_options_key = "display_all" if gelbooru_display_all_site_content else "default"
+            # dedup 档位影响 tag 截断数量，纳入缓存键避免不同档位（尤其首页 before_id 同为空时）互相污染
+            site_options_key = f"{site_options_key}:dedup_{gelbooru_dedup_mode}"
         # before_id 纳入缓存键，避免不同游标页命中同一条缓存
         cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}:{before_id}"
 
@@ -1832,9 +1851,16 @@ class DanbooruGalleryNode:
             elif tag.strip():
                 other_tags.append(tag.strip())
 
-        # 限制其他标签的数量
-        if len(other_tags) > 2:
-            other_tags = other_tags[:2]
+        # 限制其他标签的数量。默认 2；G 站开启游标时按档位调整名额
+        max_tags = 2
+        if adapter.key == "gelbooru" and before_id:  # before_id 非空 = 已确认走 G 站游标
+            creds = get_site_credentials(adapter)
+            if gelbooru_dedup_mode == "on_auth" and has_required_site_credentials(adapter, creds):
+                max_tags = 10   # 已配密钥，解除限制（较大上限）
+            else:
+                max_tags = 1    # 未配密钥，留一个名额给游标 id:<X
+        if len(other_tags) > max_tags:
+            other_tags = other_tags[:max_tags]
         
         # 重新组合标签
         final_tags = ' '.join(other_tags)
@@ -1855,9 +1881,9 @@ class DanbooruGalleryNode:
         
         tags = final_tags
 
-        # 游标分页防重复：Gelbooru 无 page 游标，但支持 meta-tag id:<X（默认按 id 降序，等效"取这张之前的"）。
-        # Danbooru 走 page=b<id>（见下方 build 后覆盖），这里不动它的 tags。
-        if before_id and adapter.key != "danbooru":
+        # G 站游标：注入 id:<X 作为搜索 metatag（配合默认 id 降序 = 取该 id 之前的图）。
+        # 三条 G 站路径（force_public_detail / 无凭据公开抓取 / DAPI）都会带上。
+        if before_id and adapter.key == "gelbooru":
             tags = f"{tags} id:<{before_id}".strip()
 
         username, api_key = load_user_auth()
@@ -1882,7 +1908,8 @@ class DanbooruGalleryNode:
             return ("[]",)
             
         params = adapter.build_posts_params(tags, limit, page, rating_query)
-        # Danbooru 游标分页：page=b<id> 表示"id 小于该值的结果"，避免有新图上传时翻页重复。
+        # Danbooru 游标分页：page=b<id> 表示"id 小于该值的结果"，消除偏移翻页重复。
+        # 显式限定 danbooru，避免与 G 站 before_id（走 id:<X 注入）串台。
         if before_id and adapter.key == "danbooru":
             params["page"] = f"b{before_id}"
         params = adapter.apply_auth_params(params, credentials)

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -21,8 +21,14 @@ from pathlib import Path
 import sys
 from ..utils.logger import get_logger
 from .site_adapters import get_site_adapter
+from collections import deque
 
 logger = get_logger(__name__)
+
+# FIFO 选择队列：每次 Queue 时前端快照一个选中条目入队，
+# 节点执行时从队首 pop 出一个，彻底解耦缓存碰撞
+_selection_queue = deque()
+_selection_queue_lock = threading.Lock()
 
 # 导入数据库管理器
 try:
@@ -38,10 +44,6 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Danbooru API的基础URL
 BASE_URL = "https://danbooru.donmai.us"
-
-# Gelbooru 公开列表页（未登录 HTML 抓取）每页固定显示的图片数，用于 pid 偏移翻页。
-# 实测约 42；pid 必须按此对齐，否则 limit≠42 时翻页会跳过/重复。
-GELBOORU_PUBLIC_PAGE_SIZE = 42
 
 # 需要一个非 python-requests 的描述性 UA 才能过 Cloudflare（从 2026-04-23 起开启拦截）。
 # 实测 CF 对 UA 黑名单里包含 "ComfyUI" —— 推测 Danbooru 为抵制训练数据爬取主动加的规则。
@@ -68,9 +70,12 @@ class _RateLimiter:
             self._last_ts = time.monotonic()
 
 _donmai_throttle = _RateLimiter(min_interval_sec=0.2)
-# Gelbooru 公开网页抓取限流：公开页对频繁请求敏感，缓冲补货会连发多次请求。
-# 取 2.5s 间隔：凑 200 张约需 5 次请求 ≈ 12.5s（落在期望的 10-20s 加载耗时区间），且避开 429。
-_gelbooru_public_throttle = _RateLimiter(min_interval_sec=2.5)
+
+# Gelbooru 公开 HTML 页列表固定每页 42 张，pid 为该页首张图片的偏移量
+GELBOORU_PUBLIC_PAGE_SIZE = 42
+
+# Gelbooru 公开页抓取限流器（0.75s = ~1.33 req/s，避开 429）
+_gelbooru_public_throttle = _RateLimiter(min_interval_sec=0.75)
 
 def _danbooru_request(method, url, **kwargs):
     """统一的 donmai.us 请求入口：限流 + 默认 UA + 429/503 带 Retry-After 退避重试一次。"""
@@ -280,9 +285,7 @@ def load_ui_settings():
         "selected_categories": settings.get("selected_categories", ["copyright", "character", "general"]),
         "multi_select_enabled": settings.get("multi_select_enabled", False),
         "source_site": settings.get("source_site", "danbooru"),
-        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False),
-        "preload_count": settings.get("preload_count", 40),
-        "gelbooru_dedup_mode": settings.get("gelbooru_dedup_mode", "off")
+        "gelbooru_display_all_site_content": settings.get("gelbooru_display_all_site_content", False)
     }
 
 def save_ui_settings(ui_settings):
@@ -295,8 +298,6 @@ def save_ui_settings(ui_settings):
     settings["multi_select_enabled"] = ui_settings.get("multi_select_enabled", False)
     settings["source_site"] = ui_settings.get("source_site", "danbooru")
     settings["gelbooru_display_all_site_content"] = ui_settings.get("gelbooru_display_all_site_content", False)
-    settings["preload_count"] = ui_settings.get("preload_count", 40)
-    settings["gelbooru_dedup_mode"] = ui_settings.get("gelbooru_dedup_mode", "off")
     return save_settings(settings)
 
 # ================================
@@ -1215,52 +1216,73 @@ def _fetch_supported_media(url):
 def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, display_all_site_content=False):
     """Fetch Gelbooru posts from public HTML pages when DAPI credentials are unavailable.
 
-    单页抓取：每次只请求 Gelbooru 公开列表页的一页（约 42 张，由网站固定）。
-    pid 偏移基于固定页大小（GELBOORU_PUBLIC_PAGE_SIZE），与 limit 解耦——
-    否则 limit≠42 时 page 翻页会错位跳过/重复。凑够 preload_count 由前端连续翻页完成。
+    Uses fixed page size GELBOORU_PUBLIC_PAGE_SIZE (42) so pid is decoupled from
+    the frontend's requested limit; the frontend chains multiple page fetches via
+    maybeLoadMore to reach the user's preload_count.
+
+    On transient failure (429/503) it retries once with Retry-After back-off.
+    If retry also fails or the response is non-recoverable, returns an error
+    placeholder object so the frontend can display a per-cell error rather than
+    crashing the whole gallery.
     """
     id_match = re.search(r"(?:^|\s)id:(\d+)(?:\s|$)", tags or "")
     if id_match:
         refs = [{"id": id_match.group(1)}]
     else:
-        session = _get_gelbooru_session(display_all_site_content)
-        # 公开列表页 pid 是图片偏移量；每页固定约 42 张，按固定页大小推进，避免与 limit 错位
+        # 固定页大小，pid 与 frontend 的 limit 解耦
         pid_value = max(page - 1, 0) * GELBOORU_PUBLIC_PAGE_SIZE
         params = adapter.build_public_posts_params(tags, limit, page, rating_query)
+        # override pid with fixed page size
         params["pid"] = pid_value
 
+        session = _get_gelbooru_session(display_all_site_content)
+
         def _get_list_page(sess):
-            """限流 + 429/503 退避重试一次。返回 response 或 None（失败时不抛异常）。"""
+            """Inner closure: fetch list page with rate limiting + retry."""
             for attempt in range(2):
                 _gelbooru_public_throttle.wait()
-                resp = sess.get(adapter.posts_url, params=params, timeout=(8, 15))
+                try:
+                    resp = sess.get(adapter.posts_url, params=params, timeout=(8, 15))
+                except requests.exceptions.RequestException as e:
+                    if attempt == 0:
+                        _log_gelbooru_retry_warning(f"网络异常: {e}", pid_value=pid_value)
+                        time.sleep(3)
+                    continue
+
                 if resp.status_code not in (429, 503):
-                    resp.raise_for_status()
-                    return resp
+                    return resp  # 正常（含 200/500/403），交调用方判断
+
+                # 429/503 限流: 读 Retry-After 退避一次
+                retry_after = resp.headers.get("Retry-After")
+                delay = 2.0
+                try:
+                    if retry_after is not None:
+                        delay = min(max(float(retry_after), 0.5), 10.0)
+                except ValueError:
+                    pass
                 if attempt == 0:
-                    retry_after = resp.headers.get("Retry-After")
-                    delay = 3.0
-                    try:
-                        if retry_after is not None:
-                            delay = min(max(float(retry_after), 1.0), 10.0)
-                    except ValueError:
-                        pass
-                    logger.warning(f"[GelbooruPublic] {resp.status_code} 限流，{delay:.1f}s 后重试 pid={pid_value}")
+                    _log_gelbooru_retry_warning(f"HTTP {resp.status_code} 限流，{delay:.1f}s 后重试", pid_value=pid_value)
                     time.sleep(delay)
                 else:
-                    logger.warning(f"[GelbooruPublic] 重试后仍 {resp.status_code}，本页放弃 pid={pid_value}")
-                    return None
+                    _log_gelbooru_retry_warning(f"重试仍限流({resp.status_code})，跳过本页", pid_value=pid_value)
+                    return None  # 重试仍限流 → 跳过本页
+
             return None
 
         list_response = _get_list_page(session)
         if list_response is None:
-            return []  # 被限流且重试失败 → 返回空，让前端按"暂无更多"处理，不崩溃
+            # 返回 error 占位格（不含 list_response.text 细节）
+            driver_pid = params.get("pid", pid_value)
+            return [{"error": "Gelbooru 服务暂不可用", "pid": driver_pid, "page": page}]
+
         if display_all_site_content and _gelbooru_public_page_requires_options(list_response.text):
             logger.warning("[GelbooruPublic] Result page still requested Display all site content; rebuilding session and retrying")
             session = _get_gelbooru_session(display_all_site_content, force_refresh=True)
             list_response = _get_list_page(session)
             if list_response is None:
-                return []
+                driver_pid = params.get("pid", pid_value)
+                return [{"error": "Gelbooru 服务暂不可用", "pid": driver_pid, "page": page}]
+
         refs = adapter.extract_public_post_refs(list_response.text, limit)
         logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} refs={len(refs)}")
 
@@ -1273,20 +1295,35 @@ def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, displ
         if not post_id:
             continue
 
-        try:
-            post_response = _get_gelbooru_session(display_all_site_content).get(
-                adapter.posts_url,
-                params=adapter.build_public_post_params(post_id),
-                timeout=(8, 15),
-            )
-            post_response.raise_for_status()
-            post = adapter.normalize_public_post_page(post_id, post_response.text, ref)
-            if post.get("preview_file_url") or post.get("file_url"):
-                posts.append(post)
-        except requests.exceptions.RequestException as e:
-            logger.warning(f"[GelbooruPublic] 帖子页面解析失败 id={post_id}: {e}")
+        # 0 引用重试：HTML 结构有可能解析失败
+        for attempt in range(2):
+            try:
+                post_response = _get_gelbooru_session(display_all_site_content).get(
+                    adapter.posts_url,
+                    params=adapter.build_public_post_params(post_id),
+                    timeout=(8, 15),
+                )
+                post_response.raise_for_status()
+                post = adapter.normalize_public_post_page(post_id, post_response.text, ref)
+                if post.get("preview_file_url") or post.get("file_url"):
+                    posts.append(post)
+                    break
+            except requests.exceptions.RequestException as e:
+                if attempt == 0:
+                    logger.warning(f"[GelbooruPublic] 帖子页面解析失败/id={post_id} 尝试重试: {e}")
+                    time.sleep(1)
+                else:
+                    logger.warning(f"[GelbooruPublic] 帖子页面解析失败/id={post_id} 放弃: {e}")
 
     return posts
+
+
+def _log_gelbooru_retry_warning(message, pid_value=None):
+    """Short helper for logging gelbooru public fetch retry messages."""
+    if pid_value is not None:
+        logger.warning(f"[GelbooruPublic] {message} (pid={pid_value})")
+    else:
+        logger.warning(f"[GelbooruPublic] {message}")
 
 @PromptServer.instance.routes.get("/danbooru_gallery/image_proxy")
 async def image_proxy(request):
@@ -1359,9 +1396,12 @@ async def get_posts_for_front(request):
     limit = query.get("limit", "100")
     rating = query.get("search[rating]", "")
     source = query.get("source", "danbooru")
-    before_id = query.get("before_id", "")
     gelbooru_display_all_site_content = query.get("gelbooru_display_all_site_content", "").lower() in ("1", "true", "yes", "on")
     force_public_detail = query.get("force_public_detail", "").lower() in ("1", "true", "yes", "on")
+    before_id_raw = query.get("before_id", "")
+    gelbooru_dedup_mode = query.get("gelbooru_dedup_mode", "off").strip().lower()
+    if gelbooru_dedup_mode not in ("off", "on", "on_auth"):
+        gelbooru_dedup_mode = "off"
 
     posts_json_str, = DanbooruGalleryNode.get_posts_internal(
         tags=tags,
@@ -1369,9 +1409,10 @@ async def get_posts_for_front(request):
         page=int(page),
         rating=rating,
         source=source,
-        before_id=before_id,
         gelbooru_display_all_site_content=gelbooru_display_all_site_content,
         force_public_detail=force_public_detail,
+        before_id=before_id_raw,
+        gelbooru_dedup_mode=gelbooru_dedup_mode,
     )
     
     try:
@@ -1547,14 +1588,43 @@ async def save_ui_settings_route(request):
             "selected_categories": data.get("selected_categories", ["copyright", "character", "general"]),
             "multi_select_enabled": data.get("multi_select_enabled", False),
             "source_site": data.get("source_site", "danbooru"),
-            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False),
-            "preload_count": data.get("preload_count", 40),
-            "gelbooru_dedup_mode": data.get("gelbooru_dedup_mode", "off")
+            "gelbooru_display_all_site_content": data.get("gelbooru_display_all_site_content", False)
         }
         success = save_ui_settings(ui_settings)
         return web.json_response({"success": success})
     except Exception as e:
         logger.error(f"保存UI设置接口错误: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/selection_queue_push")
+async def selection_queue_push(request):
+    """前端在每次 Queue 前把当前选中的条目推入 FIFO 队列"""
+    try:
+        data = await request.json()
+        item = data.get("item")
+        if item:
+            with _selection_queue_lock:
+                _selection_queue.append(item)
+            logger.debug(f"[SelectionQueue] push → 队列长度 {len(_selection_queue)}")
+        return web.json_response({"success": True})
+    except Exception as e:
+        logger.error(f"[SelectionQueue] push error: {e}")
+        return web.json_response({"success": False, "error": str(e)})
+
+@PromptServer.instance.routes.post("/danbooru_gallery/selection_queue_pop")
+async def selection_queue_pop(request):
+    """节点执行时从队列头部 pop 一个条目（不移除则 peek）"""
+    try:
+        data = await request.json() if request.can_read_body else {}
+        remove = data.get("remove", True)
+        with _selection_queue_lock:
+            if _selection_queue:
+                item = _selection_queue.popleft() if remove else _selection_queue[0]
+                logger.debug(f"[SelectionQueue] pop → 剩余 {len(_selection_queue)}")
+                return web.json_response({"success": True, "item": item})
+        return web.json_response({"success": True, "item": None})
+    except Exception as e:
+        logger.error(f"[SelectionQueue] pop error: {e}")
         return web.json_response({"success": False, "error": str(e)})
 
 # ================================
@@ -1787,19 +1857,37 @@ class DanbooruGalleryNode:
 
     @classmethod
     def IS_CHANGED(cls, selection_data="{}", **kwargs):
-        return selection_data
+        """返回队首条目的 _queue_id（唯一），队列空时返回 ""（缓存命中不再重复执行）。
+        彻底解决快速选图 1→Queue→2→Queue→... 导致的提示词覆盖竞态。"""
+        with _selection_queue_lock:
+            if _selection_queue:
+                return _selection_queue[0].get("_queue_id", time.time())
+        return ""
 
     def get_selected_data(self, selection_data="{}", **kwargs):
-        """处理选中的图片数据，支持单选和多选模式"""
-        if not selection_data or selection_data == "{}":
-            return ([torch.zeros(1, 1, 1, 3)], [""])
-
+        """处理选中的图片数据，从 FIFO 队列中 pop（优先），否则回退到 selection_data widget。
+        队列模式确保 1→Queue→2→Queue→3→Queue→4→Queue 依次正确输出，互不覆盖。"""
         images = []
         prompts = []
 
         try:
-            data = json.loads(selection_data)
-            selections = data.get("selections", [])
+            # 先从 FIFO 队列 pop（每次 Queue 时前端推入的 snapshot）
+            with _selection_queue_lock:
+                if _selection_queue:
+                    item = _selection_queue.popleft()
+                    logger.debug(f"[SelectionQueue] get_selected_data pop → 剩余 {len(_selection_queue)}")
+                else:
+                    item = None
+
+            if item:
+                # 队列模式：单个条目
+                selections = item.get("selections", [])
+            else:
+                # 回退：widget 值（无 Queue 点击，手动拖线等场景）
+                if not selection_data or selection_data == "{}":
+                    return ([torch.zeros(1, 1, 1, 3)], [""])
+                data = json.loads(selection_data)
+                selections = data.get("selections", [])
 
             if not selections:
                 return ([torch.zeros(1, 1, 1, 3)], [""])
@@ -1832,7 +1920,7 @@ class DanbooruGalleryNode:
         return (images, prompts)
     
     @staticmethod
-    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", before_id: str = None, gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False):
+    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False, before_id=None, gelbooru_dedup_mode: str = "off"):
         settings = load_settings()
         cache_enabled = settings.get("cache_enabled", True)
         max_cache_age = settings.get("max_cache_age", 3600)
@@ -1840,30 +1928,34 @@ class DanbooruGalleryNode:
         if gelbooru_display_all_site_content is None:
             gelbooru_display_all_site_content = settings.get("gelbooru_display_all_site_content", False)
 
-        # 游标分页（page=b<id>）归一化：只接受纯数字，防注入
+        if gelbooru_dedup_mode not in ("off", "on", "on_auth"):
+            gelbooru_dedup_mode = "off"
+
+        # before_id分页：化 + 数字校验，防止 page=b; DROP TABLE 类拼接注入
         before_id = str(before_id).strip() if before_id else ""
         if before_id and not before_id.isdigit():
             before_id = ""
-        # order/ordfav/sort 改变 id 降序前提，任何站点都禁用游标（防乱序漏图）
-        gelbooru_dedup_mode = settings.get("gelbooru_dedup_mode", "off")
-        has_sort = bool(re.search(r'(?:^|\s)(?:order|ordfav|sort):', tags or ''))
-        if before_id and has_sort:
+        # order/ordfav/sort变结果顺序，游标会漏图，禁用
+        if before_id and re.search(r'(?:^|\s)(?:order|ordfav|sort):', tags or ''):
             before_id = ""
-        # D 站默认排序始终用游标；G 站仅当 gelbooru_dedup_mode 开启时用；其余禁用
+        #仅在 Danbooru（官方 page=b<id>）或 Gelbooru + dedup 开启时生效
         if before_id and not (
             adapter.key == "danbooru"
             or (adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"))
         ):
             before_id = ""
 
+        credentials = get_site_credentials(adapter)
+        has_gelbooru_creds = has_required_site_credentials(adapter, credentials)
+
         # 创建缓存键（rating 归一化排序，避免 "e,q" 与 "q,e" 命中两条缓存）
         rating_key = ','.join(sorted(r.strip().lower() for r in (rating or '').split(',') if r.strip()))
         site_options_key = ""
         if adapter.key == "gelbooru":
             site_options_key = "display_all" if gelbooru_display_all_site_content else "default"
-            # dedup 档位影响 tag 截断数量，纳入缓存键避免不同档位（尤其首页 before_id 同为空时）互相污染
-            site_options_key = f"{site_options_key}:dedup_{gelbooru_dedup_mode}"
-        # before_id 纳入缓存键，避免不同游标页命中同一条缓存
+            # dedup位影响 tag断数量，须区分，否则 on/off/on_auth 在 before_id 同为空时互相污染
+            site_options_key += f"_dedup_{gelbooru_dedup_mode}"
+        # before_id 入键避免不同游标页相互污染
         cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}:{before_id}"
 
         # 判断是否获取收藏列表，如果是清除缓存以避免相同的请求前端列表不更新
@@ -1885,14 +1977,15 @@ class DanbooruGalleryNode:
             elif tag.strip():
                 other_tags.append(tag.strip())
 
-        # 限制其他标签的数量。默认 2；G 站开启游标时按档位调整名额
-        max_tags = 2
-        if adapter.key == "gelbooru" and before_id:  # before_id 非空 = 已确认走 G 站游标
-            creds = get_site_credentials(adapter)
-            if gelbooru_dedup_mode == "on_auth" and has_required_site_credentials(adapter, creds):
-                max_tags = 10   # 已配密钥，解除限制（较大上限）
+        # 限制其他标签的数量。Gelbooru标模式下 id:<X 占用一个 tag 名额（公开页/2-tag 限制），
+        # on_auth + 已配密钥走 DAPI 时可放宽到更多 tag。
+        if adapter.key == "gelbooru" and gelbooru_dedup_mode in ("on", "on_auth"):
+            if gelbooru_dedup_mode == "on_auth" and has_gelbooru_creds:
+                max_tags = 10
             else:
-                max_tags = 1    # 未配密钥，留一个名额给游标 id:<X
+                max_tags = 1
+        else:
+            max_tags = 2
         if len(other_tags) > max_tags:
             other_tags = other_tags[:max_tags]
         
@@ -1914,9 +2007,7 @@ class DanbooruGalleryNode:
             rating_query = rating
         
         tags = final_tags
-
-        # G 站游标：注入 id:<X 作为搜索 metatag（配合默认 id 降序 = 取该 id 之前的图）。
-        # 三条 G 站路径（force_public_detail / 无凭据公开抓取 / DAPI）都会带上。
+        # Gelbooru：拼进 tags（公开页 / DAPI用 tags 参数，见 build_public_posts_params / build_posts_params）
         if before_id and adapter.key == "gelbooru":
             tags = f"{tags} id:<{before_id}".strip()
 
@@ -1935,18 +2026,20 @@ class DanbooruGalleryNode:
                 result_text = json.dumps(posts, ensure_ascii=False)
 
                 if cache_enabled and not (adapter.key == "gelbooru" and gelbooru_display_all_site_content and not posts):
-                    DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
+                    # 跳过 error 占位格缓存（否则一次限流会让接下来 TTL 内都看不到新图）
+                    has_error_placeholder = posts and any(isinstance(p, dict) and p.get("error") for p in posts)
+                    if not has_error_placeholder:
+                        DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
 
                 return (result_text,)
             logger.warning(f"[{adapter.key}] 缺少必要认证信息，已跳过帖子请求")
             return ("[]",)
             
         params = adapter.build_posts_params(tags, limit, page, rating_query)
-        # Danbooru 游标分页：page=b<id> 表示"id 小于该值的结果"，消除偏移翻页重复。
-        # 显式限定 danbooru，避免与 G 站 before_id（走 id:<X 注入）串台。
+        params = adapter.apply_auth_params(params, credentials)
+        # Danbooru：走官方 page=b<id>
         if before_id and adapter.key == "danbooru":
             params["page"] = f"b{before_id}"
-        params = adapter.apply_auth_params(params, credentials)
 
         try:
             response = _danbooru_request("GET", adapter.posts_url, params=params, auth=auth, timeout=15)
@@ -1959,9 +2052,11 @@ class DanbooruGalleryNode:
 
             result_text = json.dumps(posts, ensure_ascii=False)
             
-            # 如果启用了缓存，则存储结果
+            # 如果启用了缓存，则存储结果（跳过 error 占位格）
             if cache_enabled and not (adapter.key == "gelbooru" and gelbooru_display_all_site_content and not posts):
-                DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
+                has_error_placeholder = posts and any(isinstance(p, dict) and p.get("error") for p in posts)
+                if not has_error_placeholder:
+                    DanbooruGalleryNode._post_cache[cache_key] = (result_text, time.time())
                 # 清理旧缓存（可选，防止内存无限增长）
                 if len(DanbooruGalleryNode._post_cache) > 200: # 假设最多缓存200个请求
                     oldest_key = min(DanbooruGalleryNode._post_cache.keys(), key=lambda k: DanbooruGalleryNode._post_cache[k][1])

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -1321,6 +1321,7 @@ async def get_posts_for_front(request):
     limit = query.get("limit", "100")
     rating = query.get("search[rating]", "")
     source = query.get("source", "danbooru")
+    before_id = query.get("before_id", "")
     gelbooru_display_all_site_content = query.get("gelbooru_display_all_site_content", "").lower() in ("1", "true", "yes", "on")
     force_public_detail = query.get("force_public_detail", "").lower() in ("1", "true", "yes", "on")
 
@@ -1330,6 +1331,7 @@ async def get_posts_for_front(request):
         page=int(page),
         rating=rating,
         source=source,
+        before_id=before_id,
         gelbooru_display_all_site_content=gelbooru_display_all_site_content,
         force_public_detail=force_public_detail,
     )
@@ -1790,7 +1792,7 @@ class DanbooruGalleryNode:
         return (images, prompts)
     
     @staticmethod
-    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False):
+    def get_posts_internal(tags: str, limit: int = 100, page: int = 1, rating: str = None, source: str = "danbooru", before_id: str = None, gelbooru_display_all_site_content: bool = None, force_public_detail: bool = False):
         settings = load_settings()
         cache_enabled = settings.get("cache_enabled", True)
         max_cache_age = settings.get("max_cache_age", 3600)
@@ -1798,12 +1800,18 @@ class DanbooruGalleryNode:
         if gelbooru_display_all_site_content is None:
             gelbooru_display_all_site_content = settings.get("gelbooru_display_all_site_content", False)
 
+        # 归一化 before_id（游标分页：只取数字，防止注入）
+        before_id = str(before_id).strip() if before_id else ""
+        if before_id and not before_id.isdigit():
+            before_id = ""
+
         # 创建缓存键（rating 归一化排序，避免 "e,q" 与 "q,e" 命中两条缓存）
         rating_key = ','.join(sorted(r.strip().lower() for r in (rating or '').split(',') if r.strip()))
         site_options_key = ""
         if adapter.key == "gelbooru":
             site_options_key = "display_all" if gelbooru_display_all_site_content else "default"
-        cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}"
+        # before_id 纳入缓存键，避免不同游标页命中同一条缓存
+        cache_key = f"{adapter.key}:{site_options_key}:{tags}:{limit}:{page}:{rating_key}:{before_id}"
 
         # 判断是否获取收藏列表，如果是清除缓存以避免相同的请求前端列表不更新
         match = re.search(r'\bordfav:([^\s]+)', tags)
@@ -1847,6 +1855,11 @@ class DanbooruGalleryNode:
         
         tags = final_tags
 
+        # 游标分页防重复：Gelbooru 无 page 游标，但支持 meta-tag id:<X（默认按 id 降序，等效"取这张之前的"）。
+        # Danbooru 走 page=b<id>（见下方 build 后覆盖），这里不动它的 tags。
+        if before_id and adapter.key != "danbooru":
+            tags = f"{tags} id:<{before_id}".strip()
+
         username, api_key = load_user_auth()
         auth = HTTPBasicAuth(username, api_key) if adapter.requires_auth and username and api_key else None
         credentials = get_site_credentials(adapter)
@@ -1869,6 +1882,9 @@ class DanbooruGalleryNode:
             return ("[]",)
             
         params = adapter.build_posts_params(tags, limit, page, rating_query)
+        # Danbooru 游标分页：page=b<id> 表示"id 小于该值的结果"，避免有新图上传时翻页重复。
+        if before_id and adapter.key == "danbooru":
+            params["page"] = f"b{before_id}"
         params = adapter.apply_auth_params(params, credentials)
 
         try:

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -1046,7 +1046,7 @@ _gelbooru_session_lock = threading.Lock()
 def _get_image_proxy_semaphore():
     global _image_proxy_semaphore
     if _image_proxy_semaphore is None:
-        _image_proxy_semaphore = asyncio.Semaphore(6)
+        _image_proxy_semaphore = asyncio.Semaphore(1)
     return _image_proxy_semaphore
 
 def _gelbooru_browser_headers(accept="text/html,*/*"):

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -68,6 +68,9 @@ class _RateLimiter:
             self._last_ts = time.monotonic()
 
 _donmai_throttle = _RateLimiter(min_interval_sec=0.2)
+# Gelbooru 公开网页抓取限流：公开页对频繁请求敏感，缓冲补货会连发多次请求。
+# 取 2.5s 间隔：凑 200 张约需 5 次请求 ≈ 12.5s（落在期望的 10-20s 加载耗时区间），且避开 429。
+_gelbooru_public_throttle = _RateLimiter(min_interval_sec=2.5)
 
 def _danbooru_request(method, url, **kwargs):
     """统一的 donmai.us 请求入口：限流 + 默认 UA + 429/503 带 Retry-After 退避重试一次。"""
@@ -1225,15 +1228,41 @@ def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, displ
         pid_value = max(page - 1, 0) * GELBOORU_PUBLIC_PAGE_SIZE
         params = adapter.build_public_posts_params(tags, limit, page, rating_query)
         params["pid"] = pid_value
-        list_response = session.get(adapter.posts_url, params=params, timeout=(8, 15))
-        list_response.raise_for_status()
+
+        def _get_list_page(sess):
+            """限流 + 429/503 退避重试一次。返回 response 或 None（失败时不抛异常）。"""
+            for attempt in range(2):
+                _gelbooru_public_throttle.wait()
+                resp = sess.get(adapter.posts_url, params=params, timeout=(8, 15))
+                if resp.status_code not in (429, 503):
+                    resp.raise_for_status()
+                    return resp
+                if attempt == 0:
+                    retry_after = resp.headers.get("Retry-After")
+                    delay = 3.0
+                    try:
+                        if retry_after is not None:
+                            delay = min(max(float(retry_after), 1.0), 10.0)
+                    except ValueError:
+                        pass
+                    logger.warning(f"[GelbooruPublic] {resp.status_code} 限流，{delay:.1f}s 后重试 pid={pid_value}")
+                    time.sleep(delay)
+                else:
+                    logger.warning(f"[GelbooruPublic] 重试后仍 {resp.status_code}，本页放弃 pid={pid_value}")
+                    return None
+            return None
+
+        list_response = _get_list_page(session)
+        if list_response is None:
+            return []  # 被限流且重试失败 → 返回空，让前端按"暂无更多"处理，不崩溃
         if display_all_site_content and _gelbooru_public_page_requires_options(list_response.text):
             logger.warning("[GelbooruPublic] Result page still requested Display all site content; rebuilding session and retrying")
             session = _get_gelbooru_session(display_all_site_content, force_refresh=True)
-            list_response = session.get(adapter.posts_url, params=params, timeout=(8, 15))
-            list_response.raise_for_status()
+            list_response = _get_list_page(session)
+            if list_response is None:
+                return []
         refs = adapter.extract_public_post_refs(list_response.text, limit)
-        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} page={page} pid={pid_value} refs={len(refs)}")
+        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} refs={len(refs)}")
 
     if not id_match:
         return refs

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -1046,7 +1046,7 @@ _gelbooru_session_lock = threading.Lock()
 def _get_image_proxy_semaphore():
     global _image_proxy_semaphore
     if _image_proxy_semaphore is None:
-        _image_proxy_semaphore = asyncio.Semaphore(1)
+        _image_proxy_semaphore = asyncio.Semaphore(6)
     return _image_proxy_semaphore
 
 def _gelbooru_browser_headers(accept="text/html,*/*"):

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -39,6 +39,10 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # Danbooru API的基础URL
 BASE_URL = "https://danbooru.donmai.us"
 
+# Gelbooru 公开列表页（未登录 HTML 抓取）每页固定显示的图片数，用于 pid 偏移翻页。
+# 实测约 42；pid 必须按此对齐，否则 limit≠42 时翻页会跳过/重复。
+GELBOORU_PUBLIC_PAGE_SIZE = 42
+
 # 需要一个非 python-requests 的描述性 UA 才能过 Cloudflare（从 2026-04-23 起开启拦截）。
 # 实测 CF 对 UA 黑名单里包含 "ComfyUI" —— 推测 Danbooru 为抵制训练数据爬取主动加的规则。
 # 本节点只是图片浏览器（单图挑选，无批量导出），不参与训练数据收集，按 e621 式约定
@@ -1206,29 +1210,30 @@ def _fetch_supported_media(url):
     return response.content
 
 def _fetch_gelbooru_public_posts(adapter, tags, limit, page, rating_query, display_all_site_content=False):
-    """Fetch Gelbooru posts from public HTML pages when DAPI credentials are unavailable."""
+    """Fetch Gelbooru posts from public HTML pages when DAPI credentials are unavailable.
+
+    单页抓取：每次只请求 Gelbooru 公开列表页的一页（约 42 张，由网站固定）。
+    pid 偏移基于固定页大小（GELBOORU_PUBLIC_PAGE_SIZE），与 limit 解耦——
+    否则 limit≠42 时 page 翻页会错位跳过/重复。凑够 preload_count 由前端连续翻页完成。
+    """
     id_match = re.search(r"(?:^|\s)id:(\d+)(?:\s|$)", tags or "")
     if id_match:
         refs = [{"id": id_match.group(1)}]
     else:
         session = _get_gelbooru_session(display_all_site_content)
-        list_response = session.get(
-            adapter.posts_url,
-            params=adapter.build_public_posts_params(tags, limit, page, rating_query),
-            timeout=(8, 15),
-        )
+        # 公开列表页 pid 是图片偏移量；每页固定约 42 张，按固定页大小推进，避免与 limit 错位
+        pid_value = max(page - 1, 0) * GELBOORU_PUBLIC_PAGE_SIZE
+        params = adapter.build_public_posts_params(tags, limit, page, rating_query)
+        params["pid"] = pid_value
+        list_response = session.get(adapter.posts_url, params=params, timeout=(8, 15))
         list_response.raise_for_status()
         if display_all_site_content and _gelbooru_public_page_requires_options(list_response.text):
             logger.warning("[GelbooruPublic] Result page still requested Display all site content; rebuilding session and retrying")
             session = _get_gelbooru_session(display_all_site_content, force_refresh=True)
-            list_response = session.get(
-                adapter.posts_url,
-                params=adapter.build_public_posts_params(tags, limit, page, rating_query),
-                timeout=(8, 15),
-            )
+            list_response = session.get(adapter.posts_url, params=params, timeout=(8, 15))
             list_response.raise_for_status()
         refs = adapter.extract_public_post_refs(list_response.text, limit)
-        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} refs={len(refs)}")
+        logger.info(f"[GelbooruPublic] tags='{tags}' display_all={display_all_site_content} page={page} pid={pid_value} refs={len(refs)}")
 
     if not id_match:
         return refs

--- a/py/danbooru_gallery/danbooru_gallery.py
+++ b/py/danbooru_gallery/danbooru_gallery.py
@@ -21,14 +21,16 @@ from pathlib import Path
 import sys
 from ..utils.logger import get_logger
 from .site_adapters import get_site_adapter
-from collections import deque
+from collections import defaultdict, deque
 
 logger = get_logger(__name__)
 
-# FIFO 选择队列：每次 Queue 时前端快照一个选中条目入队，
-# 节点执行时从队首 pop 出一个，彻底解耦缓存碰撞
-_selection_queue = deque()
-_selection_queue_lock = threading.Lock()
+# FIFO 选择队列（按 nodeId 分桶）：每次 Queue 时前端快照推入对应节点的队列，
+# 节点执行时只 pop 自己 nodeId 的条目，其他节点的条目不受影响。
+# 支持同一工作流中多个画廊节点互不干扰、主子工作流各自取自己的数据。
+_selection_queues = defaultdict(deque)
+_selection_queues_lock = threading.Lock()
+_selection_queue_gen = 0  # 每次 push 递增，IS_CHANGED 据此让所有节点都重新执行
 
 # 导入数据库管理器
 try:
@@ -1598,14 +1600,17 @@ async def save_ui_settings_route(request):
 
 @PromptServer.instance.routes.post("/danbooru_gallery/selection_queue_push")
 async def selection_queue_push(request):
-    """前端在每次 Queue 前把当前选中的条目推入 FIFO 队列"""
+    """前端在每次 Queue 前把当前选中的条目推入对应 nodeId 的 FIFO 桶"""
     try:
         data = await request.json()
         item = data.get("item")
+        node_id = data.get("nodeId", "")
         if item:
-            with _selection_queue_lock:
-                _selection_queue.append(item)
-            logger.debug(f"[SelectionQueue] push → 队列长度 {len(_selection_queue)}")
+            global _selection_queue_gen
+            with _selection_queues_lock:
+                _selection_queues[node_id].append(item)
+                _selection_queue_gen += 1
+            logger.debug(f"[SelectionQueue] push node={node_id} → 队列长度 {len(_selection_queues[node_id])}")
         return web.json_response({"success": True})
     except Exception as e:
         logger.error(f"[SelectionQueue] push error: {e}")
@@ -1858,32 +1863,49 @@ class DanbooruGalleryNode:
     @classmethod
     def IS_CHANGED(cls, selection_data="{}", **kwargs):
         """返回队首条目的 _queue_id（唯一），队列空时返回 ""（缓存命中不再重复执行）。
-        彻底解决快速选图 1→Queue→2→Queue→... 导致的提示词覆盖竞态。"""
-        with _selection_queue_lock:
-            if _selection_queue:
-                return _selection_queue[0].get("_queue_id", time.time())
-        return ""
+        彻底解决快速选图 1→Queue→2→Queue→... 导致的提示词覆盖竞态。
+        注意：此方法不感知 nodeId，但只要每个节点都有自己的 selection_data widget，
+        每次 Queue 序列化时都会 snapshot 各节点当前值，配合后端 FIFO 分桶即可逐节点隔离。"""
+        if not selection_data or selection_data == "{}":
+            return ""
+        try:
+            data = json.loads(selection_data)
+            node_id = data.get("nodeId", "")
+            with _selection_queues_lock:
+                q = _selection_queues.get(node_id)
+                if q and len(q) > 0:
+                    return str(q[0].get("_queue_id", ""))
+        except (json.JSONDecodeError, TypeError):
+            pass
+        if not selection_data or selection_data == "{}":
+            return ""
+        return selection_data
 
     def get_selected_data(self, selection_data="{}", **kwargs):
-        """处理选中的图片数据，从 FIFO 队列中 pop（优先），否则回退到 selection_data widget。
-        队列模式确保 1→Queue→2→Queue→3→Queue→4→Queue 依次正确输出，互不覆盖。"""
+        """处理选中的图片数据，从 FIFO 队列（按 nodeId 分桶）中 pop，否则回退。"""
         images = []
         prompts = []
+        my_node_id = ""
 
         try:
-            # 先从 FIFO 队列 pop（每次 Queue 时前端推入的 snapshot）
-            with _selection_queue_lock:
-                if _selection_queue:
-                    item = _selection_queue.popleft()
-                    logger.debug(f"[SelectionQueue] get_selected_data pop → 剩余 {len(_selection_queue)}")
-                else:
-                    item = None
+            # 解析自己的 selection_data 获取 nodeId
+            if selection_data and selection_data != "{}":
+                data = json.loads(selection_data)
+                my_node_id = data.get("nodeId", "")
+
+            # 从 FIFO 按 nodeId 分桶 pop
+            item = None
+            if my_node_id:
+                with _selection_queues_lock:
+                    q = _selection_queues.get(my_node_id)
+                    if q and len(q) > 0:
+                        item = q.popleft()
+                        logger.debug(f"[SelectionQueue] get_selected_data pop node={my_node_id} → 剩余 {len(q)}")
 
             if item:
-                # 队列模式：单个条目
                 selections = item.get("selections", [])
             else:
-                # 回退：widget 值（无 Queue 点击，手动拖线等场景）
+                # 回退：从自己的 widget 读取
                 if not selection_data or selection_data == "{}":
                     return ([torch.zeros(1, 1, 1, 3)], [""])
                 data = json.loads(selection_data)
@@ -1896,7 +1918,6 @@ class DanbooruGalleryNode:
                 prompt = sel.get("prompt", "")
                 image_url = sel.get("image_url")
                 prompts.append(prompt)
-
                 if image_url:
                     try:
                         img_data = _fetch_supported_media(image_url)

--- a/py/danbooru_gallery/site_adapters.py
+++ b/py/danbooru_gallery/site_adapters.py
@@ -118,8 +118,9 @@ class GelbooruAdapter(GallerySiteAdapter):
             "page": "post",
             "s": "list",
             "tags": public_tags,
-            # Gelbooru's public list page uses an offset-like pid.
-            "pid": max(page - 1, 0) * max(limit, 1),
+            # Gelbooru's public list page uses a fixed page size of 42.
+            # pid = (page-1) * 42, decoupled from the frontend's limit param.
+            "pid": max(page - 1, 0) * 42,
         }
 
     def build_public_post_params(self, post_id: Any) -> Dict[str, Any]:


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><hr>
<h2>Title</h2>
<p>feat: cursor pagination, progressive loading, FIFO queue, scroll-ratio preloading, dynamic batch size</p>
<h2>与原版对比</h2>
<p>基于 [Aaalice233/ComfyUI-Danbooru-Gallery] 的全部差异，<strong>4 个文件</strong>，<strong>+623 / -126</strong>。</p>
<h2>新增功能</h2>
<h3>1. 游标分页（before_id cursor）</h3>
<p>彻底解决 G 站/D 站翻页重复和漏图问题。</p>
<ul>
<li><strong>前端</strong>：<code>lastPostId</code> / <code>seenPostIds</code> 状态追踪，搜索条件变化时自动重置</li>
<li><strong>后端</strong>：<code>get_posts_internal</code> 新增 <code>before_id</code> 参数
<ul>
<li>D 站：<code>page=b&lt;id&gt;</code> 官方游标</li>
<li>G 站：<code>id:&lt;X</code> metatag 注入 tags</li>
<li>数字校验防注入，<code>order</code>/<code>ordfav</code>/<code>sort</code> 时自动禁用</li>
<li><code>max_tags</code> 动态限制：<code>dedup on=1 tag</code> / <code>on_auth+token=10 tag</code> / 其他=2</li>
<li><code>cache_key</code> 增加 <code>before_id</code> + <code>dedup_&lt;mode&gt;</code> 防污染</li>
</ul>
</li>
</ul>
<h3>2. 三种预加载机制</h3>
<ul>
<li><strong>动态 limit</strong>：首次加载 <code>limit = min(40 + preload_count, 200)</code>，一次拿满缓冲</li>
<li><strong>maybeLoadMore</strong>：加载完成后自动算 <code>aheadBuffer</code>，不足即续</li>
<li><strong>2 秒轮询</strong>：<code>setInterval(maybeLoadMore, 2000)</code>，防滚动事件漏触</li>
</ul>
<h3>3. 滚动补货（去 400px 阈值）</h3>
<p>滚动时不看底部距离，直接算<strong>前方未看图数</strong>，不足 <code>preload_count</code> 就补。</p>
<h3>4. FIFO 选择队列（防 Queue 竞态）</h3>
<p>拦截 Queue 按钮（兼容新版 <code>data-testid</code> + 旧版 <code>#comfy-queue-btn</code>），选中快照入后端队列，按 <code>nodeId</code> 分桶，多节点互不干扰。</p>
<h3>5. 刷新重定位（scroll anchor）</h3>
<p>每秒记录视野上方第 8 张图的 id，刷新时 <code>lastPostId = scrollAnchorPostId</code>，加载后自动 <code>scrollIntoView</code>。</p>
<h3>6. G 站公开抓取重构</h3>
<ul>
<li><code>_gelbooru_public_throttle</code>（0.75s 限流器）</li>
<li>429/503 Retry-After 退避重试</li>
<li>失败返回 <code>{error}</code> 占位格，不整屏崩溃</li>
</ul>
<h3>7. 错误占位格 + 防御性 JSON</h3>
<p>后端返回非 JSON 时保留已有内容，只追加红色错误格。</p>
<h3>8. 设置面板「预加载」导航</h3>
<ul>
<li>每次缓冲张数（20-200）</li>
<li>G 站防重复（off / on / on_auth）</li>
<li>全局日志开关 → <code>loggerClient.setConsoleOutput(true)</code></li>
</ul>
<h3>9. 同步选图链路</h3>
<p><code>buildPromptForPost</code> / <code>updateSelectionData</code> / <code>getPostWithOriginalMedia</code> 全部同步化，消除快速连选竞态。</p>
<h3>10. 图片代理并发</h3>
<p><code>asyncio.Semaphore(1)</code> → <code>Semaphore(6)</code>，缩略图加载速度提升约 6 倍。</p>
<h3>11. 网络检查 30s TTL</h3>
<p>上次成功且 30s 内跳过完整往返。</p>
<h3>12. 全局日志输出</h3>
<p>JS 日志通过 <code>POST /danbooru/logs/batch</code> 转发到 ComfyUI 后端终端。</p>
<h2>Bug 修复</h2>
<ul>
<li>快速 Queue 提示词覆盖竞态（队列模式彻底修复）</li>
<li>刷新后 scrollTop 归零无还原</li>
<li><code>currentTags</code> 初始化不匹配导致锚点清空</li>
<li>异步竞态：连选时 await 交错覆盖 widget</li>
<li>parseFailed 作用域 / try-finally 引用错误</li>
<li>网格塌陷：getColumnWidth 保底 150px，自定义元素 row-span 估高</li>
</ul>
<h2>文件变更</h2>

文件 | + | - | 主要内容
-- | -- | -- | --
js/danbooru_gallery/danbooru_gallery.js | 463 | 126 | 核心架构重构
py/danbooru_gallery/danbooru_gallery.py | 275 | 37 | 游标/FIFO/限流/日志路由
py/danbooru_gallery/site_adapters.py | 5 | 0 | 固定 42 张/页
js/global/logger_client.js | 6 | 0 | setConsoleOutput 级别降级

</body></html><!--EndFragment-->
</body>
</html>